### PR TITLE
test: improve coverage for config subcommands, overview helpers, and output formatter

### DIFF
--- a/internal/commands/config_subcommands_test.go
+++ b/internal/commands/config_subcommands_test.go
@@ -1,0 +1,405 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jamf/jamfpro-cli/internal/config"
+)
+
+// --- config show tests ---
+
+func TestConfigShow_ValidConfig(t *testing.T) {
+	jDir := setupTempConfig(t)
+	yaml := `default-profile: prod
+profiles:
+  prod:
+    url: https://prod.jamfcloud.com
+    auth-method: token
+    token: env:MY_TOKEN
+`
+	os.WriteFile(filepath.Join(jDir, "config.yaml"), []byte(yaml), 0600)
+
+	cmd := newConfigShowCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "# Config file:") {
+		t.Error("expected config file header")
+	}
+	if !strings.Contains(out, "prod.jamfcloud.com") {
+		t.Error("expected URL in output")
+	}
+}
+
+func TestConfigShow_MissingFile(t *testing.T) {
+	setupTempConfig(t)
+
+	cmd := newConfigShowCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	// Load returns empty config for missing file — no error
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- config path tests ---
+
+func TestConfigPath_PrintsPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	cmd := newConfigPathCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+
+	cmd.Run(cmd, nil)
+
+	out := strings.TrimSpace(buf.String())
+	want := filepath.Join(dir, "jamfpro-cli", "config.yaml")
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+// --- config list tests ---
+
+func TestConfigList_Empty(t *testing.T) {
+	setupTempConfig(t)
+
+	cmd := newConfigListCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "No profiles configured") {
+		t.Errorf("expected 'No profiles configured' message, got:\n%s", buf.String())
+	}
+}
+
+func TestConfigList_WithProfiles(t *testing.T) {
+	jDir := setupTempConfig(t)
+	yaml := `default-profile: alpha
+profiles:
+  alpha:
+    url: https://alpha.jamfcloud.com
+    auth-method: token
+  beta:
+    url: https://beta.jamfcloud.com
+    auth-method: oauth2
+`
+	os.WriteFile(filepath.Join(jDir, "config.yaml"), []byte(yaml), 0600)
+
+	cmd := newConfigListCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	// Alpha should be marked as active (default)
+	if !strings.Contains(out, "* alpha") {
+		t.Error("expected alpha to be marked as default with *")
+	}
+	if !strings.Contains(out, "beta") {
+		t.Error("expected beta in output")
+	}
+	if !strings.Contains(out, "alpha.jamfcloud.com") {
+		t.Error("expected alpha URL in output")
+	}
+}
+
+// --- config remove-profile tests ---
+
+func TestConfigRemoveProfile_Exists(t *testing.T) {
+	jDir := setupTempConfig(t)
+	yaml := `default-profile: test
+profiles:
+  test:
+    url: https://test.jamfcloud.com
+    auth-method: token
+    token: env:TOKEN
+  other:
+    url: https://other.jamfcloud.com
+    auth-method: token
+    token: env:TOKEN2
+`
+	os.WriteFile(filepath.Join(jDir, "config.yaml"), []byte(yaml), 0600)
+
+	cmd := newConfigRemoveProfileCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"test"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), `Profile "test" removed`) {
+		t.Errorf("expected removal confirmation, got:\n%s", buf.String())
+	}
+
+	// Verify config was updated
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	if _, ok := cfg.Profiles["test"]; ok {
+		t.Error("expected 'test' profile to be removed")
+	}
+	if cfg.DefaultProfile != "" {
+		t.Errorf("expected default-profile to be cleared, got %q", cfg.DefaultProfile)
+	}
+	if _, ok := cfg.Profiles["other"]; !ok {
+		t.Error("expected 'other' profile to remain")
+	}
+}
+
+func TestConfigRemoveProfile_NotFound(t *testing.T) {
+	jDir := setupTempConfig(t)
+	yaml := `profiles:
+  existing:
+    url: https://example.com
+    auth-method: token
+`
+	os.WriteFile(filepath.Join(jDir, "config.yaml"), []byte(yaml), 0600)
+
+	cmd := newConfigRemoveProfileCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"nonexistent"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent profile")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+// --- config set-default tests ---
+
+func TestConfigSetDefault_Valid(t *testing.T) {
+	jDir := setupTempConfig(t)
+	yaml := `profiles:
+  alpha:
+    url: https://alpha.jamfcloud.com
+    auth-method: token
+  beta:
+    url: https://beta.jamfcloud.com
+    auth-method: token
+`
+	os.WriteFile(filepath.Join(jDir, "config.yaml"), []byte(yaml), 0600)
+
+	cmd := newConfigSetDefaultCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"beta"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), `Default profile set to "beta"`) {
+		t.Errorf("expected confirmation, got:\n%s", buf.String())
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	if cfg.DefaultProfile != "beta" {
+		t.Errorf("default-profile = %q, want %q", cfg.DefaultProfile, "beta")
+	}
+}
+
+func TestConfigSetDefault_NotFound(t *testing.T) {
+	jDir := setupTempConfig(t)
+	yaml := `profiles:
+  alpha:
+    url: https://alpha.jamfcloud.com
+    auth-method: token
+`
+	os.WriteFile(filepath.Join(jDir, "config.yaml"), []byte(yaml), 0600)
+
+	cmd := newConfigSetDefaultCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"nonexistent"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent profile")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+// --- checkHealth tests ---
+
+func TestCheckHealth_Healthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthCheck.html" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]string{})
+	}))
+	defer srv.Close()
+
+	result := checkHealth(srv.URL)
+	if !result.Healthy {
+		t.Error("expected healthy")
+	}
+	if result.Status != "ok" {
+		t.Errorf("status = %q, want %q", result.Status, "ok")
+	}
+}
+
+func TestCheckHealth_Unhealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]string{"DataLayer:UNHEALTHY"})
+	}))
+	defer srv.Close()
+
+	result := checkHealth(srv.URL)
+	if result.Healthy {
+		t.Error("expected unhealthy")
+	}
+	if result.Status != "DataLayer:UNHEALTHY" {
+		t.Errorf("status = %q, want %q", result.Status, "DataLayer:UNHEALTHY")
+	}
+}
+
+func TestCheckHealth_ServerDown(t *testing.T) {
+	result := checkHealth("http://127.0.0.1:1") // port 1 — will fail to connect
+	if result.Healthy {
+		t.Error("expected unhealthy for unreachable server")
+	}
+	if result.Status != "offline" {
+		t.Errorf("status = %q, want %q", result.Status, "offline")
+	}
+}
+
+func TestCheckHealth_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	result := checkHealth(srv.URL)
+	if result.Healthy {
+		t.Error("expected unhealthy for 503")
+	}
+	if result.Status != "HTTP 503" {
+		t.Errorf("status = %q, want %q", result.Status, "HTTP 503")
+	}
+}
+
+func TestCheckHealth_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	result := checkHealth(srv.URL)
+	if result.Healthy {
+		t.Error("expected unhealthy for invalid JSON")
+	}
+	if result.Status != "unknown" {
+		t.Errorf("status = %q, want %q", result.Status, "unknown")
+	}
+}
+
+// --- storeOrRefSecret tests ---
+
+func TestStoreOrRefSecret_EmptyValue(t *testing.T) {
+	var dest string
+	err := storeOrRefSecret(newMockKeychainStore(), "prof", "field", "", &dest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dest != "" {
+		t.Errorf("dest = %q, want empty", dest)
+	}
+}
+
+func TestStoreOrRefSecret_EnvRef(t *testing.T) {
+	var dest string
+	err := storeOrRefSecret(newMockKeychainStore(), "prof", "field", "env:MY_VAR", &dest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dest != "env:MY_VAR" {
+		t.Errorf("dest = %q, want %q", dest, "env:MY_VAR")
+	}
+}
+
+func TestStoreOrRefSecret_FileRef(t *testing.T) {
+	var dest string
+	err := storeOrRefSecret(newMockKeychainStore(), "prof", "field", "file:/tmp/secret", &dest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dest != "file:/tmp/secret" {
+		t.Errorf("dest = %q, want %q", dest, "file:/tmp/secret")
+	}
+}
+
+func TestStoreOrRefSecret_BareValue(t *testing.T) {
+	mock := newMockKeychainStore()
+	var dest string
+	err := storeOrRefSecret(mock, "myprof", "client-secret", "bare-secret-value", &dest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(dest, "keychain:") {
+		t.Errorf("dest = %q, want keychain: prefix", dest)
+	}
+	// Verify the value is in the mock store
+	key := "jamfpro-cli/myprof/client-secret"
+	if v, ok := mock.items[key]; !ok || v != "bare-secret-value" {
+		t.Errorf("keychain[%q] = %q, want %q", key, v, "bare-secret-value")
+	}
+}
+
+func TestStoreOrRefSecret_KeychainFailure(t *testing.T) {
+	var dest string
+	err := storeOrRefSecret(&failingKeychainStore{}, "prof", "secret", "bare-value", &dest)
+	if err == nil {
+		t.Fatal("expected error for failing keychain")
+	}
+	if !strings.Contains(err.Error(), "keychain") {
+		t.Errorf("expected keychain error, got: %v", err)
+	}
+}

--- a/internal/commands/overview_test.go
+++ b/internal/commands/overview_test.go
@@ -822,6 +822,82 @@ func TestPrintOverviewTable_NotificationsActive(t *testing.T) {
 	}
 }
 
+func TestFormatCount(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+		want  string
+	}{
+		{"float64 zero", float64(0), "0"},
+		{"float64 small", float64(42), "42"},
+		{"float64 large", float64(1234567), "1,234,567"},
+		{"int", int(99), "99"},
+		{"int64", int64(5000), "5,000"},
+		{"non-numeric string", "hello", "hello"},
+		{"nil", nil, "<nil>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatCount(tt.input)
+			if got != tt.want {
+				t.Errorf("formatCount(%v) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatEpochExpiration(t *testing.T) {
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		epoch     float64
+		wantColor string
+		wantWord  string
+	}{
+		{"expired", float64(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Unix()), "red", "expired"},
+		{"expiring soon", float64(time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC).Unix()), "red", "days"},
+		{"expiring mid", float64(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC).Unix()), "yellow", "days"},
+		{"far future", float64(time.Date(2028, 1, 1, 0, 0, 0, 0, time.UTC).Unix()), "", "Jan 01, 2028"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatted, color := formatEpochExpiration(tt.epoch, now)
+			if color != tt.wantColor {
+				t.Errorf("color = %q, want %q", color, tt.wantColor)
+			}
+			if !strings.Contains(formatted, tt.wantWord) {
+				t.Errorf("formatted = %q, want to contain %q", formatted, tt.wantWord)
+			}
+		})
+	}
+}
+
+func TestIsNumericValue(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"0", true},
+		{"42", true},
+		{"1,234", true},
+		{"1,234,567", true},
+		{"", false},
+		{"N/A", false},
+		{"enabled", false},
+		{"1.5", false},
+		{"-1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := isNumericValue(tt.input)
+			if got != tt.want {
+				t.Errorf("isNumericValue(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPrintOverviewTable_DEPSyncSuccessful(t *testing.T) {
 	sections := []overviewSection{
 		{

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -3,6 +3,7 @@ package output
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -1171,6 +1172,221 @@ func TestPrintRaw_Table_DateFormatting(t *testing.T) {
 	// Should NOT show ISO format
 	if strings.Contains(out, "2025-09-27T") {
 		t.Errorf("expected ISO date to be formatted, got:\n%s", out)
+	}
+}
+
+// --- New constructor tests ---
+
+func TestNew(t *testing.T) {
+	f := New("json", true, false)
+	if f.format != FormatJSON {
+		t.Errorf("format = %q, want %q", f.format, FormatJSON)
+	}
+	if !f.noColor {
+		t.Error("expected noColor=true")
+	}
+	if f.wide {
+		t.Error("expected wide=false")
+	}
+	if f.writer == nil {
+		t.Error("writer should default to non-nil (os.Stdout)")
+	}
+}
+
+func TestNew_Wide(t *testing.T) {
+	f := New("table", false, true)
+	if f.format != FormatTable {
+		t.Errorf("format = %q, want %q", f.format, FormatTable)
+	}
+	if f.noColor {
+		t.Error("expected noColor=false")
+	}
+	if !f.wide {
+		t.Error("expected wide=true")
+	}
+}
+
+// --- SetWriter tests ---
+
+func TestSetWriter(t *testing.T) {
+	f := New("json", true, false)
+	buf := &bytes.Buffer{}
+	f.SetWriter(buf)
+
+	data := []map[string]interface{}{{"id": float64(1), "name": "test"}}
+	if err := f.Print(data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Error("expected output written to custom writer")
+	}
+	if !strings.Contains(buf.String(), "test") {
+		t.Error("expected 'test' in output")
+	}
+}
+
+// --- Print dispatcher tests ---
+
+func TestPrint_JSON(t *testing.T) {
+	f, buf := newTestFormatter("json")
+	data := []map[string]interface{}{{"id": float64(1)}}
+	if err := f.Print(data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should be valid JSON
+	var result []map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+}
+
+func TestPrint_YAML(t *testing.T) {
+	f, buf := newTestFormatter("yaml")
+	data := []map[string]interface{}{{"id": float64(1), "name": "test"}}
+	if err := f.Print(data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "name: test") {
+		t.Errorf("expected YAML output, got:\n%s", buf.String())
+	}
+}
+
+func TestPrint_CSV(t *testing.T) {
+	f, buf := newTestFormatter("csv")
+	data := []map[string]interface{}{{"id": float64(1), "name": "test"}}
+	if err := f.Print(data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected header + 1 row, got %d lines", len(lines))
+	}
+}
+
+func TestPrint_CSV_Empty(t *testing.T) {
+	f, buf := newTestFormatter("csv")
+	data := []map[string]interface{}{}
+	if err := f.Print(data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output for empty data, got: %s", buf.String())
+	}
+}
+
+func TestPrint_CSV_UnsupportedType(t *testing.T) {
+	f, _ := newTestFormatter("csv")
+	err := f.Print("not a slice of maps")
+	if err == nil {
+		t.Fatal("expected error for unsupported CSV type")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("expected 'not supported' in error, got: %v", err)
+	}
+}
+
+func TestPrint_Plain_String(t *testing.T) {
+	f, buf := newTestFormatter("plain")
+	if err := f.Print("hello world"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(buf.String()) != "hello world" {
+		t.Errorf("expected 'hello world', got: %s", buf.String())
+	}
+}
+
+func TestPrint_Table_NonSlice(t *testing.T) {
+	f, buf := newTestFormatter("table")
+	if err := f.Print("simple string"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "simple string") {
+		t.Errorf("expected fallback output, got: %s", buf.String())
+	}
+}
+
+func TestPrint_Table_Empty(t *testing.T) {
+	f, buf := newTestFormatter("table")
+	data := []map[string]interface{}{}
+	if err := f.Print(data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output for empty table, got: %s", buf.String())
+	}
+}
+
+// --- PrintError tests ---
+
+func TestPrintError_JSON(t *testing.T) {
+	f, buf := newTestFormatter("json")
+	testErr := fmt.Errorf("something went wrong")
+	details := map[string]interface{}{"field": "name"}
+	f.PrintError(testErr, "validation_error", details)
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nOutput: %s", err, buf.String())
+	}
+	if result["error"] != "validation_error" {
+		t.Errorf("error = %v, want %q", result["error"], "validation_error")
+	}
+	if result["message"] != "something went wrong" {
+		t.Errorf("message = %v, want %q", result["message"], "something went wrong")
+	}
+	if result["field"] != "name" {
+		t.Errorf("field = %v, want %q", result["field"], "name")
+	}
+}
+
+func TestPrintError_NonJSON(t *testing.T) {
+	// PrintError in non-JSON mode writes to os.Stderr — just verify it doesn't panic
+	f, _ := newTestFormatter("table")
+	testErr := fmt.Errorf("something went wrong")
+	f.PrintError(testErr, "general", nil)
+	// No assertion needed — we're just ensuring it doesn't panic
+}
+
+// --- parseDate and relativeDate tests ---
+
+func TestParseDate(t *testing.T) {
+	tests := []struct {
+		input string
+		ok    bool
+	}{
+		{"2025-09-27T07:26:37.424Z", true},
+		{"2025-09-27T14:30:00Z", true},
+		{"2025-09-27T19:45:37+00:00", true},
+		{"2025-09-27", true},
+		{"not-a-date", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			_, ok := parseDate(tt.input)
+			if ok != tt.ok {
+				t.Errorf("parseDate(%q) ok = %v, want %v", tt.input, ok, tt.ok)
+			}
+		})
+	}
+}
+
+func TestAbsoluteDate_MidnightOmitsTime(t *testing.T) {
+	ts := time.Date(2025, 9, 27, 0, 0, 0, 0, time.UTC)
+	got := absoluteDate(ts)
+	if strings.Contains(got, "AM") || strings.Contains(got, "PM") {
+		t.Errorf("midnight should omit time, got: %q", got)
+	}
+	if !strings.Contains(got, "Sep 27, 2025") {
+		t.Errorf("expected 'Sep 27, 2025', got: %q", got)
+	}
+}
+
+func TestAbsoluteDate_WithTime(t *testing.T) {
+	ts := time.Date(2025, 9, 27, 14, 30, 0, 0, time.UTC)
+	got := absoluteDate(ts)
+	if !strings.Contains(got, "2:30 PM") {
+		t.Errorf("expected '2:30 PM' in output, got: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds tests for config subcommands (show, path, list, remove-profile, set-default) using cobra Execute + XDG temp dir pattern
- Adds `checkHealth` tests with httptest (healthy, unhealthy, server down, non-200, invalid JSON)
- Adds `storeOrRefSecret` tests (empty, env ref, file ref, bare value → keychain, keychain failure)
- Adds overview helper tests (`formatCount` all type branches, `formatEpochExpiration`, `isNumericValue`)
- Adds output formatter tests (`New`, `SetWriter`, `Print` dispatcher for all 5 formats, `PrintError`, `parseDate`, `absoluteDate`)

**Coverage improvements:**
- `internal/commands`: 36.6% → 43.7%
- `internal/output`: 88.6% → 95.9%

## Test plan
- [x] `go test ./...` passes
- [x] No changes to production code — test-only additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)