### PR TITLE
fix(report): drop stale devices from update-status --scan-failures

### DIFF
--- a/internal/commands/pro_report_updates.go
+++ b/internal/commands/pro_report_updates.go
@@ -305,12 +305,17 @@ func runReportUpdateStatus(ctx context.Context, client registry.HTTPClient, scan
 	}
 
 	// Enrich error devices with inventory data.
+	// Devices whose ID no longer exists in inventory (stale plan/status
+	// references) are silently dropped — they have no useful data to show.
 	var lookup map[string]updateDeviceMeta
 	var errorRows []map[string]any
 	if len(errors) > 0 {
 		lookup = fetchUpdateDeviceLookup(ctx, client)
 		for _, e := range errors {
-			meta := lookup[e.deviceID]
+			meta, found := lookup[e.deviceID]
+			if !found {
+				continue
+			}
 			dt := meta.deviceType
 			if dt == "" {
 				dt = normalizeDeviceType(e.deviceType)
@@ -325,6 +330,9 @@ func runReportUpdateStatus(ctx context.Context, client registry.HTTPClient, scan
 				"product_key": e.productKey,
 				"updated":     e.updated,
 			})
+		}
+		if stale := len(errors) - len(errorRows); stale > 0 {
+			fmt.Fprintf(os.Stderr, "Skipped %d error device(s) no longer in inventory.\n", stale)
 		}
 	}
 
@@ -362,7 +370,10 @@ func runReportUpdateStatus(ctx context.Context, client registry.HTTPClient, scan
 			lookup = fetchUpdateDeviceLookup(ctx, client)
 		}
 		for _, fp := range failedPlans {
-			meta := lookup[fp.deviceID]
+			meta, found := lookup[fp.deviceID]
+			if !found {
+				continue
+			}
 			dt := meta.deviceType
 			if dt == "" {
 				dt = normalizeDeviceType(fp.deviceType)
@@ -380,6 +391,9 @@ func runReportUpdateStatus(ctx context.Context, client registry.HTTPClient, scan
 				"error":       fp.errors,
 				"last_event":  lastEvt,
 			})
+		}
+		if stale := len(failedPlans) - len(failedPlanRows); stale > 0 {
+			fmt.Fprintf(os.Stderr, "Skipped %d failed plan(s) for devices no longer in inventory.\n", stale)
 		}
 	}
 
@@ -405,7 +419,7 @@ func runReportUpdateStatus(ctx context.Context, client registry.HTTPClient, scan
 
 	// Table: error devices
 	if len(errorRows) > 0 {
-		fmt.Printf("\n── Devices With Update Errors (%d) ──\n", errorSample)
+		fmt.Printf("\n── Devices With Update Errors (%d) ──\n", len(errorRows))
 		if err := formatter.Print(errorRows); err != nil {
 			return err
 		}
@@ -421,7 +435,7 @@ func runReportUpdateStatus(ctx context.Context, client registry.HTTPClient, scan
 
 	// Table: failed plans
 	if len(failedPlanRows) > 0 {
-		fmt.Printf("\n── Failed Update Plans (%d) ──\n", planSample)
+		fmt.Printf("\n── Failed Update Plans (%d) ──\n", len(failedPlanRows))
 		if err := formatter.Print(failedPlanRows); err != nil {
 			return err
 		}

--- a/internal/commands/pro_report_updates_test.go
+++ b/internal/commands/pro_report_updates_test.go
@@ -3,7 +3,11 @@
 package commands
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
+	"os"
 	"testing"
 )
 
@@ -200,6 +204,71 @@ func TestRunReportUpdateStatus_WithErrors(t *testing.T) {
 	err := runReportUpdateStatus(context.Background(), client, true, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunReportUpdateStatus_StaleDevicesDropped(t *testing.T) {
+	// Device 999 does not exist in inventory — its error and plan rows
+	// should be silently dropped rather than showing blank fields.
+	client := &overviewMockClient{
+		responses: map[string]overviewMockResponse{
+			"/v1/managed-software-updates/update-statuses": {200, `{
+				"totalCount": 2,
+				"results": [
+					{"status": "ERROR", "device": {"deviceId": "2", "objectType": "COMPUTER"}, "productKey": "macOS15", "updated": "2026-04-01"},
+					{"status": "INSTALL_FAILED", "device": {"deviceId": "999", "objectType": "APPLE_TV"}, "productKey": "tvOS18", "updated": "2026-04-02"}
+				]
+			}`},
+			"/v1/managed-software-updates/plans": {200, `{
+				"totalCount": 2,
+				"results": [
+					{"planUuid": "aaa", "device": {"deviceId": "2", "objectType": "COMPUTER"}, "updateAction": "DOWNLOAD_INSTALL", "versionType": "LATEST_ANY", "status": {"state": "PlanFailed", "errorReasons": ["SOME_ERROR"]}},
+					{"planUuid": "bbb", "device": {"deviceId": "999", "objectType": "APPLE_TV"}, "updateAction": "DOWNLOAD_INSTALL", "versionType": "LATEST_ANY", "status": {"state": "PlanFailed", "errorReasons": ["EXISTING_PLAN_FOR_DEVICE_IN_PROGRESS"]}}
+				]
+			}`},
+			"/v3/computers-inventory": {200, `{
+				"totalCount": 1,
+				"results": [
+					{"id": "2", "general": {"name": "Mac-Bad"}, "hardware": {"serialNumber": "S2"}, "operatingSystem": {"version": "14.5"}, "userAndLocation": {"username": "bob"}}
+				]
+			}`},
+			"/v2/mobile-devices":        {200, `[]`},
+			"/v2/mobile-devices/detail": {200, `{"totalCount": 0, "results": []}`},
+		},
+	}
+
+	// Capture stdout to verify device 999 is absent from JSON output.
+	outputFmt = "json"
+	defer func() { outputFmt = "table" }()
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runReportUpdateStatus(context.Background(), client, true, 0)
+	w.Close()
+	os.Stdout = old
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	out := buf.String()
+
+	var result []map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("bad JSON output: %v", err)
+	}
+	data := result[0]
+
+	errorDevices, _ := data["error_devices"].([]any)
+	if len(errorDevices) != 1 {
+		t.Errorf("error_devices: got %d entries, want 1 (stale device 999 should be dropped)", len(errorDevices))
+	}
+	failedPlans, _ := data["failed_plans"].([]any)
+	if len(failedPlans) != 1 {
+		t.Errorf("failed_plans: got %d entries, want 1 (stale device 999 should be dropped)", len(failedPlans))
 	}
 }
 

--- a/internal/commands/pro_report_updates_test.go
+++ b/internal/commands/pro_report_updates_test.go
@@ -246,14 +246,14 @@ func TestRunReportUpdateStatus_StaleDevicesDropped(t *testing.T) {
 	os.Stdout = w
 
 	err := runReportUpdateStatus(context.Background(), client, true, 0)
-	w.Close()
+	_ = w.Close()
 	os.Stdout = old
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	out := buf.String()
 
 	var result []map[string]any


### PR DESCRIPTION
## Summary

- `pro report update-status --scan-failures` now skips devices whose ID no longer exists in inventory, instead of showing blank rows
- Table header counts reflect post-filter totals
- Stderr message logged when stale devices are skipped (e.g. `Skipped 40 failed plan(s) for devices no longer in inventory.`)

## Root cause

The Jamf Pro managed software updates API (`/v1/managed-software-updates/plans` and `/v1/managed-software-updates/update-statuses`) retains references to devices that have been deleted or re-enrolled. The `device.href` in these records points to a 404. Previously these produced blank rows in both the error devices and failed plans tables — no name, serial, or OS version.

Verified against a live instance: 590 of 647 Apple TV plan entries resolve correctly via `/v2/mobile-devices`; the remaining 57 are stale references (40 deleted devices + 17 with mismatched `objectType` in the plans API pointing to non-existent mobile device IDs).

Closes #108

## Test plan

- [x] `make test` — all pass
- [x] New test `TestRunReportUpdateStatus_StaleDevicesDropped` — captures JSON output and asserts stale device 999 is absent from both `error_devices` and `failed_plans` arrays
- [x] Verified against live Jamf Pro instance (`acs-cob.datajar.mobi`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)