### PR TITLE
feat(site): sticky search bar while browsing commands

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -105,21 +105,23 @@
 
   <!-- ===== Commands Catalog ===== -->
   <section id="commands">
-    <div class="commands-header">
-      <h2>Commands</h2>
-      <div class="tabs">
-        <button class="tab active" data-filter="all">All</button>
-        <button class="tab" data-filter="pro"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf Pro</button>
-        <button class="tab" data-filter="protect"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf Protect</button>
+    <div class="commands-sticky">
+      <div class="commands-header">
+        <h2>Commands</h2>
+        <div class="tabs">
+          <button class="tab active" data-filter="all">All</button>
+          <button class="tab" data-filter="pro"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf Pro</button>
+          <button class="tab" data-filter="protect"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf Protect</button>
+        </div>
       </div>
-    </div>
-    <div class="catalog-controls">
-      <div class="search-wrap">
-        <input id="search" type="text" placeholder="Search commands... (press / to focus)" aria-label="Search commands">
-        <button id="search-clear" class="search-clear" aria-label="Clear search" type="button">&times;</button>
+      <div class="catalog-controls">
+        <div class="search-wrap">
+          <input id="search" type="text" placeholder="Search commands... (press / to focus)" aria-label="Search commands">
+          <button id="search-clear" class="search-clear" aria-label="Clear search" type="button">&times;</button>
+        </div>
+        <button id="toggle-all" class="toggle-all-btn" title="Expand/collapse all groups">Expand All</button>
+        <button class="kbd-hint-btn" id="kbd-hint-btn" title="Keyboard shortcuts (?)" aria-label="Keyboard shortcuts"><kbd>?</kbd></button>
       </div>
-      <button id="toggle-all" class="toggle-all-btn" title="Expand/collapse all groups">Expand All</button>
-      <button class="kbd-hint-btn" id="kbd-hint-btn" title="Keyboard shortcuts (?)" aria-label="Keyboard shortcuts"><kbd>?</kbd></button>
     </div>
     <div id="catalog-loading">Loading commands...</div>
     <div id="catalog"></div>
@@ -280,6 +282,17 @@
     window.addEventListener('scroll', function () {
       document.querySelector('nav').classList.toggle('scrolled', window.scrollY > 40);
     }, { passive: true });
+
+    // Sticky commands bar — add shadow when stuck
+    (function () {
+      var sticky = document.querySelector('.commands-sticky');
+      if (!sticky) return;
+      var observer = new IntersectionObserver(function (entries) {
+        sticky.classList.toggle('stuck', !entries[0].isIntersecting);
+      }, { threshold: 1, rootMargin: '-57px 0px 0px 0px' });
+      var sentinel = document.getElementById('commands');
+      if (sentinel) observer.observe(sentinel);
+    })();
 
     // Theme toggle
     (function () {

--- a/docs/site/style.css
+++ b/docs/site/style.css
@@ -516,13 +516,59 @@ a.stat-card:hover {
   margin: 0 auto;
 }
 
+.commands-sticky {
+  position: sticky;
+  top: 57px;
+  z-index: 10;
+  background: var(--page-bg);
+  padding-bottom: 0.75rem;
+  margin-left: -2rem;
+  margin-right: -2rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  transition: box-shadow 0.2s;
+}
+
+/* Bleed mask — covers gap between sticky bar and content below */
+.commands-sticky::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.5rem;
+  height: 0.5rem;
+  background: var(--page-bg);
+  pointer-events: none;
+}
+
+/* Bottom border — appears when stuck */
+.commands-sticky::after {
+  content: '';
+  position: absolute;
+  left: 2rem;
+  right: 2rem;
+  bottom: 0;
+  height: 1px;
+  background: var(--border);
+  opacity: 0;
+  transition: opacity 0.25s;
+}
+
+.commands-sticky.stuck {
+  box-shadow: 0 6px 16px -4px rgba(0, 0, 0, 0.06);
+}
+
+.commands-sticky.stuck::after {
+  opacity: 1;
+}
+
 .commands-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 1rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 0.75rem;
 }
 
 .commands-header h2 {
@@ -568,7 +614,6 @@ a.stat-card:hover {
   display: flex;
   gap: 0.75rem;
   align-items: center;
-  margin-bottom: 1.5rem;
 }
 
 .search-wrap {
@@ -662,22 +707,22 @@ a.stat-card:hover {
   display: flex;
   align-items: center;
   gap: 1rem;
-  margin: 2rem 0 0.75rem;
+  margin: 1.25rem 0 0.75rem;
   padding: 0.75rem 0.25rem;
   position: sticky;
-  top: 57px;
+  top: 158px;
   z-index: 7;
   background: var(--page-bg);
 }
 
 .product-divider:first-child {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .product-divider-label {
-  font-size: 0.75rem;
+  font-size: 0.9rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   white-space: nowrap;
 }
@@ -751,7 +796,7 @@ a.stat-card:hover {
   border-left: 3px solid var(--brand-blue);
   border-radius: 4px;
   position: sticky;
-  top: 100px;
+  top: 196px;
   z-index: 5;
 }
 
@@ -1670,6 +1715,14 @@ footer .footer-meta {
     padding: 2rem 1rem;
   }
 
+  .commands-sticky {
+    top: 50px;
+    margin-left: -1rem;
+    margin-right: -1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
   .commands-header {
     flex-direction: column;
     align-items: flex-start;
@@ -1697,11 +1750,11 @@ footer .footer-meta {
   }
 
   .product-divider {
-    top: 50px;
+    top: 248px;
   }
 
   .catalog-group-header {
-    top: 88px;
+    top: 286px;
     font-size: 0.7rem;
     padding: 0.6rem 0.75rem;
   }
@@ -1847,6 +1900,9 @@ footer .footer-meta {
 }
 :root[data-theme="dark"] .group-count-badge {
   background: rgba(255, 255, 255, 0.1);
+}
+:root[data-theme="dark"] .commands-sticky.stuck {
+  box-shadow: 0 6px 20px -4px rgba(0, 0, 0, 0.35);
 }
 
 /* Manual Light Mode — reset dark media query overrides */


### PR DESCRIPTION
## Summary
- Search bar, product tabs, and controls now stay pinned below the nav while scrolling through the command catalog
- Subtle border + shadow appears when the bar is stuck (IntersectionObserver, no scroll listener)
- Bleed mask prevents content showing through the gap between sticky bar and catalog
- Larger product divider labels (0.75rem → 0.9rem) for better visual hierarchy
- Dark mode gets a stronger shadow for depth on dark backgrounds
- Mobile responsive with recalculated sticky offsets

## Test plan
- [x] Desktop: light + dark mode, sticky bar pins and detaches correctly
- [x] Mobile (390px): layout stacks cleanly, sticky works
- [x] Shadow/border fades in on scroll, fades out when scrolling back up
- [x] No content bleed-through between sticky bar and product dividers
- [x] Verify on Safari (sticky + z-index stacking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)