### PR TITLE
test: improve coverage across parser, client, config, and commands

### DIFF
--- a/generator/parser/generator_test.go
+++ b/generator/parser/generator_test.go
@@ -1,0 +1,505 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHasPathParam(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/v1/buildings/{id}", true},
+		{"/v1/buildings", false},
+		{"/v1/{type}/items", true},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := hasPathParam(tt.path); got != tt.want {
+				t.Errorf("hasPathParam(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPathParams(t *testing.T) {
+	params := []*Parameter{
+		{Name: "id", In: "path"},
+		{Name: "page", In: "query"},
+		{Name: "type", In: "path"},
+		{Name: "filter", In: "query"},
+	}
+	got := pathParams(params)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 path params, got %d", len(got))
+	}
+	if got[0].Name != "id" || got[1].Name != "type" {
+		t.Errorf("path params = [%s, %s], want [id, type]", got[0].Name, got[1].Name)
+	}
+}
+
+func TestQueryParams(t *testing.T) {
+	params := []*Parameter{
+		{Name: "id", In: "path"},
+		{Name: "page", In: "query"},
+		{Name: "filter", In: "query"},
+	}
+	got := queryParams(params)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 query params, got %d", len(got))
+	}
+	if got[0].Name != "page" || got[1].Name != "filter" {
+		t.Errorf("query params = [%s, %s], want [page, filter]", got[0].Name, got[1].Name)
+	}
+}
+
+func TestGoType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"integer", "int"},
+		{"boolean", "bool"},
+		{"number", "float64"},
+		{"string", "string"},
+		{"unknown", "string"},
+		{"", "string"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := goType(tt.input); got != tt.want {
+				t.Errorf("goType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"integer", "Int"},
+		{"boolean", "Bool"},
+		{"number", "Float64"},
+		{"string", "String"},
+		{"unknown", "String"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := flagType(tt.input); got != tt.want {
+				t.Errorf("flagType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEscapeQuotes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"backslash", `a\b`, `a\\b`},
+		{"quote", `say "hello"`, `say \"hello\"`},
+		{"newline", "line1\nline2", "line1 line2"},
+		{"carriage return", "line1\rline2", "line1line2"},
+		{"backtick", "use `code`", "use 'code'"},
+		{"combined", "a \"b\"\nc", `a \"b\" c`},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := escapeQuotes(tt.input); got != tt.want {
+				t.Errorf("escapeQuotes(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDedupeOperations(t *testing.T) {
+	ops := []*Operation{
+		{Name: "list"},
+		{Name: "get"},
+		{Name: "list"}, // duplicate
+		{Name: "create"},
+		{Name: "get"}, // duplicate
+	}
+	got := dedupeOperations(ops)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 unique ops, got %d", len(got))
+	}
+	names := make([]string, len(got))
+	for i, op := range got {
+		names[i] = op.Name
+	}
+	// Should keep first occurrence
+	want := []string{"list", "get", "create"}
+	for i, n := range want {
+		if names[i] != n {
+			t.Errorf("deduped[%d] = %q, want %q", i, names[i], n)
+		}
+	}
+}
+
+func TestSortOperations(t *testing.T) {
+	ops := []*Operation{
+		{Name: "delete"},
+		{Name: "create"},
+		{Name: "history"},
+		{Name: "list"},
+		{Name: "get"},
+		{Name: "update"},
+		{Name: "export"},
+		{Name: "custom-action"},
+	}
+	sorted := sortOperations(ops)
+
+	// Expected canonical order: list, get, create, update, delete, history, export, custom-action
+	expected := []string{"list", "get", "create", "update", "delete", "history", "export", "custom-action"}
+	if len(sorted) != len(expected) {
+		t.Fatalf("expected %d sorted ops, got %d", len(expected), len(sorted))
+	}
+	for i, want := range expected {
+		if sorted[i].Name != want {
+			t.Errorf("sorted[%d] = %q, want %q", i, sorted[i].Name, want)
+		}
+	}
+}
+
+func TestHasPostOrPut(t *testing.T) {
+	tests := []struct {
+		name string
+		ops  []*Operation
+		want bool
+	}{
+		{"with POST", []*Operation{{Method: "GET"}, {Method: "POST"}}, true},
+		{"with PUT", []*Operation{{Method: "PUT"}}, true},
+		{"with PATCH", []*Operation{{Method: "PATCH"}}, true},
+		{"GET only", []*Operation{{Method: "GET"}}, false},
+		{"DELETE only", []*Operation{{Method: "DELETE"}}, false},
+		{"empty", []*Operation{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasPostOrPut(tt.ops); got != tt.want {
+				t.Errorf("hasPostOrPut() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasDelete(t *testing.T) {
+	tests := []struct {
+		name string
+		ops  []*Operation
+		want bool
+	}{
+		{"with DELETE", []*Operation{{Method: "DELETE"}}, true},
+		{"without DELETE", []*Operation{{Method: "GET"}, {Method: "POST"}}, false},
+		{"empty", []*Operation{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasDelete(tt.ops); got != tt.want {
+				t.Errorf("hasDelete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasDestructive(t *testing.T) {
+	tests := []struct {
+		name string
+		ops  []*Operation
+		want bool
+	}{
+		{"with destructive", []*Operation{{IsDestructive: true}}, true},
+		{"without destructive", []*Operation{{IsDestructive: false}}, false},
+		{"empty", []*Operation{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasDestructive(tt.ops); got != tt.want {
+				t.Errorf("hasDestructive() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNeedsFmt(t *testing.T) {
+	tests := []struct {
+		name string
+		ops  []*Operation
+		want bool
+	}{
+		{"destructive", []*Operation{{IsDestructive: true}}, true},
+		{"has delete", []*Operation{{Method: "DELETE"}}, true},
+		{"has query param (non-bool)", []*Operation{{Parameters: []*Parameter{{In: "query", Type: "string"}}}}, true},
+		{"only bool query param", []*Operation{{Parameters: []*Parameter{{In: "query", Type: "boolean"}}}}, false},
+		{"no special needs", []*Operation{{Method: "GET"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := needsFmt(tt.ops); got != tt.want {
+				t.Errorf("needsFmt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerate_ProducesValidGoFile(t *testing.T) {
+	dir := t.TempDir()
+	gen := NewGenerator(dir)
+
+	resource := &Resource{
+		Name:         "widgets",
+		NameSingular: "widget",
+		GoName:       "Widgets",
+		Description:  "Test widgets",
+		Operations: []*Operation{
+			{
+				Name:       "list",
+				Method:     "GET",
+				Path:       "/v1/widgets",
+				Summary:    "List widgets",
+				APIVersion: "v1",
+				Parameters: []*Parameter{
+					{Name: "page", In: "query", Type: "integer"},
+					{Name: "filter", In: "query", Type: "string"},
+				},
+			},
+			{
+				Name:       "get",
+				Method:     "GET",
+				Path:       "/v1/widgets/{id}",
+				Summary:    "Get a widget",
+				APIVersion: "v1",
+				Parameters: []*Parameter{
+					{Name: "id", In: "path", Type: "string", Required: true},
+				},
+			},
+			{
+				Name:        "create",
+				Method:      "POST",
+				Path:        "/v1/widgets",
+				Summary:     "Create a widget",
+				APIVersion:  "v1",
+				RequestBody: &RequestBody{Required: true},
+			},
+			{
+				Name:          "delete",
+				Method:        "DELETE",
+				Path:          "/v1/widgets/{id}",
+				Summary:       "Delete a widget",
+				APIVersion:    "v1",
+				IsDestructive: true,
+				Parameters: []*Parameter{
+					{Name: "id", In: "path", Type: "string", Required: true},
+				},
+			},
+		},
+		Schemas: make(map[string]*Schema),
+	}
+
+	outPath, err := gen.Generate(resource)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	content, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(content)
+
+	checks := []string{
+		"package generated",
+		"Code generated by jamfpro-cli generator. DO NOT EDIT.",
+		"NewWidgetsCmd",
+		`Use:   "widgets"`,
+		"List widgets",
+		"Get a widget",
+		"Create a widget",
+		"Delete a widget",
+	}
+	for _, check := range checks {
+		if !strings.Contains(code, check) {
+			t.Errorf("generated code missing %q", check)
+		}
+	}
+
+	// Destructive ops should have --yes flag and confirmation prompt
+	if !strings.Contains(code, `"yes"`) {
+		t.Error("destructive op should generate --yes flag")
+	}
+	if !strings.Contains(code, "destructive operation requires --yes") {
+		t.Error("destructive op should generate --no-input guard")
+	}
+}
+
+func TestGenerate_ListOnly(t *testing.T) {
+	dir := t.TempDir()
+	gen := NewGenerator(dir)
+
+	resource := &Resource{
+		Name:         "reports",
+		NameSingular: "report",
+		GoName:       "Reports",
+		Operations: []*Operation{
+			{
+				Name:       "list",
+				Method:     "GET",
+				Path:       "/v1/reports",
+				Summary:    "List reports",
+				APIVersion: "v1",
+			},
+		},
+		Schemas: make(map[string]*Schema),
+	}
+
+	outPath, err := gen.Generate(resource)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	content, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(content)
+
+	if !strings.Contains(code, "ListCmd") || !strings.Contains(code, "newReportsList") {
+		t.Error("expected list command in output")
+	}
+	if strings.Contains(code, "CreateCmd") || strings.Contains(code, "newReportsCreate") {
+		t.Error("unexpected create command for list-only resource")
+	}
+	if strings.Contains(code, "DeleteCmd") || strings.Contains(code, "newReportsDelete") {
+		t.Error("unexpected delete command for list-only resource")
+	}
+}
+
+func TestGenerate_DestructiveOps(t *testing.T) {
+	dir := t.TempDir()
+	gen := NewGenerator(dir)
+
+	resource := &Resource{
+		Name:         "devices",
+		NameSingular: "device",
+		GoName:       "Devices",
+		Operations: []*Operation{
+			{
+				Name:          "erase",
+				Method:        "POST",
+				Path:          "/v1/devices/{id}/erase",
+				Summary:       "Erase a device",
+				APIVersion:    "v1",
+				IsAction:      true,
+				IsDestructive: true,
+				Parameters: []*Parameter{
+					{Name: "id", In: "path", Type: "string", Required: true},
+				},
+			},
+		},
+		Schemas: make(map[string]*Schema),
+	}
+
+	outPath, err := gen.Generate(resource)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	content, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(content)
+
+	// Verify --yes flag, --dry-run flag, confirmation prompt
+	if !strings.Contains(code, "--yes") {
+		t.Error("destructive op should have --yes flag definition")
+	}
+	if !strings.Contains(code, "dry-run") {
+		t.Error("destructive op should have --dry-run flag")
+	}
+	if !strings.Contains(code, "Type 'yes' to confirm") {
+		t.Error("destructive op should have confirmation prompt")
+	}
+	if !strings.Contains(code, "os.Stderr") {
+		t.Error("destructive op should write to stderr")
+	}
+}
+
+func TestGenerateRegistry(t *testing.T) {
+	dir := t.TempDir()
+	gen := NewGenerator(dir)
+
+	resources := []*Resource{
+		{Name: "widgets", GoName: "Widgets"},
+		{Name: "gadgets", GoName: "Gadgets"},
+	}
+
+	outPath, err := gen.GenerateRegistry(resources)
+	if err != nil {
+		t.Fatalf("GenerateRegistry() error = %v", err)
+	}
+
+	content, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(content)
+
+	if !strings.Contains(code, "RegisterCommands") {
+		t.Error("expected RegisterCommands function")
+	}
+	if !strings.Contains(code, "NewGadgetsCmd") {
+		t.Error("expected NewGadgetsCmd registration")
+	}
+	if !strings.Contains(code, "NewWidgetsCmd") {
+		t.Error("expected NewWidgetsCmd registration")
+	}
+
+	// Verify sorted order: gadgets before widgets
+	gadgetIdx := strings.Index(code, "NewGadgetsCmd")
+	widgetIdx := strings.Index(code, "NewWidgetsCmd")
+	if gadgetIdx > widgetIdx {
+		t.Error("expected gadgets before widgets (sorted by name)")
+	}
+}
+
+func TestGenerate_Filename(t *testing.T) {
+	dir := t.TempDir()
+	gen := NewGenerator(dir)
+
+	resource := &Resource{
+		Name:         "mobile-devices",
+		NameSingular: "mobile-device",
+		GoName:       "MobileDevices",
+		Operations: []*Operation{
+			{
+				Name:       "list",
+				Method:     "GET",
+				Path:       "/v1/mobile-devices",
+				Summary:    "List mobile devices",
+				APIVersion: "v1",
+			},
+		},
+		Schemas: make(map[string]*Schema),
+	}
+
+	outPath, err := gen.Generate(resource)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	expectedFile := filepath.Join(dir, "mobile_devices.go")
+	if outPath != expectedFile {
+		t.Errorf("output path = %q, want %q", outPath, expectedFile)
+	}
+}

--- a/generator/parser/parser_test.go
+++ b/generator/parser/parser_test.go
@@ -1,0 +1,394 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPluralize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"building", "buildings"},
+		{"policy", "policies"},
+		{"category", "categories"},
+		{"access", "accesses"},
+		{"computers", "computers"},    // already plural
+		{"match", "matches"},          // -ch suffix
+		{"key", "keys"},               // vowel+y
+		{"bus", "buss"},               // -us suffix falls through to +s
+		{"class", "classes"},          // -ss suffix
+		{"box", "boxes"},              // -x suffix
+		{"brush", "brushes"},          // -sh suffix
+		{"day", "days"},               // vowel+y
+		{"deploy", "deploys"},         // vowel+y
+		{"discovery", "discoveries"},  // consonant+y
+		{"device", "devices"},         // -ves already plural
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := pluralize(tt.input)
+			if got != tt.want {
+				t.Errorf("pluralize(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInferOperationName(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		method   string
+		isAction bool
+		want     string
+	}{
+		{"delete-multiple suffix", "/v1/buildings/delete-multiple", "POST", true, "delete-multiple"},
+		{"history export", "/v1/buildings/{id}/history/export", "POST", true, "history-export"},
+		{"export", "/v1/buildings/export", "POST", true, "export"},
+		{"history GET", "/v1/buildings/{id}/history", "GET", false, "history"},
+		{"history POST", "/v1/buildings/{id}/history", "POST", false, "add-history-note"},
+		{"x-action path extraction", "/v1/computers/{id}/erase", "POST", true, "erase"},
+		{"x-action lock", "/v1/computers/{id}/lock", "POST", true, "lock"},
+		{"GET with id", "/v1/buildings/{id}", "GET", false, "get"},
+		{"GET without id (list)", "/v1/buildings", "GET", false, "list"},
+		{"POST create", "/v1/buildings", "POST", false, "create"},
+		{"PUT update", "/v1/buildings/{id}", "PUT", false, "update"},
+		{"PATCH", "/v1/buildings/{id}", "PATCH", false, "patch"},
+		{"DELETE", "/v1/buildings/{id}", "DELETE", false, "delete"},
+		{"unknown method", "/v1/buildings", "OPTIONS", false, "options"},
+		{"POST with id and action", "/v1/computers/{id}", "POST", true, "action"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferOperationName(tt.path, tt.method, tt.isAction)
+			if got != tt.want {
+				t.Errorf("inferOperationName(%q, %q, %v) = %q, want %q", tt.path, tt.method, tt.isAction, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractAPIVersion(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/v1/buildings", "v1"},
+		{"/v2/computers", "v2"},
+		{"/preview/stuff", "preview"},
+		{"/JSSResource/policies", "v1"}, // fallback
+		{"/v3/devices/{id}", "v3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := extractAPIVersion(tt.path)
+			if got != tt.want {
+				t.Errorf("extractAPIVersion(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDestructiveAction(t *testing.T) {
+	tests := []struct {
+		opName string
+		want   bool
+	}{
+		{"delete", true},
+		{"delete-multiple", true},
+		{"erase", true},
+		{"lock", true},
+		{"wipe", true},
+		{"remove", true},
+		{"restart", true},
+		{"shutdown", true},
+		{"list", false},
+		{"create", false},
+		{"get", false},
+		{"update", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.opName, func(t *testing.T) {
+			got := isDestructiveAction(tt.opName)
+			if got != tt.want {
+				t.Errorf("isDestructiveAction(%q) = %v, want %v", tt.opName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSpec_MinimalSpec(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "Widget.yaml")
+
+	spec := `openapi: 3.0.1
+info:
+  title: Widgets
+  description: Manage widgets
+  version: 1.0.0
+paths:
+  /v1/widgets:
+    get:
+      summary: List all widgets
+      parameters:
+      - name: page
+        in: query
+        schema:
+          type: integer
+      responses:
+        200:
+          description: OK
+    post:
+      summary: Create a widget
+      requestBody:
+        required: true
+      responses:
+        201:
+          description: Created
+  /v1/widgets/{id}:
+    get:
+      summary: Get a widget
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: OK
+    delete:
+      summary: Delete a widget
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        204:
+          description: Deleted
+`
+	if err := os.WriteFile(specPath, []byte(spec), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	resource, err := ParseSpec(specPath)
+	if err != nil {
+		t.Fatalf("ParseSpec() error = %v", err)
+	}
+	if resource == nil {
+		t.Fatal("ParseSpec() returned nil resource")
+	}
+
+	if resource.Name != "widgets" {
+		t.Errorf("Name = %q, want %q", resource.Name, "widgets")
+	}
+	if resource.GoName != "Widgets" {
+		t.Errorf("GoName = %q, want %q", resource.GoName, "Widgets")
+	}
+	if resource.Description != "Manage widgets" {
+		t.Errorf("Description = %q, want %q", resource.Description, "Manage widgets")
+	}
+
+	if len(resource.Operations) != 4 {
+		t.Fatalf("expected 4 operations, got %d", len(resource.Operations))
+	}
+
+	// Verify operations by name
+	opNames := make(map[string]bool)
+	for _, op := range resource.Operations {
+		opNames[op.Name] = true
+	}
+	for _, expected := range []string{"list", "get", "create", "delete"} {
+		if !opNames[expected] {
+			t.Errorf("missing expected operation %q", expected)
+		}
+	}
+
+	// Verify delete is marked as destructive
+	for _, op := range resource.Operations {
+		if op.Name == "delete" && !op.IsDestructive {
+			t.Error("delete operation should be marked as destructive")
+		}
+	}
+
+	// Verify GET /v1/widgets/{id} has path parameter
+	for _, op := range resource.Operations {
+		if op.Name == "get" {
+			if len(op.Parameters) == 0 {
+				t.Error("get operation should have parameters")
+			}
+			found := false
+			for _, p := range op.Parameters {
+				if p.Name == "id" && p.In == "path" {
+					found = true
+				}
+			}
+			if !found {
+				t.Error("get operation should have 'id' path parameter")
+			}
+		}
+	}
+}
+
+func TestParseSpec_SkipsLibraryFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, name := range []string{"DefinitionsLibrary.yaml", "CommonTypes.yaml", "SchemaLibrary.yaml"} {
+		specPath := filepath.Join(dir, name)
+		spec := `openapi: 3.0.1
+info:
+  title: Library
+  version: 1.0.0
+paths: {}
+`
+		if err := os.WriteFile(specPath, []byte(spec), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		resource, err := ParseSpec(specPath)
+		if err != nil {
+			t.Fatalf("ParseSpec(%q) error = %v", name, err)
+		}
+		if resource != nil {
+			t.Errorf("ParseSpec(%q) should return nil for library file", name)
+		}
+	}
+}
+
+func TestParseSpec_InvalidFile(t *testing.T) {
+	_, err := ParseSpec("/nonexistent/path/spec.yaml")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestParseSpec_RealBuildingSpec(t *testing.T) {
+	// Use the real Building spec — will exercise $ref resolution
+	specPath := filepath.Join("..", "..", "specs", "Building.yaml")
+	if _, err := os.Stat(specPath); os.IsNotExist(err) {
+		t.Skip("specs/Building.yaml not found, skipping integration test")
+	}
+
+	resource, err := ParseSpec(specPath)
+	if err != nil {
+		t.Fatalf("ParseSpec(Building.yaml) error = %v", err)
+	}
+	if resource == nil {
+		t.Fatal("ParseSpec(Building.yaml) returned nil")
+	}
+
+	if resource.Name != "buildings" {
+		t.Errorf("Name = %q, want %q", resource.Name, "buildings")
+	}
+
+	// Building.yaml has: list, get, create, update, delete, delete-multiple, history, add-history-note, history-export, export
+	expectedOps := map[string]bool{
+		"list":             false,
+		"get":              false,
+		"create":           false,
+		"update":           false,
+		"delete":           false,
+		"delete-multiple":  false,
+		"history":          false,
+		"add-history-note": false,
+		"history-export":   false,
+		"export":           false,
+	}
+	for _, op := range resource.Operations {
+		if _, ok := expectedOps[op.Name]; ok {
+			expectedOps[op.Name] = true
+		}
+	}
+	for name, found := range expectedOps {
+		if !found {
+			t.Errorf("missing expected operation %q in Building spec", name)
+		}
+	}
+
+	// Verify schemas were parsed
+	if _, ok := resource.Schemas["Building"]; !ok {
+		t.Error("expected Building schema to be parsed")
+	}
+
+	// Verify Building schema has expected properties
+	if building, ok := resource.Schemas["Building"]; ok {
+		for _, prop := range []string{"name", "city", "country"} {
+			if _, ok := building.Properties[prop]; !ok {
+				t.Errorf("Building schema missing property %q", prop)
+			}
+		}
+	}
+}
+
+func TestParseSpec_WithSchemas(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "Item.yaml")
+
+	spec := `openapi: 3.0.1
+info:
+  title: Items
+  version: 1.0.0
+paths:
+  /v1/items:
+    get:
+      summary: List items
+      responses:
+        200:
+          description: OK
+components:
+  schemas:
+    Item:
+      type: object
+      required:
+      - name
+      properties:
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          description: Item name
+        count:
+          type: integer
+          nullable: true
+`
+	if err := os.WriteFile(specPath, []byte(spec), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	resource, err := ParseSpec(specPath)
+	if err != nil {
+		t.Fatalf("ParseSpec() error = %v", err)
+	}
+
+	if len(resource.Schemas) != 1 {
+		t.Fatalf("expected 1 schema, got %d", len(resource.Schemas))
+	}
+
+	item := resource.Schemas["Item"]
+	if item == nil {
+		t.Fatal("missing Item schema")
+	}
+	if item.Type != "object" {
+		t.Errorf("schema type = %q, want %q", item.Type, "object")
+	}
+	if len(item.Required) != 1 || item.Required[0] != "name" {
+		t.Errorf("schema required = %v, want [name]", item.Required)
+	}
+	if id, ok := item.Properties["id"]; !ok {
+		t.Error("missing id property")
+	} else if !id.ReadOnly {
+		t.Error("id property should be readOnly")
+	}
+	if count, ok := item.Properties["count"]; !ok {
+		t.Error("missing count property")
+	} else if !count.Nullable {
+		t.Error("count property should be nullable")
+	}
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2,13 +2,17 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
-	"github.com/ktn-jamf/jamfpro-cli/internal/auth"
+	"github.com/jamf/jamfpro-cli/internal/auth"
+	"github.com/jamf/jamfpro-cli/internal/exitcode"
 )
 
 func TestDo_ModernAPIPathPrefix(t *testing.T) {
@@ -142,5 +146,250 @@ func TestDo_ClassicAPIWithBody(t *testing.T) {
 
 	if gotBody != input {
 		t.Errorf("body = %q, want %q", gotBody, input)
+	}
+}
+
+// --- Error code mapping tests ---
+
+func TestDo_Forbidden403(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("insufficient privileges"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("test-token"))
+	_, err := c.Do(context.Background(), "GET", "/v1/buildings", nil)
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+
+	code := exitcode.CodeFrom(err)
+	if code != exitcode.PermissionDenied {
+		t.Errorf("exit code = %d, want %d (PermissionDenied)", code, exitcode.PermissionDenied)
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("error = %q, want to contain 'permission denied'", err.Error())
+	}
+}
+
+func TestDo_NotFound404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("not found"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("test-token"))
+	_, err := c.Do(context.Background(), "GET", "/v1/buildings/999", nil)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+
+	code := exitcode.CodeFrom(err)
+	if code != exitcode.NotFound {
+		t.Errorf("exit code = %d, want %d (NotFound)", code, exitcode.NotFound)
+	}
+	if !strings.Contains(err.Error(), "GET") || !strings.Contains(err.Error(), "/buildings/999") {
+		t.Errorf("404 error should contain method and path, got: %q", err.Error())
+	}
+}
+
+func TestDo_ServerError500(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("test-token"))
+	_, err := c.Do(context.Background(), "GET", "/v1/buildings", nil)
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+
+	code := exitcode.CodeFrom(err)
+	if code != exitcode.General {
+		t.Errorf("exit code = %d, want %d (General)", code, exitcode.General)
+	}
+	if !strings.Contains(err.Error(), "internal server error") {
+		t.Errorf("500 error should contain body, got: %q", err.Error())
+	}
+}
+
+func TestDo_Unauthorized401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("invalid token"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("bad-token"))
+	_, err := c.Do(context.Background(), "GET", "/v1/buildings", nil)
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+
+	code := exitcode.CodeFrom(err)
+	if code != exitcode.Authentication {
+		t.Errorf("exit code = %d, want %d (Authentication)", code, exitcode.Authentication)
+	}
+}
+
+func TestDo_RateLimited429(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte("too many requests"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("test-token"))
+	_, err := c.Do(context.Background(), "GET", "/v1/buildings", nil)
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+
+	code := exitcode.CodeFrom(err)
+	if code != exitcode.RateLimited {
+		t.Errorf("exit code = %d, want %d (RateLimited)", code, exitcode.RateLimited)
+	}
+}
+
+// --- Verbose output tests ---
+
+func TestDo_VerboseOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("test-token"), WithVerbose(true))
+
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	_, err := c.Do(context.Background(), "GET", "/v1/buildings", nil)
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+
+	output, _ := io.ReadAll(r)
+	out := string(output)
+
+	if !strings.Contains(out, "-->") {
+		t.Errorf("verbose output should contain '-->' request line, got: %q", out)
+	}
+	if !strings.Contains(out, "<--") {
+		t.Errorf("verbose output should contain '<--' response line, got: %q", out)
+	}
+	if !strings.Contains(out, "GET") {
+		t.Errorf("verbose output should contain method, got: %q", out)
+	}
+}
+
+func TestWithVerbose_SetsField(t *testing.T) {
+	c := New("https://example.com", auth.NewTokenProvider("tok"))
+	if c.verbose {
+		t.Error("verbose should default to false")
+	}
+
+	c = New("https://example.com", auth.NewTokenProvider("tok"), WithVerbose(true))
+	if !c.verbose {
+		t.Error("WithVerbose(true) should set verbose to true")
+	}
+}
+
+// --- Retry logic tests ---
+
+func TestDoWithRetry_SucceedsAfterFailure(t *testing.T) {
+	var counter int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&counter, 1)
+		if n == 1 {
+			// First request: hang up (force connection reset)
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("server does not support hijacking")
+			}
+			conn, _, _ := hj.Hijack()
+			conn.Close()
+			return
+		}
+		// Second request: succeed
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("test-token"))
+	resp, err := c.Do(context.Background(), "GET", "/v1/buildings", nil)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if atomic.LoadInt32(&counter) != 2 {
+		t.Errorf("expected 2 attempts, got %d", counter)
+	}
+}
+
+func TestDoWithRetry_RateLimitRetry(t *testing.T) {
+	var counter int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&counter, 1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte("rate limited"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("test-token"))
+	resp, err := c.Do(context.Background(), "GET", "/v1/buildings", nil)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if atomic.LoadInt32(&counter) != 2 {
+		t.Errorf("expected 2 attempts (429 then success), got %d", counter)
+	}
+}
+
+func TestDoWithRetry_ExhaustsRetries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow retry exhaustion test")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always hang up
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("server does not support hijacking")
+		}
+		conn, _, _ := hj.Hijack()
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("test-token"))
+	_, err := c.Do(context.Background(), "GET", "/v1/buildings", nil)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+
+	if !strings.Contains(err.Error(), fmt.Sprintf("after %d retries", 3)) {
+		t.Errorf("error should mention retry count, got: %q", err.Error())
 	}
 }

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ktn-jamf/jamfpro-cli/internal/exitcode"
+	"github.com/jamf/jamfpro-cli/internal/exitcode"
 )
 
 func TestCommandsSubcommand_JSON(t *testing.T) {
@@ -327,5 +327,180 @@ func TestDryRunClient_StderrOutput(t *testing.T) {
 	}
 	if !strings.Contains(output, `{"name":"Test"}`) {
 		t.Errorf("expected request body in stderr, got: %s", output)
+	}
+}
+
+// resetGlobals resets all package-level flag variables to zero values.
+// Must be called before each PersistentPreRunE test to avoid state leaking.
+func resetGlobals() {
+	profile = ""
+	outputFmt = "json"
+	quiet = false
+	verbose = false
+	noInput = false
+	noColor = false
+	dryRun = false
+	wide = false
+	outFile = ""
+	serverURL = ""
+	token = ""
+	tokenFile = ""
+	tokenStdin = false
+	clientID = ""
+	clientSecret = ""
+	username = ""
+	password = ""
+}
+
+func TestPersistentPreRunE_MissingURL(t *testing.T) {
+	resetGlobals()
+	// Clear any env vars that could provide a URL
+	t.Setenv("JAMF_URL", "")
+	t.Setenv("JAMF_TOKEN", "my-token")
+	t.Setenv("JAMF_PROFILE", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // empty config dir — no profiles
+
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+	root.SetArgs([]string{"computers", "list"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error when URL is missing")
+	}
+	if !strings.Contains(err.Error(), "server URL is required") {
+		t.Errorf("error = %q, want to contain 'server URL is required'", err.Error())
+	}
+}
+
+func TestPersistentPreRunE_MissingAuth(t *testing.T) {
+	resetGlobals()
+	t.Setenv("JAMF_URL", "https://test.jamfcloud.com")
+	t.Setenv("JAMF_TOKEN", "")
+	t.Setenv("JAMF_CLIENT_ID", "")
+	t.Setenv("JAMF_CLIENT_SECRET", "")
+	t.Setenv("JAMF_USERNAME", "")
+	t.Setenv("JAMF_PASSWORD", "")
+	t.Setenv("JAMF_PROFILE", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+	root.SetArgs([]string{"computers", "list"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error when auth is missing")
+	}
+	if !strings.Contains(err.Error(), "authentication required") {
+		t.Errorf("error = %q, want to contain 'authentication required'", err.Error())
+	}
+}
+
+func TestPersistentPreRunE_PartialOAuth2_MissingSecret(t *testing.T) {
+	resetGlobals()
+	t.Setenv("JAMF_URL", "https://test.jamfcloud.com")
+	t.Setenv("JAMF_TOKEN", "")
+	t.Setenv("JAMF_CLIENT_ID", "my-client-id")
+	t.Setenv("JAMF_CLIENT_SECRET", "")
+	t.Setenv("JAMF_USERNAME", "")
+	t.Setenv("JAMF_PASSWORD", "")
+	t.Setenv("JAMF_PROFILE", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+	root.SetArgs([]string{"computers", "list"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for partial OAuth2 credentials")
+	}
+	if !strings.Contains(err.Error(), "--client-secret is required") {
+		t.Errorf("error = %q, want to contain '--client-secret is required'", err.Error())
+	}
+}
+
+func TestPersistentPreRunE_PartialOAuth2_MissingID(t *testing.T) {
+	resetGlobals()
+	t.Setenv("JAMF_URL", "https://test.jamfcloud.com")
+	t.Setenv("JAMF_TOKEN", "")
+	t.Setenv("JAMF_CLIENT_ID", "")
+	t.Setenv("JAMF_CLIENT_SECRET", "my-secret")
+	t.Setenv("JAMF_USERNAME", "")
+	t.Setenv("JAMF_PASSWORD", "")
+	t.Setenv("JAMF_PROFILE", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+	root.SetArgs([]string{"computers", "list"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for partial OAuth2 credentials")
+	}
+	if !strings.Contains(err.Error(), "--client-id is required") {
+		t.Errorf("error = %q, want to contain '--client-id is required'", err.Error())
+	}
+}
+
+func TestPersistentPreRunE_SkipsForConfigCommand(t *testing.T) {
+	resetGlobals()
+	// No URL, no auth — but config commands should skip validation
+	t.Setenv("JAMF_URL", "")
+	t.Setenv("JAMF_TOKEN", "")
+	t.Setenv("JAMF_PROFILE", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+	root.SetArgs([]string{"config", "validate"})
+
+	err := root.Execute()
+	// config validate may fail for its own reasons, but not from PersistentPreRunE
+	if err != nil && strings.Contains(err.Error(), "server URL is required") {
+		t.Error("config commands should skip PersistentPreRunE validation")
+	}
+}
+
+func TestPersistentPreRunE_SkipsForVersionCommand(t *testing.T) {
+	resetGlobals()
+	t.Setenv("JAMF_URL", "")
+	t.Setenv("JAMF_TOKEN", "")
+	t.Setenv("JAMF_PROFILE", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+	root.SetArgs([]string{"version"})
+
+	err := root.Execute()
+	if err != nil {
+		t.Errorf("version command should not require auth, got: %v", err)
+	}
+}
+
+func TestPersistentPreRunE_NOCOLOREnv(t *testing.T) {
+	resetGlobals()
+	t.Setenv("NO_COLOR", "1")
+	t.Setenv("JAMF_URL", "")
+	t.Setenv("JAMF_TOKEN", "")
+	t.Setenv("JAMF_PROFILE", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	root.SetArgs([]string{"version"})
+	root.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	out, _ := io.ReadAll(r)
+	output := string(out)
+
+	// Verify no ANSI escape sequences
+	if strings.Contains(output, "\033[") {
+		t.Errorf("output with NO_COLOR should not contain ANSI codes, got: %q", output)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ktn-jamf/jamfpro-cli/internal/keychain"
+	"github.com/jamf/jamfpro-cli/internal/keychain"
 )
 
 // mockStore implements keychain.Store for testing.
@@ -146,5 +146,262 @@ func TestResolveSecret_Empty(t *testing.T) {
 	}
 	if val != "" {
 		t.Errorf("got %q, want empty string", val)
+	}
+}
+
+// --- ConfigPath tests ---
+
+func TestConfigPath_XDG(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	got := ConfigPath()
+	want := filepath.Join(dir, "jamfpro-cli", "config.yaml")
+	if got != want {
+		t.Errorf("ConfigPath() = %q, want %q", got, want)
+	}
+}
+
+// --- Load tests ---
+
+func TestLoad_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("Load() returned nil config")
+	}
+	if len(cfg.Profiles) != 0 {
+		t.Errorf("expected empty profiles, got %d", len(cfg.Profiles))
+	}
+	if cfg.DefaultProfile != "" {
+		t.Errorf("expected empty default-profile, got %q", cfg.DefaultProfile)
+	}
+}
+
+func TestLoad_ValidYAML(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	configDir := filepath.Join(dir, "jamfpro-cli")
+	os.MkdirAll(configDir, 0700)
+
+	yaml := `default-profile: prod
+profiles:
+  prod:
+    url: https://prod.jamfcloud.com
+    auth-method: oauth2
+    client-id: env:PROD_CLIENT_ID
+    client-secret: keychain:prod/secret
+  staging:
+    url: https://staging.jamfcloud.com
+    auth-method: token
+    token: env:STAGING_TOKEN
+`
+	os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(yaml), 0600)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.DefaultProfile != "prod" {
+		t.Errorf("DefaultProfile = %q, want %q", cfg.DefaultProfile, "prod")
+	}
+	if len(cfg.Profiles) != 2 {
+		t.Fatalf("expected 2 profiles, got %d", len(cfg.Profiles))
+	}
+
+	prod := cfg.Profiles["prod"]
+	if prod.URL != "https://prod.jamfcloud.com" {
+		t.Errorf("prod.URL = %q, want %q", prod.URL, "https://prod.jamfcloud.com")
+	}
+	if prod.AuthMethod != "oauth2" {
+		t.Errorf("prod.AuthMethod = %q, want %q", prod.AuthMethod, "oauth2")
+	}
+}
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	configDir := filepath.Join(dir, "jamfpro-cli")
+	os.MkdirAll(configDir, 0700)
+	os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte("{{not valid yaml:::"), 0600)
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+	if !strings.Contains(err.Error(), "parsing config") {
+		t.Errorf("error = %q, want to contain 'parsing config'", err.Error())
+	}
+}
+
+// --- Save tests ---
+
+func TestSave_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	cfg := &Config{
+		DefaultProfile: "test",
+		Profiles: map[string]Profile{
+			"test": {URL: "https://test.jamfcloud.com", AuthMethod: "token"},
+		},
+	}
+
+	if err := Save(cfg); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	path := ConfigPath()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+
+	// Verify 0600 permissions
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("file permissions = %o, want 0600", perm)
+	}
+}
+
+func TestSave_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	original := &Config{
+		DefaultProfile: "production",
+		DefaultOutput:  "table",
+		Profiles: map[string]Profile{
+			"production": {
+				URL:          "https://prod.jamfcloud.com",
+				AuthMethod:   "oauth2",
+				ClientID:     "env:PROD_ID",
+				ClientSecret: "keychain:prod/secret",
+			},
+			"dev": {
+				URL:        "https://dev.jamfcloud.com",
+				AuthMethod: "token",
+				Token:      "env:DEV_TOKEN",
+			},
+		},
+	}
+
+	if err := Save(original); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if loaded.DefaultProfile != original.DefaultProfile {
+		t.Errorf("DefaultProfile = %q, want %q", loaded.DefaultProfile, original.DefaultProfile)
+	}
+	if loaded.DefaultOutput != original.DefaultOutput {
+		t.Errorf("DefaultOutput = %q, want %q", loaded.DefaultOutput, original.DefaultOutput)
+	}
+	if len(loaded.Profiles) != len(original.Profiles) {
+		t.Fatalf("profiles count = %d, want %d", len(loaded.Profiles), len(original.Profiles))
+	}
+
+	prod := loaded.Profiles["production"]
+	if prod.URL != "https://prod.jamfcloud.com" {
+		t.Errorf("prod.URL = %q, want %q", prod.URL, "https://prod.jamfcloud.com")
+	}
+	if prod.AuthMethod != "oauth2" {
+		t.Errorf("prod.AuthMethod = %q, want %q", prod.AuthMethod, "oauth2")
+	}
+	if prod.ClientID != "env:PROD_ID" {
+		t.Errorf("prod.ClientID = %q, want %q", prod.ClientID, "env:PROD_ID")
+	}
+	if prod.ClientSecret != "keychain:prod/secret" {
+		t.Errorf("prod.ClientSecret = %q, want %q", prod.ClientSecret, "keychain:prod/secret")
+	}
+
+	dev := loaded.Profiles["dev"]
+	if dev.Token != "env:DEV_TOKEN" {
+		t.Errorf("dev.Token = %q, want %q", dev.Token, "env:DEV_TOKEN")
+	}
+}
+
+// --- GetProfile tests ---
+
+func TestGetProfile_ByName(t *testing.T) {
+	cfg := &Config{
+		Profiles: map[string]Profile{
+			"alpha": {URL: "https://alpha.example.com"},
+			"beta":  {URL: "https://beta.example.com"},
+		},
+	}
+
+	p, name, err := GetProfile(cfg, "beta")
+	if err != nil {
+		t.Fatalf("GetProfile() error = %v", err)
+	}
+	if name != "beta" {
+		t.Errorf("name = %q, want %q", name, "beta")
+	}
+	if p.URL != "https://beta.example.com" {
+		t.Errorf("URL = %q, want %q", p.URL, "https://beta.example.com")
+	}
+}
+
+func TestGetProfile_Default(t *testing.T) {
+	cfg := &Config{
+		DefaultProfile: "alpha",
+		Profiles: map[string]Profile{
+			"alpha": {URL: "https://alpha.example.com"},
+		},
+	}
+
+	p, name, err := GetProfile(cfg, "")
+	if err != nil {
+		t.Fatalf("GetProfile() error = %v", err)
+	}
+	if name != "alpha" {
+		t.Errorf("name = %q, want %q", name, "alpha")
+	}
+	if p.URL != "https://alpha.example.com" {
+		t.Errorf("URL = %q, want %q", p.URL, "https://alpha.example.com")
+	}
+}
+
+func TestGetProfile_Missing(t *testing.T) {
+	cfg := &Config{
+		Profiles: map[string]Profile{
+			"alpha": {URL: "https://alpha.example.com"},
+		},
+	}
+
+	_, _, err := GetProfile(cfg, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing profile")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want to contain 'not found'", err.Error())
+	}
+}
+
+func TestGetProfile_NoDefault(t *testing.T) {
+	cfg := &Config{
+		Profiles: map[string]Profile{
+			"alpha": {URL: "https://alpha.example.com"},
+		},
+	}
+
+	_, _, err := GetProfile(cfg, "")
+	if err == nil {
+		t.Fatal("expected error when no default profile and empty name")
+	}
+	if !strings.Contains(err.Error(), "no profile specified") {
+		t.Errorf("error = %q, want to contain 'no profile specified'", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary
- Add ~50 tests targeting the four highest-ROI coverage gaps before publishing
- `generator/parser`: 0% → **91%** — table-driven pure function tests + ParseSpec integration tests (including real Building.yaml)
- `internal/client`: 47% → **93%** — error code mapping (401/403/404/429/500), verbose output, retry logic (success-after-failure, rate-limit, exhaust)
- `internal/config`: 35% → **77%** — Load/Save round-trip, GetProfile lookups, ConfigPath XDG, invalid YAML handling
- `internal/commands`: 34% → **37%** — PersistentPreRunE validation paths (missing URL, missing auth, partial OAuth2, skip for config/version, NO_COLOR)

## Test plan
- [x] `go test -short ./...` — all packages pass
- [x] Coverage verified per package with `go test -coverprofile`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)