### PR TITLE
Fix - Use correct Jamf API paths for computer and mobile device groups

### DIFF
--- a/internal/commands/pro_backup.go
+++ b/internal/commands/pro_backup.go
@@ -254,7 +254,19 @@ func listModernItems(ctx context.Context, client registry.HTTPClient, def Resour
 	var items []resourceItem
 	for _, m := range all {
 		id := extractID(m)
+		if id == "" {
+			// Mobile device group list APIs use groupId / groupName (see MobileDeviceGroup.yaml SmartGroup / StaticGroup).
+			id = extractField(m, "groupId")
+		}
 		name := extractName(m)
+		if name == "" {
+			if n, ok := m["groupName"].(string); ok && n != "" {
+				name = n
+			}
+		}
+		if name == "" {
+			name = id
+		}
 		if id != "" {
 			items = append(items, resourceItem{ID: id, Name: name})
 		}

--- a/internal/commands/pro_backup_test.go
+++ b/internal/commands/pro_backup_test.go
@@ -280,8 +280,9 @@ func TestBackup_ComputerGroups(t *testing.T) {
 			"/v2/computer-groups/static-groups": {200, `{"totalCount":1,"results":[{"id":"20","name":"Lab Macs","count":5}]}`},
 			// v2 static group detail
 			"/v2/computer-groups/static-groups/20": {200, `{"id":"20","name":"Lab Macs","description":"Computer lab","siteId":"-1"}`},
-			// mobile smart groups (empty — shares Name "smart-groups" with computer smart groups)
-			"/v1/mobile-device-groups/smart-groups": {200, `[]`},
+			// mobile smart/static (empty — same Resource Name as computer groups; FilterResources runs all)
+			"/v1/mobile-device-groups/smart-groups":  {200, `[]`},
+			"/v1/mobile-device-groups/static-groups": {200, `{"totalCount":0,"results":[]}`},
 		},
 	}
 
@@ -351,6 +352,58 @@ func TestBackup_ComputerGroups(t *testing.T) {
 	}
 	if staticParsed["name"] != "Lab Macs" {
 		t.Errorf("expected static group name 'Lab Macs', got %v", staticParsed["name"])
+	}
+}
+
+func TestBackup_MobileDeviceGroups(t *testing.T) {
+	mock := &backupMockClient{
+		responses: map[string]overviewMockResponse{
+			// Computer smart/static: empty (this test targets mobile list shape groupId/groupName)
+			"/v2/computer-groups/smart-groups":  {200, `{"totalCount":0,"results":[]}`},
+			"/v2/computer-groups/static-groups": {200, `{"totalCount":0,"results":[]}`},
+			// Mobile smart: list uses groupId + groupName per Jamf API
+			"/v1/mobile-device-groups/smart-groups": {200, `{"totalCount":1,"results":[{"groupId":"5","groupName":"iPad Lab","siteId":"-1","count":3}]}`},
+			"/v1/mobile-device-groups/smart-groups/5": {200, `{"groupId":"5","groupName":"iPad Lab","criteria":[{"name":"Model","andOr":"and","searchType":"is","value":"iPad"}],"siteId":"-1"}`},
+			// Mobile static
+			"/v1/mobile-device-groups/static-groups": {200, `{"totalCount":1,"results":[{"groupId":"7","groupName":"Loaner iPads","siteId":"-1","count":0}]}`},
+			"/v1/mobile-device-groups/static-groups/7": {200, `{"groupId":"7","groupName":"Loaner iPads","groupDescription":"desc","siteId":"-1"}`},
+		},
+	}
+
+	oldURL := serverURL
+	serverURL = "https://test.jamfcloud.com"
+	defer func() { serverURL = oldURL }()
+
+	outDir := t.TempDir()
+	cliCtx := &registry.CLIContext{Client: mock}
+
+	err := runBackup(context.Background(), cliCtx, backupOptions{
+		OutputDir:   outDir,
+		Format:      "yaml",
+		Resources:   "smart-groups,static-groups",
+		IncludeIDs:  false,
+		Concurrency: 2,
+	})
+	if err != nil {
+		t.Fatalf("runBackup error: %v", err)
+	}
+
+	smartMobileDir := filepath.Join(outDir, "smart-groups", "mobile")
+	entries, err := os.ReadDir(smartMobileDir)
+	if err != nil {
+		t.Fatalf("reading smart-groups/mobile: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 mobile smart group file, got %d", len(entries))
+	}
+
+	staticMobileDir := filepath.Join(outDir, "static-groups", "mobile")
+	entries, err = os.ReadDir(staticMobileDir)
+	if err != nil {
+		t.Fatalf("reading static-groups/mobile: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 mobile static group file, got %d", len(entries))
 	}
 }
 

--- a/internal/commands/pro_backup_test.go
+++ b/internal/commands/pro_backup_test.go
@@ -269,6 +269,91 @@ func TestBackup_DuplicateNames(t *testing.T) {
 	}
 }
 
+func TestBackup_ComputerGroups(t *testing.T) {
+	mock := &backupMockClient{
+		responses: map[string]overviewMockResponse{
+			// v2 smart group list (paginated)
+			"/v2/computer-groups/smart-groups": {200, `{"totalCount":1,"results":[{"id":"10","name":"All Laptops","membershipCount":42}]}`},
+			// v2 smart group detail
+			"/v2/computer-groups/smart-groups/10": {200, `{"name":"All Laptops","description":"Laptops only","criteria":[{"name":"Model","priority":0,"andOr":"and","searchType":"like","value":"MacBook"}],"siteId":"-1"}`},
+			// v2 static group list (paginated)
+			"/v2/computer-groups/static-groups": {200, `{"totalCount":1,"results":[{"id":"20","name":"Lab Macs","count":5}]}`},
+			// v2 static group detail
+			"/v2/computer-groups/static-groups/20": {200, `{"id":"20","name":"Lab Macs","description":"Computer lab","siteId":"-1"}`},
+			// mobile smart groups (empty — shares Name "smart-groups" with computer smart groups)
+			"/v1/mobile-device-groups/smart-groups": {200, `[]`},
+		},
+	}
+
+	oldURL := serverURL
+	serverURL = "https://test.jamfcloud.com"
+	defer func() { serverURL = oldURL }()
+
+	outDir := t.TempDir()
+	cliCtx := &registry.CLIContext{Client: mock}
+
+	err := runBackup(context.Background(), cliCtx, backupOptions{
+		OutputDir:   outDir,
+		Format:      "yaml",
+		Resources:   "smart-groups,static-groups",
+		IncludeIDs:  false,
+		Concurrency: 2,
+	})
+	if err != nil {
+		t.Fatalf("runBackup error: %v", err)
+	}
+
+	// Smart group should be in smart-groups/computers/
+	smartDir := filepath.Join(outDir, "smart-groups", "computers")
+	entries, err := os.ReadDir(smartDir)
+	if err != nil {
+		t.Fatalf("reading smart-groups/computers: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 smart group file, got %d", len(entries))
+	}
+
+	smartPath := filepath.Join(smartDir, "all-laptops.yaml")
+	content, err := os.ReadFile(smartPath)
+	if err != nil {
+		t.Fatalf("reading smart group file: %v", err)
+	}
+	var smartParsed map[string]any
+	if err := yaml.Unmarshal(content, &smartParsed); err != nil {
+		t.Fatalf("parsing smart group YAML: %v", err)
+	}
+	if smartParsed["name"] != "All Laptops" {
+		t.Errorf("expected smart group name 'All Laptops', got %v", smartParsed["name"])
+	}
+	criteria, ok := smartParsed["criteria"].([]any)
+	if !ok || len(criteria) == 0 {
+		t.Error("smart group should contain criteria")
+	}
+
+	// Static group should be in static-groups/computers/
+	staticDir := filepath.Join(outDir, "static-groups", "computers")
+	entries, err = os.ReadDir(staticDir)
+	if err != nil {
+		t.Fatalf("reading static-groups/computers: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 static group file, got %d", len(entries))
+	}
+
+	staticPath := filepath.Join(staticDir, "lab-macs.yaml")
+	content, err = os.ReadFile(staticPath)
+	if err != nil {
+		t.Fatalf("reading static group file: %v", err)
+	}
+	var staticParsed map[string]any
+	if err := yaml.Unmarshal(content, &staticParsed); err != nil {
+		t.Fatalf("parsing static group YAML: %v", err)
+	}
+	if staticParsed["name"] != "Lab Macs" {
+		t.Errorf("expected static group name 'Lab Macs', got %v", staticParsed["name"])
+	}
+}
+
 func TestExtractID(t *testing.T) {
 	tests := []struct {
 		input map[string]any

--- a/internal/commands/pro_resources.go
+++ b/internal/commands/pro_resources.go
@@ -6,13 +6,10 @@ package commands
 type ResourceDef struct {
 	Name       string // CLI display name: "policies"
 	ListPath   string // API list endpoint: "/JSSResource/policies" or "/v1/scripts"
-	GetPath    string // API detail endpoint with {id} placeholder (empty when ListOnly is true)
+	GetPath    string // API detail endpoint with {id} placeholder
 	WrapperKey string // Classic API JSON wrapper key (empty for modern)
 	IsClassic  bool
 	SubDir     string // backup output subdirectory
-	// ListOnly is true when there is no GET-by-id; each list row is the full export
-	// (e.g. GET /v1/sites returns complete V1Site objects; GET /v1/sites/{id} does not exist).
-	ListOnly bool
 }
 
 // BackupResources lists all resource types that the backup command exports.

--- a/internal/commands/pro_resources.go
+++ b/internal/commands/pro_resources.go
@@ -6,10 +6,13 @@ package commands
 type ResourceDef struct {
 	Name       string // CLI display name: "policies"
 	ListPath   string // API list endpoint: "/JSSResource/policies" or "/v1/scripts"
-	GetPath    string // API detail endpoint with {id} placeholder
+	GetPath    string // API detail endpoint with {id} placeholder (empty when ListOnly is true)
 	WrapperKey string // Classic API JSON wrapper key (empty for modern)
 	IsClassic  bool
 	SubDir     string // backup output subdirectory
+	// ListOnly is true when there is no GET-by-id; each list row is the full export
+	// (e.g. GET /v1/sites returns complete V1Site objects; GET /v1/sites/{id} does not exist).
+	ListOnly bool
 }
 
 // BackupResources lists all resource types that the backup command exports.
@@ -70,8 +73,8 @@ var BackupResources = []ResourceDef{
 	// Smart Groups - Computer
 	{
 		Name:     "smart-groups",
-		ListPath: "/v1/computer-groups",
-		GetPath:  "/v1/computer-groups/{id}",
+		ListPath: "/v2/computer-groups/smart-groups",
+		GetPath:  "/v2/computer-groups/smart-groups/{id}",
 		SubDir:   "smart-groups/computers",
 	},
 	// Smart Groups - Mobile
@@ -175,8 +178,8 @@ var BackupResources = []ResourceDef{
 	// Static Groups - Computer
 	{
 		Name:     "static-groups",
-		ListPath: "/v1/computer-groups",
-		GetPath:  "/v1/computer-groups/{id}",
+		ListPath: "/v2/computer-groups/static-groups",
+		GetPath:  "/v2/computer-groups/static-groups/{id}",
 		SubDir:   "static-groups/computers",
 	},
 }

--- a/internal/commands/pro_resources.go
+++ b/internal/commands/pro_resources.go
@@ -78,7 +78,7 @@ var BackupResources = []ResourceDef{
 	{
 		Name:     "smart-groups",
 		ListPath: "/v1/mobile-device-groups/smart-groups",
-		GetPath:  "/v1/mobile-device-groups/{id}",
+		GetPath:  "/v1/mobile-device-groups/smart-groups/{id}",
 		SubDir:   "smart-groups/mobile",
 	},
 	// Categories
@@ -178,6 +178,13 @@ var BackupResources = []ResourceDef{
 		ListPath: "/v2/computer-groups/static-groups",
 		GetPath:  "/v2/computer-groups/static-groups/{id}",
 		SubDir:   "static-groups/computers",
+	},
+	// Static Groups - Mobile
+	{
+		Name:     "static-groups",
+		ListPath: "/v1/mobile-device-groups/static-groups",
+		GetPath:  "/v1/mobile-device-groups/static-groups/{id}",
+		SubDir:   "static-groups/mobile",
 	},
 }
 


### PR DESCRIPTION
`jamf-cli pro backup` was returning 404's for computer groups and not exporting any mobile device groups at all 

===
1. Computer smart/static groups — Backup used GET /v1/computer-groups/{id}, which doesn’t exist, so every detail call 404’d. It now uses the real APIs: /v2/computer-groups/smart-groups and /v2/computer-groups/static-groups for list and get.

2. Mobile smart groups — Detail URL was wrong (/v1/mobile-device-groups/{id} instead of .../smart-groups/{id}). List rows use groupId / groupName, but backup only read id / name, so it treated every group as missing and exported nothing without recording a failure.

3. Mobile static groups — There was no backup row at all; we added /v1/mobile-device-groups/static-groups (list + get) and output under static-groups/mobile.

4. Tests — Added/updated backup tests (including mocks for the duplicate smart-groups / static-groups resource names).