### PR TITLE
feat: add report profile-status and app-status commands

### DIFF
--- a/internal/commands/pro_report.go
+++ b/internal/commands/pro_report.go
@@ -21,7 +21,9 @@ Available subcommands:
   device-compliance  Devices with stale check-ins, failed commands, or missing profiles
   inventory-summary  Hardware model and OS version breakdown
   software-installs  Installed software version distribution
-  ea-results         Extension attribute results across devices`,
+  ea-results         Extension attribute results across devices
+  profile-status     Configuration profile deployment failures
+  app-status         Managed app deployment failures`,
 	}
 
 	cmd.AddCommand(newReportPatchStatusCmd(cliCtx))
@@ -30,6 +32,8 @@ Available subcommands:
 	cmd.AddCommand(newReportSoftwareInstallsCmd(cliCtx))
 	cmd.AddCommand(newReportEAResultsCmd(cliCtx))
 	cmd.AddCommand(newReportSecurityCmd(cliCtx))
+	cmd.AddCommand(newReportProfileStatusCmd(cliCtx))
+	cmd.AddCommand(newReportAppStatusCmd(cliCtx))
 
 	return cmd
 }

--- a/internal/commands/pro_report_mdm.go
+++ b/internal/commands/pro_report_mdm.go
@@ -1,0 +1,696 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/output"
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+)
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type mdmHealthReport struct {
+	Summary        mdmHealthSummary
+	Failures       []mdmFailureSummary
+	DeviceFailures []mdmDeviceSummary
+	DevicePending  []mdmDeviceSummary
+}
+
+type mdmHealthSummary struct {
+	TotalErrors        int
+	UniqueProfiles     int
+	UniqueDevices      int
+	DevicesHighFailure int
+	DevicesHighPending int
+	Days               int
+	CommandType        string
+}
+
+type mdmDeviceSummary struct {
+	ManagementID string
+	DeviceType   string
+	Name         string
+	Serial       string
+	OSVersion    string
+	Username     string
+	Count        int
+}
+
+type mdmFailureSummary struct {
+	Name       string // profile identifier or app name
+	ID         string // profileId
+	DeviceType string // COMPUTER, MOBILE_DEVICE, or MIXED
+	Errors     int
+	Devices    int
+	LastError  string
+	TopError   string // most common error description
+}
+
+// mdmCommandResult is a single MDM command from /v2/mdm/commands.
+type mdmCommandResult struct {
+	UUID              string
+	CommandType       string
+	Status            string
+	DateCompleted     time.Time
+	ProfileID         string
+	ProfileIdentifier string
+	ClientMgmtID      string
+	ClientType        string
+	ErrorDescription  string
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+func newReportProfileStatusCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var days int
+
+	cmd := &cobra.Command{
+		Use:   "profile-status",
+		Short: "Configuration profile deployment health",
+		Long: `Reports on configuration profile deployment failures from MDM command history.
+
+Queries the MDM commands API for failed InstallProfile commands and aggregates
+by profile. This is a single paginated API call — no per-device fetching.
+
+Examples:
+  # Profile failures in the last 30 days
+  jamf-cli pro report profile-status
+
+  # Narrow the window
+  jamf-cli pro report profile-status --days 7`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("output") {
+				outputFmt = "table"
+			}
+			return runMDMHealthReport(cmd.Context(), cliCtx.Client, "INSTALL_PROFILE", "profile", days)
+		},
+	}
+
+	cmd.Flags().IntVar(&days, "days", 30, "look back N days for failures")
+	return cmd
+}
+
+func newReportAppStatusCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var days int
+
+	cmd := &cobra.Command{
+		Use:   "app-status",
+		Short: "Managed app deployment health",
+		Long: `Reports on managed app deployment failures from MDM command history.
+
+Queries the MDM commands API for failed InstallApplication and
+InstallEnterpriseApplication commands and aggregates by app.
+
+Examples:
+  # App failures in the last 30 days
+  jamf-cli pro report app-status
+
+  # Narrow the window
+  jamf-cli pro report app-status --days 7`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("output") {
+				outputFmt = "table"
+			}
+			return runMDMHealthReport(cmd.Context(), cliCtx.Client, "INSTALL_APPLICATION,INSTALL_ENTERPRISE_APPLICATION", "app", days)
+		},
+	}
+
+	cmd.Flags().IntVar(&days, "days", 30, "look back N days for failures")
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// Core logic — shared between profile-status and app-status
+// ---------------------------------------------------------------------------
+
+func runMDMHealthReport(ctx context.Context, client registry.HTTPClient, commandTypes, label string, days int) error {
+	cutoff := time.Now().AddDate(0, 0, -days)
+	cutoffStr := cutoff.UTC().Format("2006-01-02T15:04:05.000Z")
+
+	fmt.Fprintf(os.Stderr, "Fetching failed %s commands (last %d days)...\n", label, days)
+
+	// Query each command type separately — RSQL OR syntax is unreliable
+	// across Jamf Pro versions.
+	var results []map[string]any
+	for _, ct := range splitCommaSeparated(commandTypes) {
+		filter := fmt.Sprintf("command==%s;status==Error;dateCompleted=ge=%s", ct, cutoffStr)
+		path := "/v2/mdm/commands?filter=" + url.QueryEscape(filter) + "&sort=dateCompleted%3Adesc"
+		batch, err := FetchAllPaginated(ctx, client, path, 200)
+		if err != nil {
+			return fmt.Errorf("fetching %s commands: %w", ct, err)
+		}
+		results = append(results, batch...)
+	}
+
+	// Parse results
+	parsed := make([]mdmCommandResult, 0, len(results))
+	for _, m := range results {
+		parsed = append(parsed, parseMDMCommand(m))
+	}
+
+	// Build name lookup from Classic API
+	var nameLookup map[string]string
+	if len(parsed) > 0 {
+		switch label {
+		case "profile":
+			nameLookup = fetchProfileNameLookup(ctx, client)
+		case "app":
+			nameLookup = fetchAppNameLookup(ctx, client)
+		}
+	}
+
+	// Aggregate failures by profile/app
+	report := aggregateMDMFailures(parsed, nameLookup, label, days)
+
+	// Per-device failure aggregation (devices with >5 errors)
+	rawDeviceFailures := aggregateByDevice(parsed, 5, nil)
+
+	// Fetch pending commands for the same command types (within date window)
+	fmt.Fprintf(os.Stderr, "Fetching pending %s commands...\n", label)
+	var pendingResults []map[string]any
+	for _, ct := range splitCommaSeparated(commandTypes) {
+		filter := fmt.Sprintf("command==%s;status==Pending;dateSent=ge=%s", ct, cutoffStr)
+		path := "/v2/mdm/commands?filter=" + url.QueryEscape(filter)
+		batch, err := FetchAllPaginated(ctx, client, path, 200)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: failed to fetch pending commands: %v\n", err)
+			break
+		}
+		pendingResults = append(pendingResults, batch...)
+	}
+
+	var pendingParsed []mdmCommandResult
+	for _, m := range pendingResults {
+		pendingParsed = append(pendingParsed, parseMDMCommand(m))
+	}
+	rawDevicePending := aggregateByDevice(pendingParsed, 10, nil)
+
+	// Only fetch device inventory if we have flagged devices to enrich
+	if len(rawDeviceFailures) > 0 || len(rawDevicePending) > 0 {
+		deviceLookup := fetchDeviceLookup(ctx, client)
+		report.DeviceFailures = enrichDeviceSummaries(rawDeviceFailures, deviceLookup)
+		report.DevicePending = enrichDeviceSummaries(rawDevicePending, deviceLookup)
+	}
+	report.Summary.DevicesHighFailure = len(report.DeviceFailures)
+	report.Summary.DevicesHighPending = len(report.DevicePending)
+
+	return printMDMHealthReport(report, label)
+}
+
+func parseMDMCommand(m map[string]any) mdmCommandResult {
+	var dateCompleted time.Time
+	if ds := strVal(m, "dateCompleted"); ds != "" {
+		dateCompleted, _ = time.Parse(time.RFC3339, ds)
+		if dateCompleted.IsZero() {
+			dateCompleted, _ = time.Parse("2006-01-02T15:04:05.999Z", ds)
+		}
+	}
+
+	profileID := extractField(m, "profileId")
+
+	// Profile identifier may be at top level or nested
+	profileIdentifier := strVal(m, "profileIdentifier")
+
+	// Client info
+	clientMgmtID := ""
+	clientType := ""
+	if client, ok := m["client"].(map[string]any); ok {
+		clientMgmtID = strVal(client, "managementId")
+		clientType = strVal(client, "clientType")
+	}
+
+	// Error description
+	errorDesc := ""
+	if cmdErr, ok := m["commandError"].(map[string]any); ok {
+		errorDesc = strVal(cmdErr, "errorLocalizedDescription")
+		if errorDesc == "" {
+			errorDesc = strVal(cmdErr, "errorEnglishDescription")
+		}
+		if errorDesc == "" {
+			errorDesc = strVal(cmdErr, "errorDomain")
+		}
+	}
+
+	return mdmCommandResult{
+		UUID:              strVal(m, "uuid"),
+		CommandType:       strVal(m, "commandType"),
+		Status:            strVal(m, "commandState"),
+		DateCompleted:     dateCompleted,
+		ProfileID:         profileID,
+		ProfileIdentifier: profileIdentifier,
+		ClientMgmtID:      clientMgmtID,
+		ClientType:        clientType,
+		ErrorDescription:  errorDesc,
+	}
+}
+
+// fetchProfileNameLookup fetches macOS and mobile config profile lists and
+// builds an id->name lookup. Returns empty map on error (non-fatal).
+func fetchProfileNameLookup(ctx context.Context, client registry.HTTPClient) map[string]string {
+	lookup := make(map[string]string)
+
+	// macOS config profiles
+	macProfiles, err := FetchClassicList(ctx, client, "/JSSResource/osxconfigurationprofiles", "os_x_configuration_profiles")
+	if err == nil {
+		for _, r := range macProfiles {
+			if m, ok := r.(map[string]any); ok {
+				lookup[extractID(m)] = extractField(m, "name")
+			}
+		}
+	}
+
+	// Mobile device config profiles
+	mobileProfiles, err := FetchClassicList(ctx, client, "/JSSResource/mobiledeviceconfigurationprofiles", "configuration_profiles")
+	if err == nil {
+		for _, r := range mobileProfiles {
+			if m, ok := r.(map[string]any); ok {
+				lookup[extractID(m)] = extractField(m, "name")
+			}
+		}
+	}
+
+	return lookup
+}
+
+// fetchAppNameLookup fetches mobile device apps and Mac apps from the Classic
+// API and builds an id->name lookup. Returns empty map on error (non-fatal).
+func fetchAppNameLookup(ctx context.Context, client registry.HTTPClient) map[string]string {
+	lookup := make(map[string]string)
+
+	// Mobile device apps
+	mobileApps, err := FetchClassicList(ctx, client, "/JSSResource/mobiledeviceapplications", "mobile_device_applications")
+	if err == nil {
+		for _, r := range mobileApps {
+			if m, ok := r.(map[string]any); ok {
+				lookup[extractID(m)] = extractField(m, "name")
+			}
+		}
+	}
+
+	// Mac App Store apps
+	macApps, err := FetchClassicList(ctx, client, "/JSSResource/macapplications", "mac_applications")
+	if err == nil {
+		for _, r := range macApps {
+			if m, ok := r.(map[string]any); ok {
+				lookup[extractID(m)] = extractField(m, "name")
+			}
+		}
+	}
+
+	return lookup
+}
+
+// mdmDeviceMeta holds inventory data for a device, keyed by managementId.
+type mdmDeviceMeta struct {
+	name, serial, osVersion, username string
+}
+
+// fetchDeviceLookup fetches computer and mobile device inventory lists and
+// builds a managementId -> device meta lookup.
+func fetchDeviceLookup(ctx context.Context, client registry.HTTPClient) map[string]mdmDeviceMeta {
+	lookup := make(map[string]mdmDeviceMeta)
+
+	// Computers
+	computers, err := FetchAllPaginated(ctx, client, "/v3/computers-inventory?section=GENERAL&section=HARDWARE&section=OPERATING_SYSTEM&section=USER_AND_LOCATION", 2000)
+	if err == nil {
+		for _, c := range computers {
+			mgmtID := strVal(c, "managementId")
+			if mgmtID == "" {
+				// Sectioned format: managementId might be top-level
+				general, _ := c["general"].(map[string]any)
+				mgmtID = strVal(general, "managementId")
+			}
+			if mgmtID == "" {
+				continue
+			}
+			general, _ := c["general"].(map[string]any)
+			hardware, _ := c["hardware"].(map[string]any)
+			osInfo, _ := c["operatingSystem"].(map[string]any)
+			userLoc, _ := c["userAndLocation"].(map[string]any)
+			lookup[mgmtID] = mdmDeviceMeta{
+				name:      strVal(general, "name"),
+				serial:    strVal(hardware, "serialNumber"),
+				osVersion: strVal(osInfo, "version"),
+				username:  strVal(userLoc, "username"),
+			}
+		}
+	}
+
+	// Mobile devices: flat list for serial/name, detail for OS version
+	// Build serial lookup from flat list first
+	mobileSerials := make(map[string]string) // managementId -> serial
+	mobileFlat, err := FetchAllPaginated(ctx, client, "/v2/mobile-devices", 2000)
+	if err == nil {
+		for _, m := range mobileFlat {
+			mgmtID := strVal(m, "managementId")
+			if mgmtID != "" {
+				mobileSerials[mgmtID] = strVal(m, "serialNumber")
+			}
+		}
+	}
+
+	// Detail endpoint for OS version and display name
+	mobiles, err := FetchAllPaginated(ctx, client, "/v2/mobile-devices/detail?section=GENERAL", 2000)
+	if err == nil {
+		for _, m := range mobiles {
+			general, _ := m["general"].(map[string]any)
+			mgmtID := strVal(general, "managementId")
+			if mgmtID == "" {
+				continue
+			}
+			lookup[mgmtID] = mdmDeviceMeta{
+				name:      strVal(general, "displayName"),
+				serial:    mobileSerials[mgmtID],
+				osVersion: strVal(general, "osVersion"),
+			}
+		}
+	}
+
+	return lookup
+}
+
+// aggregateByDevice groups commands by device management ID and returns
+// devices with count >= threshold, sorted by count descending.
+func aggregateByDevice(results []mdmCommandResult, threshold int, _ map[string]mdmDeviceMeta) []mdmDeviceSummary {
+	type acc struct {
+		count      int
+		deviceType string
+	}
+	byDevice := make(map[string]*acc)
+	for _, r := range results {
+		if r.ClientMgmtID == "" {
+			continue
+		}
+		a, ok := byDevice[r.ClientMgmtID]
+		if !ok {
+			a = &acc{}
+			byDevice[r.ClientMgmtID] = a
+		}
+		a.count++
+		if r.ClientType != "" {
+			a.deviceType = r.ClientType
+		}
+	}
+
+	var summaries []mdmDeviceSummary
+	for mgmtID, a := range byDevice {
+		if a.count < threshold {
+			continue
+		}
+		dt := "Unknown"
+		switch a.deviceType {
+		case "COMPUTER":
+			dt = "Computer"
+		case "MOBILE_DEVICE":
+			dt = "Mobile"
+		}
+		summaries = append(summaries, mdmDeviceSummary{
+			ManagementID: mgmtID,
+			DeviceType:   dt,
+			Count:        a.count,
+		})
+	}
+
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].Count > summaries[j].Count
+	})
+
+	return summaries
+}
+
+// enrichDeviceSummaries populates device details from the inventory lookup.
+func enrichDeviceSummaries(summaries []mdmDeviceSummary, lookup map[string]mdmDeviceMeta) []mdmDeviceSummary {
+	for i, s := range summaries {
+		meta := lookup[s.ManagementID]
+		summaries[i].Name = meta.name
+		summaries[i].Serial = meta.serial
+		summaries[i].OSVersion = meta.osVersion
+		summaries[i].Username = meta.username
+	}
+	return summaries
+}
+
+func aggregateMDMFailures(results []mdmCommandResult, nameLookup map[string]string, label string, days int) *mdmHealthReport {
+	type accumulator struct {
+		errors      int
+		devices     map[string]bool
+		clientTypes map[string]bool // track COMPUTER vs MOBILE_DEVICE
+		lastError   time.Time
+		errorCounts map[string]int // error description -> count
+	}
+
+	// Group by profile identifier (or profileId as fallback)
+	byName := make(map[string]*accumulator)
+	nameToID := make(map[string]string)
+
+	for _, r := range results {
+		key := r.ProfileIdentifier
+		if key == "" {
+			key = r.ProfileID
+		}
+		if key == "" {
+			key = r.CommandType // fallback for apps
+		}
+
+		acc, ok := byName[key]
+		if !ok {
+			acc = &accumulator{
+				devices:     make(map[string]bool),
+				clientTypes: make(map[string]bool),
+				errorCounts: make(map[string]int),
+			}
+			byName[key] = acc
+		}
+		if r.ProfileID != "" {
+			nameToID[key] = r.ProfileID
+		}
+
+		acc.errors++
+		if r.ClientMgmtID != "" {
+			acc.devices[r.ClientMgmtID] = true
+		}
+		if r.ClientType != "" {
+			acc.clientTypes[r.ClientType] = true
+		}
+		if r.DateCompleted.After(acc.lastError) {
+			acc.lastError = r.DateCompleted
+		}
+		if r.ErrorDescription != "" {
+			acc.errorCounts[r.ErrorDescription]++
+		}
+	}
+
+	var failures []mdmFailureSummary
+	uniqueDevices := make(map[string]bool)
+
+	for name, acc := range byName {
+		lastErr := ""
+		if !acc.lastError.IsZero() {
+			lastErr = acc.lastError.Format("2006-01-02")
+		}
+
+		// Find most common error
+		topError := ""
+		topCount := 0
+		for desc, count := range acc.errorCounts {
+			if count > topCount {
+				topError = desc
+				topCount = count
+			}
+		}
+
+		displayName := name
+		profileID := nameToID[name]
+		if profileID == "" {
+			profileID = name
+		}
+		if nameLookup != nil {
+			if resolved, ok := nameLookup[profileID]; ok && resolved != "" {
+				displayName = resolved
+			}
+		}
+
+		// Resolve device type: if only one type, use it; if mixed, say "Mixed"
+		deviceType := "Unknown"
+		switch len(acc.clientTypes) {
+		case 1:
+			for ct := range acc.clientTypes {
+				switch ct {
+				case "COMPUTER":
+					deviceType = "Computer"
+				case "MOBILE_DEVICE":
+					deviceType = "Mobile"
+				default:
+					deviceType = ct
+				}
+			}
+		case 0:
+			// no client type info
+		default:
+			deviceType = "Mixed"
+		}
+
+		failures = append(failures, mdmFailureSummary{
+			Name:       displayName,
+			ID:         profileID,
+			DeviceType: deviceType,
+			Errors:     acc.errors,
+			Devices:    len(acc.devices),
+			LastError:  lastErr,
+			TopError:   topError,
+		})
+
+		for d := range acc.devices {
+			uniqueDevices[d] = true
+		}
+	}
+
+	sort.Slice(failures, func(i, j int) bool {
+		if failures[i].DeviceType != failures[j].DeviceType {
+			return failures[i].DeviceType < failures[j].DeviceType
+		}
+		return failures[i].Errors > failures[j].Errors
+	})
+
+	return &mdmHealthReport{
+		Summary: mdmHealthSummary{
+			TotalErrors:    len(results),
+			UniqueProfiles: len(failures),
+			UniqueDevices:  len(uniqueDevices),
+			Days:           days,
+			CommandType:    label,
+		},
+		Failures: failures,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+func printMDMHealthReport(report *mdmHealthReport, label string) error {
+	formatter := output.New(outputFmt, noColor, wide)
+
+	if outputFmt == "json" || outputFmt == "yaml" {
+		combined := map[string]any{
+			"summary":         mdmSummaryToMap(report.Summary),
+			"failures":        mdmFailuresToRows(report.Failures),
+			"device_failures": mdmDevicesToRows(report.DeviceFailures),
+			"device_pending":  mdmDevicesToRows(report.DevicePending),
+		}
+		return formatter.Print([]map[string]any{combined})
+	}
+
+	// Table: summary
+	fmt.Printf("── %s Deployment Health Summary ──\n", capitalise(label))
+	if err := formatter.Print([]map[string]any{mdmSummaryToMap(report.Summary)}); err != nil {
+		return err
+	}
+
+	// Table: failures by profile/app
+	if len(report.Failures) > 0 {
+		fmt.Printf("\n── Failed %ss (last %d days) ──\n", capitalise(label), report.Summary.Days)
+		if err := formatter.Print(mdmFailuresToRows(report.Failures)); err != nil {
+			return err
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "\nNo %s failures found in the last %d days.\n", label, report.Summary.Days)
+	}
+
+	// Table: devices with high failure count
+	if len(report.DeviceFailures) > 0 {
+		fmt.Printf("\n── Devices With High Failure Count (>5 errors) ──\n")
+		if err := formatter.Print(mdmDevicesToRows(report.DeviceFailures)); err != nil {
+			return err
+		}
+	}
+
+	// Table: devices with high pending count
+	if len(report.DevicePending) > 0 {
+		fmt.Printf("\n── Devices With Command Backlog (>10 pending) ──\n")
+		if err := formatter.Print(mdmDevicesToRows(report.DevicePending)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mdmSummaryToMap(s mdmHealthSummary) map[string]any {
+	m := map[string]any{
+		"total_errors":                  s.TotalErrors,
+		"unique_" + s.CommandType + "s": s.UniqueProfiles,
+		"unique_devices":                s.UniqueDevices,
+		"days":                          s.Days,
+	}
+	if s.DevicesHighFailure > 0 {
+		m["devices_high_failure"] = s.DevicesHighFailure
+	}
+	if s.DevicesHighPending > 0 {
+		m["devices_high_pending"] = s.DevicesHighPending
+	}
+	return m
+}
+
+func mdmFailuresToRows(failures []mdmFailureSummary) []map[string]any {
+	rows := make([]map[string]any, len(failures))
+	for i, f := range failures {
+		rows[i] = map[string]any{
+			"device_type": f.DeviceType,
+			"name":        f.Name,
+			"id":          f.ID,
+			"errors":      f.Errors,
+			"devices":     f.Devices,
+			"last_error":  f.LastError,
+			"top_error":   f.TopError,
+		}
+	}
+	return rows
+}
+
+func mdmDevicesToRows(devices []mdmDeviceSummary) []map[string]any {
+	rows := make([]map[string]any, len(devices))
+	for i, d := range devices {
+		rows[i] = map[string]any{
+			"name":        d.Name,
+			"serial":      d.Serial,
+			"device_type": d.DeviceType,
+			"os_version":  d.OSVersion,
+			"username":    d.Username,
+			"count":       d.Count,
+		}
+	}
+	return rows
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func splitCommaSeparated(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, ",")
+}
+
+func capitalise(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}

--- a/internal/commands/pro_report_mdm_test.go
+++ b/internal/commands/pro_report_mdm_test.go
@@ -1,0 +1,304 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// parseMDMCommand
+// ---------------------------------------------------------------------------
+
+func TestParseMDMCommand_FullFields(t *testing.T) {
+	m := map[string]any{
+		"uuid":          "abc-123",
+		"commandType":   "INSTALL_PROFILE",
+		"commandState":  "ERROR",
+		"dateCompleted": "2026-04-01T08:00:00.000Z",
+		"dateSent":      "2026-03-31T12:00:00.000Z",
+		"profileId":     float64(42),
+		"client": map[string]any{
+			"managementId": "mgmt-id-1",
+			"clientType":   "COMPUTER",
+		},
+		"commandError": map[string]any{
+			"errorCode":                 float64(10),
+			"errorDomain":               "SPErrorDomain",
+			"errorLocalizedDescription": "Something went wrong",
+		},
+	}
+
+	result := parseMDMCommand(m)
+	if result.CommandType != "INSTALL_PROFILE" {
+		t.Errorf("commandType = %q, want INSTALL_PROFILE", result.CommandType)
+	}
+	if result.ProfileID != "42" {
+		t.Errorf("profileId = %q, want 42", result.ProfileID)
+	}
+	if result.ClientMgmtID != "mgmt-id-1" {
+		t.Errorf("clientMgmtID = %q, want mgmt-id-1", result.ClientMgmtID)
+	}
+	if result.ErrorDescription != "Something went wrong" {
+		t.Errorf("errorDescription = %q", result.ErrorDescription)
+	}
+	if result.DateCompleted.IsZero() {
+		t.Error("dateCompleted should not be zero")
+	}
+}
+
+func TestParseMDMCommand_MinimalFields(t *testing.T) {
+	m := map[string]any{
+		"commandType":  "INSTALL_PROFILE",
+		"commandState": "ERROR",
+	}
+
+	result := parseMDMCommand(m)
+	if result.CommandType != "INSTALL_PROFILE" {
+		t.Errorf("commandType = %q", result.CommandType)
+	}
+	if result.ProfileID != "" {
+		t.Errorf("profileId = %q, want empty", result.ProfileID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// aggregateMDMFailures
+// ---------------------------------------------------------------------------
+
+func TestAggregateMDMFailures_GroupsByProfile(t *testing.T) {
+	results := []mdmCommandResult{
+		{ProfileID: "10", ClientMgmtID: "dev-1", DateCompleted: time.Now(), ErrorDescription: "error A"},
+		{ProfileID: "10", ClientMgmtID: "dev-2", DateCompleted: time.Now(), ErrorDescription: "error A"},
+		{ProfileID: "10", ClientMgmtID: "dev-1", DateCompleted: time.Now(), ErrorDescription: "error B"},
+		{ProfileID: "20", ClientMgmtID: "dev-3", DateCompleted: time.Now(), ErrorDescription: "error C"},
+	}
+
+	lookup := map[string]string{"10": "WiFi Profile", "20": "VPN Profile"}
+	report := aggregateMDMFailures(results, lookup, "profile", 30)
+
+	if report.Summary.TotalErrors != 4 {
+		t.Errorf("total_errors = %d, want 4", report.Summary.TotalErrors)
+	}
+	if report.Summary.UniqueProfiles != 2 {
+		t.Errorf("unique_profiles = %d, want 2", report.Summary.UniqueProfiles)
+	}
+	if report.Summary.UniqueDevices != 3 {
+		t.Errorf("unique_devices = %d, want 3", report.Summary.UniqueDevices)
+	}
+	if len(report.Failures) != 2 {
+		t.Fatalf("got %d failures, want 2", len(report.Failures))
+	}
+
+	// Sorted by error count descending
+	if report.Failures[0].Errors != 3 {
+		t.Errorf("first failure errors = %d, want 3", report.Failures[0].Errors)
+	}
+	if report.Failures[0].Name != "WiFi Profile" {
+		t.Errorf("first failure name = %q, want WiFi Profile", report.Failures[0].Name)
+	}
+	if report.Failures[0].Devices != 2 {
+		t.Errorf("first failure devices = %d, want 2", report.Failures[0].Devices)
+	}
+	if report.Failures[0].TopError != "error A" {
+		t.Errorf("top_error = %q, want error A", report.Failures[0].TopError)
+	}
+}
+
+func TestAggregateMDMFailures_Empty(t *testing.T) {
+	report := aggregateMDMFailures(nil, nil, "profile", 30)
+	if report.Summary.TotalErrors != 0 {
+		t.Errorf("total_errors = %d, want 0", report.Summary.TotalErrors)
+	}
+	if len(report.Failures) != 0 {
+		t.Errorf("got %d failures, want 0", len(report.Failures))
+	}
+}
+
+func TestAggregateMDMFailures_NoLookup(t *testing.T) {
+	results := []mdmCommandResult{
+		{ProfileID: "10", ClientMgmtID: "dev-1", DateCompleted: time.Now()},
+	}
+
+	report := aggregateMDMFailures(results, nil, "profile", 30)
+	if len(report.Failures) != 1 {
+		t.Fatalf("got %d failures, want 1", len(report.Failures))
+	}
+	// Without lookup, name falls back to profile ID
+	if report.Failures[0].Name != "10" {
+		t.Errorf("name = %q, want 10 (fallback)", report.Failures[0].Name)
+	}
+}
+
+func TestAggregateMDMFailures_AppCommandFallback(t *testing.T) {
+	results := []mdmCommandResult{
+		{CommandType: "InstallApplication", ClientMgmtID: "dev-1", DateCompleted: time.Now()},
+		{CommandType: "InstallApplication", ClientMgmtID: "dev-2", DateCompleted: time.Now()},
+	}
+
+	report := aggregateMDMFailures(results, nil, "app", 30)
+	if len(report.Failures) != 1 {
+		t.Fatalf("got %d failures, want 1", len(report.Failures))
+	}
+	// Falls back to command type as key
+	if report.Failures[0].Name != "InstallApplication" {
+		t.Errorf("name = %q, want InstallApplication", report.Failures[0].Name)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// fetchProfileNameLookup (integration)
+// ---------------------------------------------------------------------------
+
+func TestFetchProfileNameLookup_Integration(t *testing.T) {
+	client := &overviewMockClient{
+		responses: map[string]overviewMockResponse{
+			"/JSSResource/osxconfigurationprofiles": {200, `{
+				"os_x_configuration_profiles": [
+					{"id": 10, "name": "WiFi"},
+					{"id": 20, "name": "VPN"}
+				]
+			}`},
+			"/JSSResource/mobiledeviceconfigurationprofiles": {200, `{
+				"configuration_profiles": [
+					{"id": 30, "name": "iOS WiFi"}
+				]
+			}`},
+		},
+	}
+
+	lookup := fetchProfileNameLookup(context.Background(), client)
+	if lookup["10"] != "WiFi" {
+		t.Errorf("lookup[10] = %q, want WiFi", lookup["10"])
+	}
+	if lookup["20"] != "VPN" {
+		t.Errorf("lookup[20] = %q, want VPN", lookup["20"])
+	}
+	if lookup["30"] != "iOS WiFi" {
+		t.Errorf("lookup[30] = %q, want iOS WiFi", lookup["30"])
+	}
+}
+
+func TestFetchProfileNameLookup_HandlesErrors(t *testing.T) {
+	client := &overviewMockClient{
+		responses: map[string]overviewMockResponse{
+			"/JSSResource/osxconfigurationprofiles":          {500, `{}`},
+			"/JSSResource/mobiledeviceconfigurationprofiles": {500, `{}`},
+		},
+	}
+
+	lookup := fetchProfileNameLookup(context.Background(), client)
+	if len(lookup) != 0 {
+		t.Errorf("expected empty lookup on error, got %d entries", len(lookup))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// aggregateByDevice
+// ---------------------------------------------------------------------------
+
+func TestAggregateByDevice_ThresholdFilters(t *testing.T) {
+	results := []mdmCommandResult{
+		{ClientMgmtID: "dev-1", ClientType: "COMPUTER"},
+		{ClientMgmtID: "dev-1", ClientType: "COMPUTER"},
+		{ClientMgmtID: "dev-1", ClientType: "COMPUTER"},
+		{ClientMgmtID: "dev-2", ClientType: "MOBILE_DEVICE"},
+	}
+
+	// Threshold 3: only dev-1 qualifies
+	summaries := aggregateByDevice(results, 3, nil)
+	if len(summaries) != 1 {
+		t.Fatalf("got %d summaries, want 1", len(summaries))
+	}
+	if summaries[0].ManagementID != "dev-1" {
+		t.Errorf("managementID = %q, want dev-1", summaries[0].ManagementID)
+	}
+	if summaries[0].DeviceType != "Computer" {
+		t.Errorf("deviceType = %q, want Computer", summaries[0].DeviceType)
+	}
+	if summaries[0].Count != 3 {
+		t.Errorf("count = %d, want 3", summaries[0].Count)
+	}
+}
+
+func TestAggregateByDevice_Empty(t *testing.T) {
+	summaries := aggregateByDevice(nil, 1, nil)
+	if len(summaries) != 0 {
+		t.Errorf("got %d summaries, want 0", len(summaries))
+	}
+}
+
+func TestEnrichDeviceSummaries(t *testing.T) {
+	summaries := []mdmDeviceSummary{
+		{ManagementID: "mgmt-1", DeviceType: "Computer", Count: 10},
+		{ManagementID: "mgmt-2", DeviceType: "Mobile", Count: 5},
+	}
+	lookup := map[string]mdmDeviceMeta{
+		"mgmt-1": {name: "MacBook-A", serial: "C02X", osVersion: "15.3", username: "jsmith"},
+		"mgmt-2": {name: "iPad-B", serial: "DMPQ", osVersion: "17.4"},
+	}
+
+	enriched := enrichDeviceSummaries(summaries, lookup)
+	if enriched[0].Name != "MacBook-A" {
+		t.Errorf("name = %q, want MacBook-A", enriched[0].Name)
+	}
+	if enriched[0].Serial != "C02X" {
+		t.Errorf("serial = %q, want C02X", enriched[0].Serial)
+	}
+	if enriched[1].OSVersion != "17.4" {
+		t.Errorf("osVersion = %q, want 17.4", enriched[1].OSVersion)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// fetchAppNameLookup
+// ---------------------------------------------------------------------------
+
+func TestFetchAppNameLookup_Integration(t *testing.T) {
+	client := &overviewMockClient{
+		responses: map[string]overviewMockResponse{
+			"/JSSResource/mobiledeviceapplications": {200, `{
+				"mobile_device_applications": [
+					{"id": 10, "name": "Slack"},
+					{"id": 20, "name": "Teams"}
+				]
+			}`},
+			"/JSSResource/macapplications": {200, `{
+				"mac_applications": [
+					{"id": 30, "name": "Xcode"}
+				]
+			}`},
+		},
+	}
+
+	lookup := fetchAppNameLookup(context.Background(), client)
+	if lookup["10"] != "Slack" {
+		t.Errorf("lookup[10] = %q, want Slack", lookup["10"])
+	}
+	if lookup["30"] != "Xcode" {
+		t.Errorf("lookup[30] = %q, want Xcode", lookup["30"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+func TestSplitCommaSeparated(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"INSTALL_PROFILE", 1},
+		{"InstallApplication,InstallEnterpriseApplication", 2},
+		{"", 0},
+	}
+	for _, tc := range tests {
+		got := splitCommaSeparated(tc.input)
+		if len(got) != tc.want {
+			t.Errorf("splitCommaSeparated(%q) = %d parts, want %d", tc.input, len(got), tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `jamf-cli pro report profile-status` — config profile deployment failure report
- Adds `jamf-cli pro report app-status` — managed app deployment failure report
- Both query `/v2/mdm/commands` API with RSQL filters — single paginated calls, no per-device fetching
- Profile names resolved from Classic API (macOS + mobile config profiles)
- App names resolved from Classic API (mobile device apps + Mac apps)
- Device type column (Computer/Mobile/Mixed) with sort-by-type-first
- Devices with high failure count (>5 errors) flagged with inventory details
- Devices with command backlog (>10 pending) flagged with inventory details
- Device inventory lookup only fetched when flagged devices exist (lazy)
- Pending commands filtered to `--days` window

## Test plan

- [x] `make test` — all 14 packages pass (13 new MDM tests)
- [x] Live tested on pro-hhg, pro-lse, pro-gdst-put
- [x] Profile names resolve for both macOS and mobile device profiles
- [x] App names resolve for both mobile device apps and Mac apps
- [x] Computer details: name, serial, OS version, username
- [x] Mobile device details: name, serial, OS version
- [x] Device type correctly identified from MDM command client data
- [x] Empty results handled gracefully (no failures found message)
- [x] 403 permission error surfaces clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)