### PR TITLE
fix: place API version before tenant ID in gateway URL paths

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -79,7 +79,7 @@ func (c *Client) Do(ctx context.Context, method, path string, body io.Reader) (*
 
 	// Platform gateway mode: rewrite paths to include tenant routing.
 	//   /JSSResource/* → /api/proclassic/tenant/{id}/*
-	//   /api/v*        → /api/pro/tenant/{id}/v*
+	//   /api/v*        → /api/pro/v*/tenant/{id}/*
 	if c.tenantID != "" {
 		path = rewritePathForGateway(path, c.tenantID)
 	}
@@ -274,8 +274,8 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 // rewritePathForGateway transforms an API path for the Jamf Platform Gateway.
 //
 //	/JSSResource/computers        → /api/proclassic/tenant/{id}/computers
-//	/api/v1/accounts              → /api/pro/tenant/{id}/v1/accounts
-//	/api/preview/computers        → /api/pro/tenant/{id}/preview/computers
+//	/api/v1/accounts              → /api/pro/v1/tenant/{id}/accounts
+//	/api/preview/computers        → /api/pro/preview/tenant/{id}/computers
 func rewritePathForGateway(path, tenantID string) string {
 	if after, ok := strings.CutPrefix(path, "/JSSResource/"); ok {
 		suffix := after
@@ -286,9 +286,15 @@ func rewritePathForGateway(path, tenantID string) string {
 		return "/api/proclassic/tenant/" + tenantID + suffix
 	}
 	// Modern API: /api/v1/..., /api/v2/..., /api/preview/..., etc.
+	// Version segment goes before /tenant/{id} to match the Platform SDK convention:
+	//   /api/{namespace}/{version}/tenant/{tenantID}/{resource}
 	if after, ok := strings.CutPrefix(path, "/api/"); ok {
-		suffix := after
-		return "/api/pro/tenant/" + tenantID + "/" + suffix
+		// after = "v1/accounts" → version = "v1", rest = "accounts"
+		version, rest, _ := strings.Cut(after, "/")
+		if rest == "" {
+			return "/api/pro/" + version + "/tenant/" + tenantID
+		}
+		return "/api/pro/" + version + "/tenant/" + tenantID + "/" + rest
 	}
 	return path
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -498,10 +498,10 @@ func TestRewritePathForGateway_ModernAPI(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"/api/v1/buildings", "/api/pro/tenant/abc-123/v1/buildings"},
-		{"/api/v2/mobile-devices", "/api/pro/tenant/abc-123/v2/mobile-devices"},
-		{"/api/v1/accounts/userid/1", "/api/pro/tenant/abc-123/v1/accounts/userid/1"},
-		{"/api/preview/computers", "/api/pro/tenant/abc-123/preview/computers"},
+		{"/api/v1/buildings", "/api/pro/v1/tenant/abc-123/buildings"},
+		{"/api/v2/mobile-devices", "/api/pro/v2/tenant/abc-123/mobile-devices"},
+		{"/api/v1/accounts/userid/1", "/api/pro/v1/tenant/abc-123/accounts/userid/1"},
+		{"/api/preview/computers", "/api/pro/preview/tenant/abc-123/computers"},
 	}
 	for _, tt := range tests {
 		got := rewritePathForGateway(tt.input, "abc-123")
@@ -562,7 +562,7 @@ func TestDo_PlatformGateway_ModernPath(t *testing.T) {
 		t.Fatalf("Do() error = %v", err)
 	}
 
-	want := "/api/pro/tenant/tenant-uuid/v1/buildings"
+	want := "/api/pro/v1/tenant/tenant-uuid/buildings"
 	if gotPath != want {
 		t.Errorf("path = %q, want %q", gotPath, want)
 	}
@@ -583,7 +583,7 @@ func TestDo_PlatformGateway_ExplicitAPIPrefix(t *testing.T) {
 		t.Fatalf("Do() error = %v", err)
 	}
 
-	want := "/api/pro/tenant/tenant-uuid/v2/users"
+	want := "/api/pro/v2/tenant/tenant-uuid/users"
 	if gotPath != want {
 		t.Errorf("path = %q, want %q", gotPath, want)
 	}


### PR DESCRIPTION
## Summary
- Aligns Pro gateway URL rewriting with the Platform SDK convention: `/api/pro/{version}/tenant/{id}/{resource}` instead of `/api/pro/tenant/{id}/{version}/{resource}`
- Classic API paths unchanged (`/api/proclassic/tenant/{id}/{resource}`)
- Live tested against `pro-stuartdea` (v1, v2, preview, classic, platform endpoints all return 200)

## Test plan
- [x] Unit tests updated and passing (`TestRewritePathForGateway_*`, `TestDo_PlatformGateway_*`)
- [x] Full test suite passing (`make test`)
- [x] Live tested: modern v1 (scripts, buildings, computer-groups), v2 (mobile-devices), preview (computers), classic (policies, printers), platform (blueprints), overview (~37 parallel calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)