### PR TITLE
chore: add @grahampugh as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default code owners for the entire repository
-* @ktn-jamf @neilmartin83
+* @ktn-jamf @neilmartin83 @grahampugh


### PR DESCRIPTION
## Summary

- Adds @grahampugh as a code owner alongside @ktn-jamf and @neilmartin83

🤖 Generated with [Claude Code](https://claude.com/claude-code)