### PR TITLE
feat: add multi command for cross-profile execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ jamf-cli pro buildings apply --from-file building.json --yes
 
 # Delete a building by name
 jamf-cli pro buildings delete-by-name "HQ" --yes
+
+# Run a command against multiple instances
+jamf-cli multi --filter 'pro-*' -- pro buildings apply --from-file building.json --yes
 ```
 
 See the [Setup Guide](https://github.com/Jamf-Concepts/jamf-cli/wiki/Setup-Guide) for the full walkthrough.
@@ -88,6 +91,7 @@ See the [Setup Guide](https://github.com/Jamf-Concepts/jamf-cli/wiki/Setup-Guide
 - **Five output formats** — `table`, `json`, `csv`, `yaml`, `plain`
 - **Auto-pagination** — `--all` fetches every page; `--limit` caps results
 - **Dry-run mode** — `--dry-run` previews writes without executing
+- **`multi`** — Run any command against multiple profiles: `jamf-cli multi --filter 'pro-*' -- pro comp list`. Supports glob patterns, file input (profile names or URLs), and interactive selection
 - **Destructive safeguards** — Delete and replace operations require `--yes` confirmation
 - **System keychain** — Secrets stored via macOS Keychain or Linux secret-service
 - **Jamf Platform Gateway** — Route Jamf Pro through regional gateways with `--tenant-id`

--- a/internal/commands/groups.go
+++ b/internal/commands/groups.go
@@ -16,6 +16,7 @@ var rootGroupMap = map[string]string{
 	"config":     "core",
 	"completion": "core",
 	"commands":   "core",
+	"multi":      "core",
 	"pro":        "products",
 	"protect":    "products",
 }

--- a/internal/commands/multi.go
+++ b/internal/commands/multi.go
@@ -1,0 +1,490 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/config"
+)
+
+func newMultiCmd() *cobra.Command {
+	var (
+		filter      string
+		profilesCSV string
+		fromFile    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "multi [flags] [--] <command> [args...]",
+		Short: "Run a command against multiple profiles",
+		Long: `Execute any jamf-cli command against multiple config profiles.
+
+Target profiles can be selected by glob pattern (--filter), explicit list
+(--profiles), or from a file (--from-file). The file can contain profile
+names or instance URLs — URLs are matched against profile URLs in your
+config.
+
+When no targeting flag is provided, an interactive selection prompt is
+shown. The -- separator is optional but recommended when the inner
+command has flags that could conflict with multi's flags.
+
+Examples:
+  # Interactive profile selection (no multi flags, no -- needed)
+  jamf-cli multi pro overview
+  jamf-cli multi pro comp list
+
+  # Filter by glob pattern (use -- to separate flags)
+  jamf-cli multi --filter 'pro-*' -- pro comp list -o table
+
+  # Explicit list
+  jamf-cli multi --profiles pro-school1,pro-school2 -- pro overview
+
+  # Reuse the same URL file from setup
+  jamf-cli multi --from-file instances.txt -- pro buildings apply --from-file b.json --yes`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := cmd.ErrOrStderr()
+
+			// Determine inner command args.
+			// With --:    multi --filter 'pro-*' -- pro comp list
+			// Without --: multi pro comp list (interactive mode)
+			dashIdx := cmd.ArgsLenAtDash()
+			var innerArgs []string
+			if dashIdx >= 0 {
+				innerArgs = args[dashIdx:]
+				if len(innerArgs) == 0 {
+					return fmt.Errorf("no command specified after --")
+				}
+			} else if len(args) > 0 {
+				innerArgs = args
+			} else {
+				return fmt.Errorf("no command specified\n\nUsage: jamf-cli multi [flags] [--] <command> [args...]")
+			}
+
+			// Load config
+			cfg, err := config.Load()
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			// Determine product from inner command to filter out wrong-product profiles
+			product := detectProduct(innerArgs)
+
+			// Resolve target profiles
+			profiles, err := resolveMultiProfiles(cfg, filter, profilesCSV, fromFile, product, noInput)
+			if err != nil {
+				return err
+			}
+
+			// Get the executable path for re-invocation
+			executable, err := os.Executable()
+			if err != nil {
+				return fmt.Errorf("determining executable path: %w", err)
+			}
+
+			_, _ = fmt.Fprintf(w, "Running against %d profile(s)...\n", len(profiles))
+
+			var succeeded, failed int
+			var failures []string
+
+			total := len(profiles)
+			for i, profileName := range profiles {
+				url := ""
+				if p, ok := cfg.Profiles[profileName]; ok {
+					url = p.URL
+				}
+
+				if url != "" {
+					_, _ = fmt.Fprintf(w, "\n── [%d/%d] %s (%s) ──\n", i+1, total, profileName, url)
+				} else {
+					_, _ = fmt.Fprintf(w, "\n── [%d/%d] %s ──\n", i+1, total, profileName)
+				}
+
+				// Build command: jamf-cli --profile <name> <inner args...>
+				cmdArgs := append([]string{"--profile", profileName}, innerArgs...)
+				child := exec.Command(executable, cmdArgs...)
+				child.Stdout = cmd.OutOrStdout()
+				child.Stderr = cmd.ErrOrStderr()
+
+				if err := child.Run(); err != nil {
+					_, _ = fmt.Fprintf(w, "  ✗ FAILED: %v\n", err)
+					failures = append(failures, fmt.Sprintf("%s: %v", profileName, err))
+					failed++
+				} else {
+					succeeded++
+				}
+			}
+
+			// Summary
+			_, _ = fmt.Fprintf(w, "\n── Summary ──\n")
+			_, _ = fmt.Fprintf(w, "  Succeeded: %d\n", succeeded)
+			if failed > 0 {
+				_, _ = fmt.Fprintf(w, "  Failed:    %d\n", failed)
+				for _, f := range failures {
+					_, _ = fmt.Fprintf(w, "    - %s\n", f)
+				}
+				return fmt.Errorf("%d of %d profile(s) failed", failed, len(profiles))
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&filter, "filter", "", "glob pattern to match profile names (e.g., 'pro-*')")
+	cmd.Flags().StringVar(&profilesCSV, "profiles", "", "comma-separated list of profile names")
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "file containing profile names or instance URLs (one per line)")
+	cmd.MarkFlagsMutuallyExclusive("filter", "profiles", "from-file")
+
+	return cmd
+}
+
+// resolveMultiProfiles determines which profiles to target based on flags.
+// When no flag is set, prompts interactively (unless --no-input).
+// The product parameter filters profiles to match the inner command's product
+// ("pro" or "protect"), preventing accidental cross-product execution.
+func resolveMultiProfiles(cfg *config.Config, filter, profilesCSV, fromFile, product string, noInput bool) ([]string, error) {
+	allNames := sortedProfileNames(cfg)
+	if len(allNames) == 0 {
+		return nil, fmt.Errorf("no profiles configured — run 'jamf-cli pro setup' first")
+	}
+
+	var names []string
+	var err error
+
+	switch {
+	case filter != "":
+		names, err = filterProfiles(allNames, filter)
+	case profilesCSV != "":
+		names, err = validateProfileNames(cfg, splitAndTrim(profilesCSV, ","))
+	case fromFile != "":
+		names, err = readProfilesFromFile(cfg, fromFile)
+	default:
+		// For interactive selection, pre-filter the list by product
+		filteredNames := filterByProduct(cfg, allNames, product)
+		names, err = promptProfileSelection(cfg, filteredNames, noInput)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter resolved profiles by product (skip silently for explicit --profiles)
+	if product != "" && profilesCSV == "" {
+		names = filterByProduct(cfg, names, product)
+	}
+
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no matching %s profiles found", product)
+	}
+	return names, nil
+}
+
+// detectProduct inspects the inner command args to determine the target product.
+// Returns "pro", "protect", or "" if indeterminate.
+func detectProduct(innerArgs []string) string {
+	for _, arg := range innerArgs {
+		switch arg {
+		case "pro":
+			return "pro"
+		case "protect":
+			return "protect"
+		}
+		// Stop at first non-flag argument
+		if !strings.HasPrefix(arg, "-") {
+			break
+		}
+	}
+	return ""
+}
+
+// filterByProduct returns only profiles matching the given product type.
+// Pro profiles have Product=="" or Product=="pro". Protect profiles have Product=="protect".
+func filterByProduct(cfg *config.Config, names []string, product string) []string {
+	if product == "" {
+		return names
+	}
+	var filtered []string
+	for _, name := range names {
+		p := cfg.Profiles[name]
+		profileProduct := p.Product
+		if profileProduct == "" {
+			profileProduct = "pro"
+		}
+		if profileProduct == product {
+			filtered = append(filtered, name)
+		}
+	}
+	return filtered
+}
+
+// sortedProfileNames returns all profile names in sorted order.
+func sortedProfileNames(cfg *config.Config) []string {
+	names := make([]string, 0, len(cfg.Profiles))
+	for name := range cfg.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// filterProfiles returns profile names matching a glob pattern.
+func filterProfiles(allNames []string, pattern string) ([]string, error) {
+	var matched []string
+	for _, name := range allNames {
+		ok, err := filepath.Match(pattern, name)
+		if err != nil {
+			return nil, fmt.Errorf("invalid filter pattern %q: %w", pattern, err)
+		}
+		if ok {
+			matched = append(matched, name)
+		}
+	}
+	if len(matched) == 0 {
+		return nil, fmt.Errorf("no profiles match filter %q", pattern)
+	}
+	return matched, nil
+}
+
+// validateProfileNames checks that all names exist in config and deduplicates.
+func validateProfileNames(cfg *config.Config, names []string) ([]string, error) {
+	seen := make(map[string]bool)
+	var result []string
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if _, ok := cfg.Profiles[name]; !ok {
+			return nil, fmt.Errorf("profile %q not found in config", name)
+		}
+		if !seen[name] {
+			seen[name] = true
+			result = append(result, name)
+		}
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no valid profile names provided")
+	}
+	return result, nil
+}
+
+// readProfilesFromFile reads profile names or instance URLs from a file.
+// URLs are resolved to profile names by matching against config.
+func readProfilesFromFile(cfg *config.Config, path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	seen := make(map[string]bool)
+	var names []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		var profileName string
+		if _, ok := cfg.Profiles[line]; ok {
+			// Exact profile name match — use it directly
+			profileName = line
+		} else if looksLikeURL(line) {
+			// Not a profile name — try resolving as a URL
+			resolved, err := resolveURLToProfile(cfg, line)
+			if err != nil {
+				return nil, err
+			}
+			profileName = resolved
+		} else {
+			return nil, fmt.Errorf("profile %q not found in config", line)
+		}
+
+		if !seen[profileName] {
+			seen[profileName] = true
+			names = append(names, profileName)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no profiles found in %s", path)
+	}
+	return names, nil
+}
+
+// looksLikeURL returns true if the string appears to be a URL rather than a profile name.
+// Checks for scheme prefix or common Jamf cloud domain suffixes.
+func looksLikeURL(s string) bool {
+	lower := strings.ToLower(s)
+	return strings.Contains(s, "://") ||
+		strings.HasSuffix(lower, ".jamfcloud.com") ||
+		strings.HasSuffix(lower, ".jamf.com")
+}
+
+// resolveURLToProfile finds the profile name whose URL matches the given URL.
+// When multiple profiles share the same URL, prefers pro-<subdomain> profiles
+// (created by setup --from-file), then falls back to the first alphabetical match.
+func resolveURLToProfile(cfg *config.Config, rawURL string) (string, error) {
+	normalized := normalizeURLForMatch(rawURL)
+	var matches []string
+	for name, p := range cfg.Profiles {
+		if normalizeURLForMatch(p.URL) == normalized {
+			matches = append(matches, name)
+		}
+	}
+
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no profile found for %s — run 'jamf-cli pro setup' first", rawURL)
+	}
+
+	// Prefer pro-<subdomain> profiles (auto-generated by setup --from-file)
+	for _, name := range matches {
+		if strings.HasPrefix(name, "pro-") {
+			return name, nil
+		}
+	}
+
+	// Fall back to alphabetically first match for determinism
+	sort.Strings(matches)
+	return matches[0], nil
+}
+
+// normalizeURLForMatch normalizes a URL for comparison: adds https, strips trailing slash.
+func normalizeURLForMatch(rawURL string) string {
+	rawURL = strings.TrimSpace(rawURL)
+	rawURL = strings.TrimRight(rawURL, "/")
+	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
+		rawURL = "https://" + rawURL
+	}
+	return strings.ToLower(rawURL)
+}
+
+// promptProfileSelection shows an interactive profile picker.
+func promptProfileSelection(cfg *config.Config, allNames []string, noInput bool) ([]string, error) {
+	if noInput {
+		return nil, fmt.Errorf("no profiles specified — use --filter, --profiles, or --from-file (required with --no-input)")
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return nil, fmt.Errorf("no profiles specified and stdin is not a terminal — use --filter, --profiles, or --from-file")
+	}
+
+	fmt.Fprintln(os.Stderr, "\nAvailable profiles:")
+	for i, name := range allNames {
+		url := cfg.Profiles[name].URL
+		fmt.Fprintf(os.Stderr, "  %d. %s (%s)\n", i+1, name, url)
+	}
+	fmt.Fprint(os.Stderr, "\nSelect profiles (numbers, ranges, 'all', or glob pattern): ")
+
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	input := strings.TrimSpace(line)
+
+	if input == "" {
+		return nil, fmt.Errorf("no selection made")
+	}
+
+	if strings.EqualFold(input, "all") {
+		return allNames, nil
+	}
+
+	// Check if it's a glob pattern
+	if strings.ContainsAny(input, "*?[") {
+		return filterProfiles(allNames, input)
+	}
+
+	// Parse as space/comma separated tokens, supporting ranges (e.g., "1 3 5-8")
+	tokens := tokenizeSelection(input)
+	seen := make(map[string]bool)
+	var selected []string
+	for _, tok := range tokens {
+		// Check for range: N-M
+		if start, end, ok := parseRange(tok); ok {
+			if start < 1 || end > len(allNames) || start > end {
+				return nil, fmt.Errorf("range %q is out of bounds (1-%d)", tok, len(allNames))
+			}
+			for i := start; i <= end; i++ {
+				name := allNames[i-1]
+				if !seen[name] {
+					seen[name] = true
+					selected = append(selected, name)
+				}
+			}
+			continue
+		}
+
+		// Try as single number
+		var idx int
+		if _, err := fmt.Sscanf(tok, "%d", &idx); err == nil && idx >= 1 && idx <= len(allNames) {
+			name := allNames[idx-1]
+			if !seen[name] {
+				seen[name] = true
+				selected = append(selected, name)
+			}
+			continue
+		}
+
+		// Try as profile name
+		if _, ok := cfg.Profiles[tok]; ok {
+			if !seen[tok] {
+				seen[tok] = true
+				selected = append(selected, tok)
+			}
+			continue
+		}
+
+		return nil, fmt.Errorf("%q is not a valid number (1-%d), range, or profile name", tok, len(allNames))
+	}
+
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("no profiles selected")
+	}
+	return selected, nil
+}
+
+// tokenizeSelection splits user input on spaces and commas.
+// "1, 3 5-8" → ["1", "3", "5-8"]
+func tokenizeSelection(input string) []string {
+	// Replace commas with spaces, then split on whitespace
+	input = strings.ReplaceAll(input, ",", " ")
+	fields := strings.Fields(input)
+	return fields
+}
+
+// parseRange parses a "N-M" range string. Returns (start, end, true) on success.
+func parseRange(s string) (int, int, bool) {
+	parts := strings.SplitN(s, "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	var start, end int
+	if _, err := fmt.Sscanf(parts[0], "%d", &start); err != nil {
+		return 0, 0, false
+	}
+	if _, err := fmt.Sscanf(parts[1], "%d", &end); err != nil {
+		return 0, 0, false
+	}
+	return start, end, true
+}
+
+// splitAndTrim splits a string by sep and trims whitespace from each part.
+func splitAndTrim(s, sep string) []string {
+	parts := strings.Split(s, sep)
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
+}

--- a/internal/commands/multi_test.go
+++ b/internal/commands/multi_test.go
@@ -1,0 +1,501 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/config"
+)
+
+func testConfig() *config.Config {
+	return &config.Config{
+		Profiles: map[string]config.Profile{
+			"default":      {URL: "https://main.jamfcloud.com", AuthMethod: "oauth2"},
+			"pro-school1":  {URL: "https://school1.jamfcloud.com", AuthMethod: "oauth2"},
+			"pro-school2":  {URL: "https://school2.jamfcloud.com", AuthMethod: "oauth2"},
+			"pro-school3":  {URL: "https://school3.jamfcloud.com", AuthMethod: "oauth2"},
+			"protect-test": {URL: "https://test.protect.jamfcloud.com", AuthMethod: "oauth2", Product: "protect"},
+			"staging":      {URL: "https://staging.jamfcloud.com", AuthMethod: "oauth2"},
+		},
+	}
+}
+
+func TestSortedProfileNames(t *testing.T) {
+	cfg := testConfig()
+	names := sortedProfileNames(cfg)
+	if len(names) != 6 {
+		t.Fatalf("got %d names, want 6", len(names))
+	}
+	// Should be sorted
+	for i := 1; i < len(names); i++ {
+		if names[i] < names[i-1] {
+			t.Errorf("names not sorted: %v", names)
+			break
+		}
+	}
+}
+
+func TestFilterProfiles_GlobMatch(t *testing.T) {
+	names := []string{"default", "pro-school1", "pro-school2", "pro-school3", "protect-test", "staging"}
+
+	matched, err := filterProfiles(names, "pro-*")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matched) != 3 {
+		t.Fatalf("got %d matches, want 3", len(matched))
+	}
+	for _, m := range matched {
+		if !strings.HasPrefix(m, "pro-") {
+			t.Errorf("unexpected match: %q", m)
+		}
+	}
+}
+
+func TestFilterProfiles_NoMatch(t *testing.T) {
+	names := []string{"default", "pro-school1"}
+
+	_, err := filterProfiles(names, "missing-*")
+	if err == nil {
+		t.Fatal("expected error for no matches")
+	}
+	if !strings.Contains(err.Error(), "no profiles match") {
+		t.Errorf("error = %q, want it to contain 'no profiles match'", err.Error())
+	}
+}
+
+func TestFilterProfiles_InvalidPattern(t *testing.T) {
+	names := []string{"default"}
+
+	_, err := filterProfiles(names, "[invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid pattern")
+	}
+}
+
+func TestValidateProfileNames_AllValid(t *testing.T) {
+	cfg := testConfig()
+
+	names, err := validateProfileNames(cfg, []string{"default", "pro-school1", "staging"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 3 {
+		t.Fatalf("got %d names, want 3", len(names))
+	}
+}
+
+func TestValidateProfileNames_Unknown(t *testing.T) {
+	cfg := testConfig()
+
+	_, err := validateProfileNames(cfg, []string{"default", "nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for unknown profile")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want it to contain 'not found'", err.Error())
+	}
+}
+
+func TestValidateProfileNames_Dedup(t *testing.T) {
+	cfg := testConfig()
+
+	names, err := validateProfileNames(cfg, []string{"default", "default", "pro-school1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("got %d names, want 2 (deduped)", len(names))
+	}
+}
+
+func TestResolveURLToProfile_Found(t *testing.T) {
+	cfg := testConfig()
+
+	name, err := resolveURLToProfile(cfg, "https://school1.jamfcloud.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "pro-school1" {
+		t.Errorf("got %q, want %q", name, "pro-school1")
+	}
+}
+
+func TestResolveURLToProfile_FoundWithoutScheme(t *testing.T) {
+	cfg := testConfig()
+
+	name, err := resolveURLToProfile(cfg, "school2.jamfcloud.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "pro-school2" {
+		t.Errorf("got %q, want %q", name, "pro-school2")
+	}
+}
+
+func TestResolveURLToProfile_NotFound(t *testing.T) {
+	cfg := testConfig()
+
+	_, err := resolveURLToProfile(cfg, "https://unknown.jamfcloud.com")
+	if err == nil {
+		t.Fatal("expected error for unknown URL")
+	}
+	if !strings.Contains(err.Error(), "no profile found") {
+		t.Errorf("error = %q, want it to contain 'no profile found'", err.Error())
+	}
+}
+
+func TestReadProfilesFromFile_ProfileNames(t *testing.T) {
+	cfg := testConfig()
+
+	f, err := os.CreateTemp("", "profiles-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	_, _ = f.WriteString("pro-school1\n")
+	_, _ = f.WriteString("# comment\n")
+	_, _ = f.WriteString("\n")
+	_, _ = f.WriteString("pro-school2\n")
+	_ = f.Close()
+
+	names, err := readProfilesFromFile(cfg, f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("got %d names, want 2", len(names))
+	}
+	if names[0] != "pro-school1" || names[1] != "pro-school2" {
+		t.Errorf("names = %v, want [pro-school1 pro-school2]", names)
+	}
+}
+
+func TestReadProfilesFromFile_URLs(t *testing.T) {
+	cfg := testConfig()
+
+	f, err := os.CreateTemp("", "urls-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	_, _ = f.WriteString("school1.jamfcloud.com\n")
+	_, _ = f.WriteString("https://school3.jamfcloud.com\n")
+	_ = f.Close()
+
+	names, err := readProfilesFromFile(cfg, f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("got %d names, want 2", len(names))
+	}
+	if names[0] != "pro-school1" || names[1] != "pro-school3" {
+		t.Errorf("names = %v, want [pro-school1 pro-school3]", names)
+	}
+}
+
+func TestReadProfilesFromFile_Dedup(t *testing.T) {
+	cfg := testConfig()
+
+	f, err := os.CreateTemp("", "dup-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	_, _ = f.WriteString("pro-school1\n")
+	_, _ = f.WriteString("school1.jamfcloud.com\n") // same profile via URL
+	_, _ = f.WriteString("pro-school1\n")           // exact duplicate
+	_ = f.Close()
+
+	names, err := readProfilesFromFile(cfg, f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 1 {
+		t.Fatalf("got %d names, want 1 (deduped)", len(names))
+	}
+}
+
+func TestReadProfilesFromFile_UnknownURL(t *testing.T) {
+	cfg := testConfig()
+
+	f, err := os.CreateTemp("", "unknown-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	_, _ = f.WriteString("https://unknown.jamfcloud.com\n")
+	_ = f.Close()
+
+	_, err = readProfilesFromFile(cfg, f.Name())
+	if err == nil {
+		t.Fatal("expected error for unknown URL")
+	}
+	if !strings.Contains(err.Error(), "no profile found") {
+		t.Errorf("error = %q, want it to contain 'no profile found'", err.Error())
+	}
+}
+
+func TestLooksLikeURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"https://school1.jamfcloud.com", true},
+		{"school1.jamfcloud.com", true},
+		{"http://localhost:8080", true},
+		{"tenant.protect.jamfcloud.com", true},
+		{"us.apigw.jamf.com", true},
+		{"pro-school1", false},
+		{"default", false},
+		{"v2.prod", false},          // dotted profile name — not a URL
+		{"staging.internal", false}, // dotted profile name — not a URL
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := looksLikeURL(tt.input)
+			if got != tt.want {
+				t.Errorf("looksLikeURL(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeURLForMatch(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://School1.JamfCloud.com", "https://school1.jamfcloud.com"},
+		{"school1.jamfcloud.com/", "https://school1.jamfcloud.com"},
+		{"  school1.jamfcloud.com  ", "https://school1.jamfcloud.com"},
+		{"http://localhost:8080", "http://localhost:8080"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeURLForMatch(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeURLForMatch(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitAndTrim(t *testing.T) {
+	got := splitAndTrim(" a , b , c , ", ",")
+	if len(got) != 3 {
+		t.Fatalf("got %d parts, want 3", len(got))
+	}
+	if got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Errorf("got %v, want [a b c]", got)
+	}
+}
+
+func TestTokenizeSelection(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"1 2 3", []string{"1", "2", "3"}},
+		{"1,2,3", []string{"1", "2", "3"}},
+		{"1, 2, 3", []string{"1", "2", "3"}},
+		{"1 3 5-8", []string{"1", "3", "5-8"}},
+		{"1,3,5-8", []string{"1", "3", "5-8"}},
+		{"  1  2  ", []string{"1", "2"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := tokenizeSelection(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("token[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseRange(t *testing.T) {
+	start, end, ok := parseRange("3-7")
+	if !ok {
+		t.Fatal("expected ok for valid range")
+	}
+	if start != 3 || end != 7 {
+		t.Errorf("got %d-%d, want 3-7", start, end)
+	}
+
+	_, _, ok = parseRange("5")
+	if ok {
+		t.Error("expected !ok for non-range")
+	}
+
+	_, _, ok = parseRange("a-b")
+	if ok {
+		t.Error("expected !ok for non-numeric range")
+	}
+}
+
+func TestDetectProduct(t *testing.T) {
+	tests := []struct {
+		args []string
+		want string
+	}{
+		{[]string{"pro", "comp", "list"}, "pro"},
+		{[]string{"protect", "plans", "list"}, "protect"},
+		{[]string{"config", "list"}, ""},
+		{[]string{}, ""},
+	}
+
+	for _, tt := range tests {
+		got := detectProduct(tt.args)
+		if got != tt.want {
+			t.Errorf("detectProduct(%v) = %q, want %q", tt.args, got, tt.want)
+		}
+	}
+}
+
+func TestFilterByProduct_Pro(t *testing.T) {
+	cfg := testConfig()
+	all := sortedProfileNames(cfg)
+
+	proOnly := filterByProduct(cfg, all, "pro")
+	for _, name := range proOnly {
+		if cfg.Profiles[name].Product == "protect" {
+			t.Errorf("pro filter included protect profile %q", name)
+		}
+	}
+	// Should exclude protect-test
+	for _, name := range proOnly {
+		if name == "protect-test" {
+			t.Error("pro filter should not include protect-test")
+		}
+	}
+}
+
+func TestFilterByProduct_Protect(t *testing.T) {
+	cfg := testConfig()
+	all := sortedProfileNames(cfg)
+
+	protectOnly := filterByProduct(cfg, all, "protect")
+	if len(protectOnly) != 1 {
+		t.Fatalf("got %d protect profiles, want 1", len(protectOnly))
+	}
+	if protectOnly[0] != "protect-test" {
+		t.Errorf("got %q, want protect-test", protectOnly[0])
+	}
+}
+
+func TestFilterByProduct_Empty(t *testing.T) {
+	cfg := testConfig()
+	all := sortedProfileNames(cfg)
+
+	// Empty product should return all
+	result := filterByProduct(cfg, all, "")
+	if len(result) != len(all) {
+		t.Errorf("got %d profiles, want %d (empty product should return all)", len(result), len(all))
+	}
+}
+
+// --- resolveMultiProfiles integration tests ---
+
+func TestResolveMultiProfiles_FilterWithProductFilter(t *testing.T) {
+	cfg := testConfig()
+
+	// --filter '*' with product=pro should exclude protect-test
+	names, err := resolveMultiProfiles(cfg, "*", "", "", "pro", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, name := range names {
+		if name == "protect-test" {
+			t.Error("product filter should have excluded protect-test")
+		}
+	}
+	// Should have 5 pro profiles (all except protect-test)
+	if len(names) != 5 {
+		t.Errorf("got %d profiles, want 5", len(names))
+	}
+}
+
+func TestResolveMultiProfiles_FilterWithProductProtect(t *testing.T) {
+	cfg := testConfig()
+
+	// --filter '*' with product=protect should only return protect profiles
+	names, err := resolveMultiProfiles(cfg, "*", "", "", "protect", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 1 || names[0] != "protect-test" {
+		t.Errorf("got %v, want [protect-test]", names)
+	}
+}
+
+func TestResolveMultiProfiles_ExplicitProfilesSkipProductFilter(t *testing.T) {
+	cfg := testConfig()
+
+	// --profiles with explicit names should NOT be filtered by product
+	names, err := resolveMultiProfiles(cfg, "", "protect-test,pro-school1", "", "pro", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should include both — explicit profiles are trusted
+	if len(names) != 2 {
+		t.Errorf("got %d profiles, want 2 (explicit profiles skip product filter)", len(names))
+	}
+}
+
+func TestResolveMultiProfiles_NoMatchingProduct(t *testing.T) {
+	// Config with only pro profiles
+	cfg := &config.Config{
+		Profiles: map[string]config.Profile{
+			"default": {URL: "https://main.jamfcloud.com", AuthMethod: "oauth2"},
+		},
+	}
+
+	_, err := resolveMultiProfiles(cfg, "*", "", "", "protect", true)
+	if err == nil {
+		t.Fatal("expected error when no profiles match product")
+	}
+	if !strings.Contains(err.Error(), "no matching") {
+		t.Errorf("error = %q, want it to contain 'no matching'", err.Error())
+	}
+}
+
+func TestResolveMultiProfiles_EmptyConfig(t *testing.T) {
+	cfg := &config.Config{Profiles: map[string]config.Profile{}}
+
+	_, err := resolveMultiProfiles(cfg, "*", "", "", "", true)
+	if err == nil {
+		t.Fatal("expected error for empty config")
+	}
+	if !strings.Contains(err.Error(), "no profiles configured") {
+		t.Errorf("error = %q, want it to contain 'no profiles configured'", err.Error())
+	}
+}
+
+func TestResolveMultiProfiles_NoInput(t *testing.T) {
+	cfg := testConfig()
+
+	// No flags + noInput=true should error
+	_, err := resolveMultiProfiles(cfg, "", "", "", "", true)
+	if err == nil {
+		t.Fatal("expected error for no flags with --no-input")
+	}
+	if !strings.Contains(err.Error(), "--filter") {
+		t.Errorf("error = %q, want it to mention --filter", err.Error())
+	}
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -410,6 +410,7 @@ analytics, threat prevention, and configuration).`,
 				"commands":   true,
 				"diff":       true,
 				"setup":      true,
+				"multi":      true,
 			}
 			for c := cmd; c != nil; c = c.Parent() {
 				if skipCommands[c.Name()] {
@@ -523,6 +524,9 @@ analytics, threat prevention, and configuration).`,
 
 	// Commands discovery subcommand
 	cmd.AddCommand(newCommandsCmd(cmd))
+
+	// Multi-profile command runner
+	cmd.AddCommand(newMultiCmd())
 
 	// Jamf Pro product namespace
 	cmd.AddCommand(newProCmd(cliCtx))


### PR DESCRIPTION
## Summary

Adds `jamf-cli multi` — run any command against multiple config profiles in one shot.

### Targeting modes

| Flag | Description |
|------|-------------|
| `--filter 'pro-*'` | Glob pattern on profile names |
| `--profiles a,b,c` | Explicit comma-separated list |
| `--from-file f.txt` | File of profile names or instance URLs (same file as `pro setup --from-file`) |
| *(none)* | Interactive picker with numbers, ranges, "all", or glob |

### Examples

```bash
# Interactive (no -- needed)
jamf-cli multi pro overview

# Glob filter
jamf-cli multi --filter 'pro-*' -- pro comp list -o table

# Same URL file used for setup
jamf-cli multi --from-file instances.txt -- pro buildings apply --from-file b.json --yes
```

### Key design decisions

- **Process re-invocation** — each profile gets a fresh `os/exec` subprocess with `--profile <name>`. Avoids shared state issues from the global auth resolution chain in PersistentPreRunE.
- **Product-aware filtering** — detects `pro`/`protect` from the inner command and filters profiles by product type. Prevents accidentally running Pro commands against Protect instances.
- **URL-to-profile resolution** — `--from-file` accepts URLs as well as profile names. URLs are normalized and matched against config. Prefers `pro-` prefixed profiles when multiple match the same URL.
- **Continue on failure** — failed instances are logged and reported in summary, execution continues.
- **Optional `--` separator** — not needed for simple interactive use (`multi pro overview`), recommended when inner command has conflicting flags.
- **Interactive selection** — supports numbers (`1 3 5`), ranges (`1-5`), commas (`1,3,5`), glob patterns (`pro-*`), profile names, and `all`.

### Files

- `internal/commands/multi.go` — new command (479 lines)
- `internal/commands/multi_test.go` — 36 tests
- `internal/commands/root.go` — wire multi, add to skipCommands
- `internal/commands/groups.go` — add to root core group
- `README.md` — document multi command

## Test plan

- [x] All 36 tests pass (`make test`)
- [x] Lint clean (`make lint`)
- [x] Live tested `--filter 'pro-*'` against nmartin + msptestacs
- [x] Live tested `--from-file instances.txt` (URL resolution to pro- profiles)
- [x] Live tested `--profiles default,pro-nmartin` (continue-on-failure with stale creds)
- [x] Verified product filtering excludes protect profiles for pro commands
- [x] Verified progress counter `[N/M]` in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)