### PR TITLE
fix(ci): build site binary from latest release tag

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -3,6 +3,8 @@ name: Deploy Site
 on:
   push:
     branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -24,6 +26,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Checkout latest release tag for binary build
+        if: github.event_name != 'release'
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          git checkout "$LATEST_TAG"
+          git checkout ${{ github.sha }} -- docs/site
 
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## Summary

- Adds `release: published` trigger to the Deploy Site workflow
- On `push to main` and `workflow_dispatch`, checks out the latest release tag to build the binary, then restores `docs/site/` from the triggering commit — so style changes on `main` deploy correctly without picking up unreleased commands
- On `release: published`, `actions/checkout` already lands on the tag; no extra step needed

## Test plan

- [ ] Merge to main and verify the deploy runs from the latest release tag
- [ ] Publish a release and verify the deploy runs from that release tag
- [ ] Push a style-only change to `docs/site/` and verify `commands.json` reflects the latest release, not unreleased commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)