### PR TITLE
feat(device-actions): add mobile and computer MDM commands via modern API

### DIFF
--- a/internal/commands/pro.go
+++ b/internal/commands/pro.go
@@ -58,10 +58,13 @@ func newProCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	addSubcommand(cmd, []string{"mobile-devices"}, newMobileEraseCmd(cliCtx))
 	addSubcommand(cmd, []string{"mobile-devices"}, newMobileUnmanageCmd(cliCtx))
 
-	// Classic API computer MDM commands (no modern API equivalent)
+	// Modern API computer MDM commands
 	addSubcommand(cmd, []string{"computers"}, newComputerLockCmd(cliCtx))
 	addSubcommand(cmd, []string{"computers"}, newComputerEnableRemoteDesktopCmd(cliCtx))
 	addSubcommand(cmd, []string{"computers"}, newComputerDisableRemoteDesktopCmd(cliCtx))
+	addSubcommand(cmd, []string{"computers"}, newComputerRestartCmd(cliCtx))
+	addSubcommand(cmd, []string{"computers"}, newComputerShutdownCmd(cliCtx))
+	addSubcommand(cmd, []string{"computers"}, newComputerSetRecoveryLockCmd(cliCtx))
 
 	// Mobile device MDM commands (modern API where available, Classic where not)
 	addSubcommand(cmd, []string{"mobile-devices"}, newMobileRestartCmd(cliCtx))         // modern: RESTART_DEVICE

--- a/internal/commands/pro_bulk.go
+++ b/internal/commands/pro_bulk.go
@@ -287,6 +287,7 @@ func resolveComputerTargets(ctx context.Context, client registry.HTTPClient, fro
 }
 
 // sendMDMCommand posts a Classic API MDM command to a single computer.
+// Used by the bulk send-command operation; individual action commands use sendComputerModernMDMCommand.
 func sendMDMCommand(ctx context.Context, client registry.HTTPClient, computerID, command string) error {
 	path := fmt.Sprintf("/JSSResource/computercommands/command/%s/id/%s", command, computerID)
 	resp, err := client.Do(ctx, "POST", path, nil)

--- a/internal/commands/pro_device_actions.go
+++ b/internal/commands/pro_device_actions.go
@@ -427,7 +427,7 @@ func runDeviceAction(cmd *cobra.Command, cliCtx *registry.CLIContext, dt *device
 	if err != nil {
 		return err
 	}
-	return executeAction(cmd, cliCtx, dt, devices, yes, confirmDestructive, cfg)
+	return executeAction(cmd, dt, devices, yes, confirmDestructive, cfg)
 }
 
 func runMobileAction(cmd *cobra.Command, cliCtx *registry.CLIContext, dt *deviceTarget, yes, confirmDestructive bool, cfg deviceActionConfig) error {
@@ -438,10 +438,10 @@ func runMobileAction(cmd *cobra.Command, cliCtx *registry.CLIContext, dt *device
 	if err != nil {
 		return err
 	}
-	return executeAction(cmd, cliCtx, dt, devices, yes, confirmDestructive, cfg)
+	return executeAction(cmd, dt, devices, yes, confirmDestructive, cfg)
 }
 
-func executeAction(cmd *cobra.Command, cliCtx *registry.CLIContext, dt *deviceTarget, devices []*resolve.DeviceIdentifiers, yes, confirmDestructive bool, cfg deviceActionConfig) error {
+func executeAction(cmd *cobra.Command, dt *deviceTarget, devices []*resolve.DeviceIdentifiers, yes, confirmDestructive bool, cfg deviceActionConfig) error {
 	stderr := cmd.ErrOrStderr()
 
 	// Reject --body-file with bulk targeting (body can't be reused per device
@@ -561,17 +561,35 @@ func readActionBody(bodyFile string) (io.Reader, error) {
 	return nil, nil
 }
 
-// --- Classic API MDM commands (no modern API equivalent) ---
+// --- Modern API computer MDM commands ---
 
-// newClassicMDMCmd creates a computer subcommand that sends a Classic API MDM
-// command. This is the shared factory for lock, restart, shutdown, etc.
-func newClassicMDMCmd(cliCtx *registry.CLIContext, name, apiCommand, short, long, example string, destructive bool) *cobra.Command {
+// sendComputerModernMDMCommand sends a single MDM command to a computer via
+// POST /v2/mdm/commands using the management ID (UUID).
+func sendComputerModernMDMCommand(cmd *cobra.Command, cliCtx *registry.CLIContext, d *resolve.DeviceIdentifiers, commandData map[string]any) error {
+	if d.ManagementID == "" {
+		return fmt.Errorf("computer %s has no managementId — cannot send MDM command", resolve.FormatDeviceDesc(d))
+	}
+	body := map[string]any{
+		"clientData": []map[string]any{
+			{"managementId": d.ManagementID},
+		},
+		"commandData": commandData,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	return doPostAction(cmd, cliCtx, "/v2/mdm/commands", strings.NewReader(string(data)))
+}
+
+// newModernComputerMDMCmd creates a computer subcommand that sends a
+// modern API MDM command via POST /v2/mdm/commands with no additional body fields.
+func newModernComputerMDMCmd(cliCtx *registry.CLIContext, name, commandType, short, long, example string, destructive bool) *cobra.Command {
 	var (
 		dt                 deviceTarget
 		yes                bool
 		confirmDestructive bool
 	)
-
 	cmd := &cobra.Command{
 		Use:     name,
 		Short:   short,
@@ -583,12 +601,13 @@ func newClassicMDMCmd(cliCtx *registry.CLIContext, name, apiCommand, short, long
 				deviceType:  "computer",
 				destructive: destructive,
 				execSingle: func(d *resolve.DeviceIdentifiers, _ io.Reader) error {
-					return sendMDMCommand(cmd.Context(), cliCtx.Client, d.ID, apiCommand)
+					return sendComputerModernMDMCommand(cmd, cliCtx, d, map[string]any{
+						"commandType": commandType,
+					})
 				},
 			})
 		},
 	}
-
 	dt.addFlags(cmd)
 	cmd.Flags().BoolVar(&yes, "yes", false, "skip confirmation prompt")
 	if destructive {
@@ -598,31 +617,120 @@ func newClassicMDMCmd(cliCtx *registry.CLIContext, name, apiCommand, short, long
 }
 
 func newComputerLockCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newClassicMDMCmd(cliCtx, "lock", "DeviceLock",
+	return newModernComputerMDMCmd(cliCtx, "lock", "DEVICE_LOCK",
 		"Lock a computer",
 		"Lock a computer by serial number, name, or ID. This is a destructive operation.",
-		`  jamf-cli pro comp lock --serial C02X1234 --yes --confirm-destructive
+		`  jamf-cli pro comp lock --serial C02X1234 --yes
   jamf-cli pro comp lock --group "Lost Devices" --yes --confirm-destructive`,
 		true,
 	)
 }
 
 func newComputerEnableRemoteDesktopCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newClassicMDMCmd(cliCtx, "enable-remote-desktop", "EnableRemoteDesktop",
+	return newModernComputerMDMCmd(cliCtx, "enable-remote-desktop", "ENABLE_REMOTE_DESKTOP",
 		"Enable Remote Desktop on a computer",
-		"Enable the Remote Desktop agent on a computer.",
-		`  jamf-cli pro comp enable-remote-desktop --serial C02X1234 --yes`,
+		"Enable the Remote Desktop agent on a computer by serial number, name, or ID.",
+		`  jamf-cli pro comp enable-remote-desktop --serial C02X1234
+  jamf-cli pro comp enable-remote-desktop --group "Lab Macs" --yes`,
 		false,
 	)
 }
 
 func newComputerDisableRemoteDesktopCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newClassicMDMCmd(cliCtx, "disable-remote-desktop", "DisableRemoteDesktop",
+	return newModernComputerMDMCmd(cliCtx, "disable-remote-desktop", "DISABLE_REMOTE_DESKTOP",
 		"Disable Remote Desktop on a computer",
-		"Disable the Remote Desktop agent on a computer.",
-		`  jamf-cli pro comp disable-remote-desktop --serial C02X1234 --yes`,
+		"Disable the Remote Desktop agent on a computer by serial number, name, or ID.",
+		`  jamf-cli pro comp disable-remote-desktop --serial C02X1234
+  jamf-cli pro comp disable-remote-desktop --group "Lab Macs" --yes`,
 		false,
 	)
+}
+
+func newComputerRestartCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var (
+		dt                 deviceTarget
+		yes                bool
+		rebuildKernelCache bool
+	)
+	cmd := &cobra.Command{
+		Use:   "restart",
+		Short: "Restart a computer",
+		Long:  "Restart a supervised computer by serial number, name, or ID.",
+		Example: `  jamf-cli pro comp restart --serial C02X1234
+  jamf-cli pro comp restart --serial C02X1234 --rebuild-kernel-cache
+  jamf-cli pro comp restart --group "Lab Macs" --yes`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDeviceAction(cmd, cliCtx, &dt, yes, false, deviceActionConfig{
+				actionName: "restart",
+				deviceType: "computer",
+				execSingle: func(d *resolve.DeviceIdentifiers, _ io.Reader) error {
+					commandData := map[string]any{"commandType": "RESTART_DEVICE"}
+					if rebuildKernelCache {
+						commandData["rebuildKernelCache"] = true
+					}
+					return sendComputerModernMDMCommand(cmd, cliCtx, d, commandData)
+				},
+			})
+		},
+	}
+	dt.addFlags(cmd)
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip confirmation for bulk operations")
+	cmd.Flags().BoolVar(&rebuildKernelCache, "rebuild-kernel-cache", false, "rebuild the kernel cache before restarting")
+	return cmd
+}
+
+func newComputerShutdownCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	return newModernComputerMDMCmd(cliCtx, "shutdown", "SHUT_DOWN_DEVICE",
+		"Shut down a computer",
+		"Shut down a supervised computer by serial number, name, or ID.",
+		`  jamf-cli pro comp shutdown --serial C02X1234
+  jamf-cli pro comp shutdown --group "Lab Macs" --yes`,
+		false,
+	)
+}
+
+func newComputerSetRecoveryLockCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var (
+		dt                 deviceTarget
+		yes                bool
+		confirmDestructive bool
+		newPassword        string
+	)
+	cmd := &cobra.Command{
+		Use:   "set-recovery-lock",
+		Short: "Set or clear the Recovery Lock password on a computer",
+		Long: `Set the Recovery Lock password on an Apple Silicon or Apple T2 computer.
+Omit --new-password or pass an empty string to clear the existing password.
+
+This is a destructive operation: setting an unknown password can permanently
+lock a user out of their machine.`,
+		Example: `  # Set a recovery lock password
+  jamf-cli pro comp set-recovery-lock --serial C02X1234 --new-password "S3cur3P@ss" --yes
+
+  # Clear the recovery lock password
+  jamf-cli pro comp set-recovery-lock --serial C02X1234 --yes
+
+  # Bulk (requires both --yes and --confirm-destructive)
+  jamf-cli pro comp set-recovery-lock --group "Lab Macs" --new-password "S3cur3" --yes --confirm-destructive`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDeviceAction(cmd, cliCtx, &dt, yes, confirmDestructive, deviceActionConfig{
+				actionName:  "set-recovery-lock",
+				deviceType:  "computer",
+				destructive: true,
+				execSingle: func(d *resolve.DeviceIdentifiers, _ io.Reader) error {
+					return sendComputerModernMDMCommand(cmd, cliCtx, d, map[string]any{
+						"commandType": "SET_RECOVERY_LOCK",
+						"newPassword": newPassword,
+					})
+				},
+			})
+		},
+	}
+	dt.addFlags(cmd)
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip confirmation prompt")
+	cmd.Flags().BoolVar(&confirmDestructive, "confirm-destructive", false, "required for bulk destructive operations")
+	cmd.Flags().StringVar(&newPassword, "new-password", "", "Recovery Lock password (omit to clear)")
+	return cmd
 }
 
 // --- Modern API mobile device MDM commands ---

--- a/internal/commands/pro_device_actions_test.go
+++ b/internal/commands/pro_device_actions_test.go
@@ -67,6 +67,7 @@ func TestComputerActionSubcommands_Exist(t *testing.T) {
 		"erase", "remove-mdm", "redeploy-framework",
 		"blank-push", "ddm-sync", "renew-mdm",
 		"lock", "enable-remote-desktop", "disable-remote-desktop",
+		"restart", "shutdown", "set-recovery-lock",
 	}
 	for _, name := range wantComputer {
 		t.Run("computers/"+name, func(t *testing.T) {
@@ -151,7 +152,6 @@ func TestExecuteAction_DryRun(t *testing.T) {
 	var stderr bytes.Buffer
 	cmd := newTestCmd()
 	cmd.SetErr(&stderr)
-	cliCtx := &registry.CLIContext{}
 
 	devices := []*resolve.DeviceIdentifiers{
 		{ID: "1", Name: "Mac-1", SerialNumber: "C02X1"},
@@ -168,7 +168,7 @@ func TestExecuteAction_DryRun(t *testing.T) {
 		},
 	}
 
-	err := executeAction(cmd, cliCtx, dt, devices, true, false, cfg)
+	err := executeAction(cmd, dt, devices, true, false, cfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -186,7 +186,6 @@ func TestExecuteAction_BulkDestructive_BlockedWithoutConfirmDestructive(t *testi
 	var stderr bytes.Buffer
 	cmd := newTestCmd()
 	cmd.SetErr(&stderr)
-	cliCtx := &registry.CLIContext{}
 
 	devices := []*resolve.DeviceIdentifiers{
 		{ID: "1", Name: "Mac-1"},
@@ -205,7 +204,7 @@ func TestExecuteAction_BulkDestructive_BlockedWithoutConfirmDestructive(t *testi
 	}
 
 	// yes=true but confirmDestructive=false → should be blocked
-	err := executeAction(cmd, cliCtx, dt, devices, true, false, cfg)
+	err := executeAction(cmd, dt, devices, true, false, cfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -223,7 +222,6 @@ func TestExecuteAction_BulkDestructive_ProceedsWithBothFlags(t *testing.T) {
 	var stderr bytes.Buffer
 	cmd := newTestCmd()
 	cmd.SetErr(&stderr)
-	cliCtx := &registry.CLIContext{}
 
 	devices := []*resolve.DeviceIdentifiers{
 		{ID: "1", Name: "Mac-1", SerialNumber: "C02X1"},
@@ -241,7 +239,7 @@ func TestExecuteAction_BulkDestructive_ProceedsWithBothFlags(t *testing.T) {
 	}
 
 	// yes=true, confirmDestructive=true → should proceed
-	err := executeAction(cmd, cliCtx, dt, devices, true, true, cfg)
+	err := executeAction(cmd, dt, devices, true, true, cfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -256,7 +254,6 @@ func TestExecuteAction_SingleDestructive_NoInput_RequiresYes(t *testing.T) {
 	cmd := newTestCmd()
 	cmd.SetErr(&bytes.Buffer{})
 	_ = cmd.Flags().Set("no-input", "true")
-	cliCtx := &registry.CLIContext{}
 
 	devices := []*resolve.DeviceIdentifiers{
 		{ID: "1", Name: "Mac-1"},
@@ -273,7 +270,7 @@ func TestExecuteAction_SingleDestructive_NoInput_RequiresYes(t *testing.T) {
 	}
 
 	// yes=false, no-input=true → should error
-	err := executeAction(cmd, cliCtx, dt, devices, false, false, cfg)
+	err := executeAction(cmd, dt, devices, false, false, cfg)
 	if err == nil {
 		t.Fatal("expected error for destructive op without --yes in no-input mode")
 	}
@@ -329,6 +326,38 @@ func TestSendMobileModernMDMCommand_MissingManagementID(t *testing.T) {
 	d := &resolve.DeviceIdentifiers{ID: "7", Name: "iPad-1"} // no ManagementID
 
 	err := sendMobileModernMDMCommand(cmd, cliCtx, d, map[string]any{"commandType": "RESTART_DEVICE"})
+	if err == nil {
+		t.Fatal("expected error for missing managementId, got nil")
+	}
+	if !strings.Contains(err.Error(), "managementId") {
+		t.Errorf("error = %q, want it to mention managementId", err.Error())
+	}
+}
+
+func TestSendComputerModernMDMCommand_Success(t *testing.T) {
+	client := &bodyCapturingClient{}
+	cmd := &cobra.Command{Use: "test"}
+	cliCtx := &registry.CLIContext{Client: client, Output: mockOutput{}}
+	d := &resolve.DeviceIdentifiers{ID: "42", ManagementID: "cccc-dddd", Name: "MacBook-1"}
+
+	err := sendComputerModernMDMCommand(cmd, cliCtx, d, map[string]any{"commandType": "DEVICE_LOCK"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(client.capturedBody, `"DEVICE_LOCK"`) {
+		t.Errorf("request body = %q, want it to contain commandType", client.capturedBody)
+	}
+	if !strings.Contains(client.capturedBody, `"cccc-dddd"`) {
+		t.Errorf("request body = %q, want it to contain managementId", client.capturedBody)
+	}
+}
+
+func TestSendComputerModernMDMCommand_MissingManagementID(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cliCtx := &registry.CLIContext{}
+	d := &resolve.DeviceIdentifiers{ID: "42", Name: "MacBook-1"} // no ManagementID
+
+	err := sendComputerModernMDMCommand(cmd, cliCtx, d, map[string]any{"commandType": "DEVICE_LOCK"})
 	if err == nil {
 		t.Fatal("expected error for missing managementId, got nil")
 	}


### PR DESCRIPTION
## Summary

- Adds 6 new mobile device MDM commands via \`POST /v2/mdm/commands\` (modern API, \`managementId\`-based)
- Migrates \`restart\` and \`shutdown\` from deprecated Classic API endpoints to modern API
- Keeps \`update-inventory\` on Classic API — \`UpdateInventory\` has no modern equivalent and is not deprecated
- Adds 6 new computer MDM commands via modern API: \`restart\`, \`shutdown\`, \`lock\`, \`enable-remote-desktop\`, \`disable-remote-desktop\`, \`set-recovery-lock\`

## New mobile commands

| Command | Type | Notes |
|---------|------|-------|
| \`lock\` | \`DEVICE_LOCK\` | Optional \`--message\`, \`--phone-number\`, \`--pin\` |
| \`clear-passcode\` | \`CLEAR_PASSCODE\` | Required \`--unlock-token\` |
| \`enable-lost-mode\` | \`ENABLE_LOST_MODE\` | \`--message\`/\`--phone\` (at least one required), \`--footnote\` optional |
| \`disable-lost-mode\` | \`DISABLE_LOST_MODE\` | Destructive |
| \`play-lost-mode-sound\` | \`PLAY_LOST_MODE_SOUND\` | Device must be in Lost Mode |
| \`clear-restrictions-password\` | \`CLEAR_RESTRICTIONS_PASSWORD\` | |

## Migrated mobile commands

| Command | Was | Now |
|---------|-----|-----|
| \`restart\` | Classic \`RestartDevice\` (deprecated 2025-02-25) | \`RESTART_DEVICE\` |
| \`shutdown\` | Classic \`ShutDownDevice\` | \`SHUT_DOWN_DEVICE\` |

## New computer commands

| Command | Type | Notes |
|---------|------|-------|
| \`restart\` | \`RESTART_DEVICE\` | Optional \`--rebuild-kernel-cache\` |
| \`shutdown\` | \`SHUT_DOWN_DEVICE\` | |
| \`lock\` | \`DEVICE_LOCK\` | Destructive |
| \`enable-remote-desktop\` | \`ENABLE_REMOTE_DESKTOP\` | |
| \`disable-remote-desktop\` | \`DISABLE_REMOTE_DESKTOP\` | |
| \`set-recovery-lock\` | \`SET_RECOVERY_LOCK\` | Destructive; omit \`--new-password\` to clear |

## Test plan
- [x] All unit tests pass (\`make test\`)
- [x] Mobile: \`restart\`, \`lock\`, \`play-lost-mode-sound\`, \`enable-lost-mode\`, \`disable-lost-mode\`, \`clear-restrictions-password\`, \`clear-passcode\` live-tested on nmartin.jamfcloud.com
- [x] \`update-inventory\` live-tested via Classic API — silent success
- [x] Computer: \`restart\`, \`shutdown\`, \`lock\`, \`enable-remote-desktop\`, \`disable-remote-desktop\`, \`set-recovery-lock\` live-tested on nmartin.jamfcloud.com
- [x] Validation errors fire correctly
- [x] \`--dry-run\` preview works correctly
- [x] \`set-recovery-lock\` requires \`--yes\` (single) and \`--confirm-destructive\` (bulk)

Closes #36
Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)