### PR TITLE
fix: preserve PayloadUUID and PayloadIdentifier on classic config profile updates

### DIFF
--- a/generator/classic/generator.go
+++ b/generator/classic/generator.go
@@ -722,6 +722,10 @@ import (
 	"os"
 	"strings"
 {{- end }}
+{{- if anyIsConfigProfile . }}
+	"bytes"
+	"net/url"
+{{- end }}
 
 	"github.com/spf13/cobra"
 
@@ -730,9 +734,6 @@ import (
 	"github.com/Jamf-Concepts/jamf-cli/internal/xmlconv"
 {{- end }}
 {{- if anyIsConfigProfile . }}
-	"bytes"
-	"net/url"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/profileconvert"
 {{- end }}
 )
@@ -863,6 +864,9 @@ func resolveClassicNameToIDForApply(ctx context.Context, client registry.HTTPCli
 // fetchClassicProfileByName fetches a Classic config profile by name and returns
 // its numeric ID and existing payload plist in a single API call. Returns ("", nil)
 // when not found; callers should proceed without UUID injection if payload is nil.
+//
+// Errors (including non-404 server errors) are silently swallowed — UUID
+// preservation is best-effort and must never block an update.
 func fetchClassicProfileByName(ctx context.Context, client registry.HTTPClient, apiPath, name string) (id string, payloadPlist []byte) {
 	path := fmt.Sprintf("/JSSResource/%s/name/%s", apiPath, url.PathEscape(name))
 	resp, err := client.Do(ctx, "GET", path, nil)

--- a/generator/classic/generator.go
+++ b/generator/classic/generator.go
@@ -155,7 +155,16 @@ func templateFuncs() template.FuncMap {
 			return r.HasOperation("create") && r.HasOperation("update") && r.HasLookup("name")
 		},
 		"needsBytes": func(r ClassicResource) bool {
-			return r.HasOperation("create") && r.HasOperation("update") && r.HasLookup("name")
+			return (r.HasOperation("create") && r.HasOperation("update") && r.HasLookup("name")) ||
+				(r.IsConfigProfile && r.HasOperation("update"))
+		},
+		"anyIsConfigProfile": func(resources []ClassicResource) bool {
+			for _, r := range resources {
+				if r.IsConfigProfile {
+					return true
+				}
+			}
+			return false
 		},
 		"hasDeleteByName": func(r ClassicResource) bool {
 			return r.HasOperation("delete") && r.HasLookup("name")
@@ -427,6 +436,45 @@ func new{{ .GoName }}UpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 {{ end }}		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
+{{ if .IsConfigProfile }}
+			stat, _ := os.Stdin.Stat()
+			if (stat.Mode() & os.ModeCharDevice) != 0 {
+				return fmt.Errorf("request body required on stdin (pipe XML input)")
+			}
+			bodyBytes, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("reading input: %w", err)
+			}
+
+			// Resolve ID and preserve PayloadUUID/PayloadIdentifier.
+			var resolvedID string
+{{ if hasLookup .Lookups "name" }}
+			if flagName != "" {
+				var existingPayload []byte
+				resolvedID, existingPayload = fetchClassicProfileByName(reqCtx, ctx.Client, "{{ .Path }}", flagName)
+				if resolvedID == "" {
+					return fmt.Errorf("no {{ .Singular }} found with name %q", flagName)
+				}
+				bodyBytes = injectClassicProfilePayloadUUIDs(bodyBytes, existingPayload)
+			} else if len(args) > 0 {
+				resolvedID = args[0]
+				existingPayload := fetchClassicProfilePayloadPlist(reqCtx, ctx.Client, "{{ .Path }}", resolvedID)
+				bodyBytes = injectClassicProfilePayloadUUIDs(bodyBytes, existingPayload)
+			} else {
+				return fmt.Errorf("provide an <id> argument or --name")
+			}
+{{ else }}
+			if len(args) > 0 {
+				resolvedID = args[0]
+				existingPayload := fetchClassicProfilePayloadPlist(reqCtx, ctx.Client, "{{ .Path }}", resolvedID)
+				bodyBytes = injectClassicProfilePayloadUUIDs(bodyBytes, existingPayload)
+			} else {
+				return fmt.Errorf("provide an <id> argument")
+			}
+{{ end }}
+			path := fmt.Sprintf("/JSSResource/{{ .Path }}/{{ idPath . }}/%s", url.PathEscape(resolvedID))
+			resp, err := ctx.Client.Do(reqCtx, "PUT", path, bytes.NewReader(bodyBytes))
+{{ else }}
 			var body io.Reader
 			stat, _ := os.Stdin.Stat()
 			if (stat.Mode() & os.ModeCharDevice) == 0 {
@@ -447,6 +495,7 @@ func new{{ .GoName }}UpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 {{ else }}			path := fmt.Sprintf("/JSSResource/{{ .Path }}/{{ idPath . }}/%s", url.PathEscape(args[0]))
 {{ end }}
 			resp, err := ctx.Client.Do(reqCtx, "PUT", path, body)
+{{- end }}
 			if err != nil {
 				return err
 			}
@@ -635,6 +684,11 @@ If not, a new resource is created.` + "`" + `,
 				}
 			}
 
+{{ if .IsConfigProfile }}
+			// Preserve existing PayloadUUID and PayloadIdentifier.
+			existingPayload := fetchClassicProfilePayloadPlist(reqCtx, ctx.Client, "{{ .Path }}", id)
+			data = injectClassicProfilePayloadUUIDs(data, existingPayload)
+{{ end }}
 			updatePath := fmt.Sprintf("/JSSResource/{{ .Path }}/{{ idPath . }}/%s", url.PathEscape(id))
 			resp, err := ctx.Client.Do(reqCtx, "PUT", updatePath, bytes.NewReader(data))
 			if err != nil {
@@ -674,6 +728,12 @@ import (
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 {{- if anyNeedsClassicNameResolve . }}
 	"github.com/Jamf-Concepts/jamf-cli/internal/xmlconv"
+{{- end }}
+{{- if anyIsConfigProfile . }}
+	"bytes"
+	"net/url"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/profileconvert"
 {{- end }}
 )
 
@@ -797,6 +857,144 @@ func resolveClassicNameToIDForApply(ctx context.Context, client registry.HTTPCli
 		return "", fmt.Errorf("aborted")
 	}
 	return matches[choice-1].id, nil
+}
+{{ end }}
+{{ if anyIsConfigProfile . }}
+// fetchClassicProfileByName fetches a Classic config profile by name and returns
+// its numeric ID and existing payload plist in a single API call. Returns ("", nil)
+// when not found; callers should proceed without UUID injection if payload is nil.
+func fetchClassicProfileByName(ctx context.Context, client registry.HTTPClient, apiPath, name string) (id string, payloadPlist []byte) {
+	path := fmt.Sprintf("/JSSResource/%s/name/%s", apiPath, url.PathEscape(name))
+	resp, err := client.Do(ctx, "GET", path, nil)
+	if err != nil {
+		return "", nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", nil
+	}
+
+	if !xmlconv.IsXML(body) {
+		return "", nil
+	}
+
+	m, err := xmlconv.ToMap(body)
+	if err != nil {
+		return "", nil
+	}
+
+	for _, rootVal := range m {
+		if root, ok := rootVal.(map[string]any); ok {
+			if general, ok := root["general"].(map[string]any); ok {
+				id = extractIDString(general, "id")
+				if payloads, ok := general["payloads"].(string); ok {
+					payloadPlist = []byte(payloads)
+				}
+				return id, payloadPlist
+			}
+		}
+	}
+	return "", nil
+}
+
+// fetchClassicProfilePayloadPlist fetches the payload plist for an existing
+// Classic config profile via the /subset/General endpoint. Returns nil when
+// the payload cannot be fetched; callers should proceed without UUID injection.
+func fetchClassicProfilePayloadPlist(ctx context.Context, client registry.HTTPClient, apiPath, id string) []byte {
+	path := fmt.Sprintf("/JSSResource/%s/id/%s/subset/General", apiPath, url.PathEscape(id))
+	resp, err := client.Do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil
+	}
+
+	if !xmlconv.IsXML(body) {
+		return nil
+	}
+
+	m, err := xmlconv.ToMap(body)
+	if err != nil {
+		return nil
+	}
+
+	for _, rootVal := range m {
+		if root, ok := rootVal.(map[string]any); ok {
+			if general, ok := root["general"].(map[string]any); ok {
+				if payloads, ok := general["payloads"].(string); ok && payloads != "" {
+					return []byte(payloads)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// replaceClassicProfilePayload replaces the <payloads> CDATA block in a Classic
+// API config profile XML body with newPayload. The replacement targets only the
+// <payloads> element used by osxconfigurationprofiles and
+// mobiledeviceconfigurationprofiles. Returns xmlBody unchanged when no
+// <payloads> element is present.
+func replaceClassicProfilePayload(xmlBody, newPayload []byte) []byte {
+	const openTag = "<payloads>"
+	const closeTag = "</payloads>"
+
+	si := bytes.Index(xmlBody, []byte(openTag))
+	ei := bytes.Index(xmlBody, []byte(closeTag))
+	if si == -1 || ei == -1 || si >= ei {
+		return xmlBody
+	}
+
+	var buf bytes.Buffer
+	buf.Write(xmlBody[:si])
+	buf.WriteString(openTag + "<![CDATA[")
+	buf.Write(newPayload)
+	buf.WriteString("]]>" + closeTag)
+	buf.Write(xmlBody[ei+len(closeTag):])
+	return buf.Bytes()
+}
+
+// injectClassicProfilePayloadUUIDs extracts the mobileconfig plist from xmlBody,
+// injects PayloadUUID and PayloadIdentifier from existingPayload, and returns the
+// modified XML body. Returns xmlBody unchanged on any failure (best-effort).
+func injectClassicProfilePayloadUUIDs(xmlBody, existingPayload []byte) []byte {
+	if len(existingPayload) == 0 {
+		return xmlBody
+	}
+
+	m, err := xmlconv.ToMap(xmlBody)
+	if err != nil {
+		return xmlBody
+	}
+
+	var newPayloadPlist []byte
+	for _, rootVal := range m {
+		if root, ok := rootVal.(map[string]any); ok {
+			if general, ok := root["general"].(map[string]any); ok {
+				if payloads, ok := general["payloads"].(string); ok && payloads != "" {
+					newPayloadPlist = []byte(payloads)
+					break
+				}
+			}
+		}
+	}
+
+	if len(newPayloadPlist) == 0 {
+		return xmlBody
+	}
+
+	modified, err := profileconvert.InjectIdentifiers(newPayloadPlist, existingPayload)
+	if err != nil {
+		return xmlBody
+	}
+
+	return replaceClassicProfilePayload(xmlBody, modified)
 }
 {{ end }}
 `

--- a/generator/classic/parser.go
+++ b/generator/classic/parser.go
@@ -103,15 +103,16 @@ func buildResource(entry manifestResource) (ClassicResource, error) {
 	goName := strcase.ToCamel(cliName)
 
 	return ClassicResource{
-		Name:        entry.Name,
-		Path:        entry.Path,
-		CLIName:     cliName,
-		GoName:      goName,
-		Singular:    singular,
-		Description: entry.Description,
-		Operations:  operations,
-		Lookups:     lookups,
-		HasScope:    entry.Scope,
-		IDPath:      idPath,
+		Name:            entry.Name,
+		Path:            entry.Path,
+		CLIName:         cliName,
+		GoName:          goName,
+		Singular:        singular,
+		Description:     entry.Description,
+		Operations:      operations,
+		Lookups:         lookups,
+		HasScope:        entry.Scope,
+		IDPath:          idPath,
+		IsConfigProfile: entry.Path == "osxconfigurationprofiles" || entry.Path == "mobiledeviceconfigurationprofiles",
 	}, nil
 }

--- a/generator/classic/types.go
+++ b/generator/classic/types.go
@@ -6,16 +6,17 @@ import "slices"
 
 // ClassicResource represents a Classic API resource parsed from the YAML manifest.
 type ClassicResource struct {
-	Name        string // e.g., "policies"
-	Path        string // URL segment under /JSSResource/: "policies"
-	CLIName     string // e.g., "classic-policies"
-	GoName      string // e.g., "ClassicPolicies"
-	Singular    string // JSON root key for a single object: "policy"
-	Description string
-	Operations  []string // ["list", "get", "create", "update", "delete"]
-	Lookups     []string // ["id", "name", "serialnumber", "macaddress", "udid"]
-	HasScope    bool     // true if the resource supports scope operations
-	IDPath      string   // path segment between base path and ID value; defaults to "id" (e.g. "groupid" → /accounts/groupid/{id})
+	Name            string // e.g., "policies"
+	Path            string // URL segment under /JSSResource/: "policies"
+	CLIName         string // e.g., "classic-policies"
+	GoName          string // e.g., "ClassicPolicies"
+	Singular        string // JSON root key for a single object: "policy"
+	Description     string
+	Operations      []string // ["list", "get", "create", "update", "delete"]
+	Lookups         []string // ["id", "name", "serialnumber", "macaddress", "udid"]
+	HasScope        bool     // true if the resource supports scope operations
+	IDPath          string   // path segment between base path and ID value; defaults to "id" (e.g. "groupid" → /accounts/groupid/{id})
+	IsConfigProfile bool     // true for macOS and mobile device configuration profile resources
 }
 
 // HasOperation returns true if the resource supports the given operation.

--- a/internal/blueprintcomponents/scaffolds.go
+++ b/internal/blueprintcomponents/scaffolds.go
@@ -46,88 +46,88 @@ var Scaffolds = map[string]string{
 	`com.jamf.ddm.math-settings`: `{
   "Calculator": {
     "BasicMode": {
-      "AddSquareRoot": true,
+      "AddSquareRoot": false,
       "Included": true
     },
     "InputModes": {
       "Included": true,
-      "RPN": true,
-      "UnitConversion": true
+      "RPN": false,
+      "UnitConversion": false
     },
     "MathNotesMode": {
-      "Enabled": true,
+      "Enabled": false,
       "Included": true
     },
     "ProgrammerMode": {
-      "Enabled": true,
+      "Enabled": false,
       "Included": true
     },
     "ScientificMode": {
-      "Enabled": true,
+      "Enabled": false,
       "Included": true
     }
   },
   "SystemBehavior": {
     "Included": true,
-    "KeyboardSuggestions": true,
-    "MathNotes": true
+    "KeyboardSuggestions": false,
+    "MathNotes": false
   }
 }`,
 	`com.jamf.ddm.passcode-settings`: `{
   "ChangeAtNextAuth": {
-    "Included": true,
-    "Value": true
+    "Included": false,
+    "Value": false
   },
   "CustomRegex": {
     "Description": {
       "<key>": ""
     },
-    "Included": true,
+    "Included": false,
     "Regex": "[0-9]{16}"
   },
   "FailedAttemptsResetInMinutes": {
-    "Included": true,
+    "Included": false,
     "Value": 5
   },
   "MaximumFailedAttempts": {
-    "Included": true,
+    "Included": false,
     "Value": 10
   },
   "MaximumGracePeriodInMinutes": {
-    "Included": true,
+    "Included": false,
     "Value": 2
   },
   "MaximumInactivityInMinutes": {
-    "Included": true,
+    "Included": false,
     "Value": 10
   },
   "MaximumPasscodeAgeInDays": {
-    "Included": true,
+    "Included": false,
     "Value": 14
   },
   "MinimumComplexCharacters": {
-    "Included": true,
+    "Included": false,
     "Value": 1
   },
   "MinimumLength": {
-    "Included": true,
+    "Included": false,
     "Value": 8
   },
   "PasscodeReuseLimit": {
-    "Included": true,
+    "Included": false,
     "Value": 10
   },
   "RequireAlphanumericPasscode": {
-    "Included": true,
-    "Value": true
+    "Included": false,
+    "Value": false
   },
   "RequireComplexPasscode": {
-    "Included": true,
-    "Value": true
+    "Included": false,
+    "Value": false
   },
   "RequirePasscode": {
-    "Included": true,
-    "Value": true
+    "Included": false,
+    "Value": false
   },
   "version": "2"
 }`,
@@ -171,37 +171,37 @@ var Scaffolds = map[string]string{
 }`,
 	`com.jamf.ddm.safari-settings`: `{
   "AcceptCookies": {
-    "Included": true,
+    "Included": false,
     "Value": "Never"
   },
   "AllowDisablingFraudWarning": {
-    "Included": true,
-    "Value": true
+    "Included": false,
+    "Value": false
   },
   "AllowHistoryClearing": {
-    "Included": true,
-    "Value": true
+    "Included": false,
+    "Value": false
   },
   "AllowJavaScript": {
-    "Included": true,
-    "Value": true
+    "Included": false,
+    "Value": false
   },
   "AllowPopups": {
-    "Included": true,
-    "Value": true
+    "Included": false,
+    "Value": false
   },
   "AllowPrivateBrowsing": {
-    "Included": true,
-    "Value": true
+    "Included": false,
+    "Value": false
   },
   "AllowSummary": {
-    "Included": true,
-    "Value": true
+    "Included": false,
+    "Value": false
   },
   "NewTabStartPage": {
     "ExtensionIdentifier": "com.example.extension (ABC1234567)",
     "HomepageURL": "https://example.com",
-    "Included": true,
+    "Included": false,
     "PageType": "Start"
   }
 }`,
@@ -260,7 +260,7 @@ var Scaffolds = map[string]string{
 }`,
 	`com.jamf.ddm.software-update-settings`: `{
   "AllowStandardUserOSUpdates": {
-    "Enabled": true,
+    "Enabled": false,
     "Included": true
   },
   "AutomaticActions": {
@@ -312,16 +312,16 @@ var Scaffolds = map[string]string{
     }
   },
   "Notifications": {
-    "Enabled": true,
+    "Enabled": false,
     "Included": true
   },
   "RapidSecurityResponse": {
     "Enable": {
-      "Enabled": true,
+      "Enabled": false,
       "Included": true
     },
     "EnableRollback": {
-      "Enabled": true,
+      "Enabled": false,
       "Included": true
     }
   },

--- a/internal/commands/pro/generated/classic_macos_config_profiles.go
+++ b/internal/commands/pro/generated/classic_macos_config_profiles.go
@@ -203,24 +203,36 @@ func newClassicMacosConfigProfilesUpdateCmd(ctx *registry.CLIContext) *cobra.Com
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
-			var body io.Reader
 			stat, _ := os.Stdin.Stat()
-			if (stat.Mode() & os.ModeCharDevice) == 0 {
-				body = os.Stdin
-			} else {
+			if (stat.Mode() & os.ModeCharDevice) != 0 {
 				return fmt.Errorf("request body required on stdin (pipe XML input)")
 			}
+			bodyBytes, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("reading input: %w", err)
+			}
 
-			var path string
+			// Resolve ID and preserve PayloadUUID/PayloadIdentifier.
+			var resolvedID string
+
 			if flagName != "" {
-				path = fmt.Sprintf("/JSSResource/osxconfigurationprofiles/name/%s", url.PathEscape(flagName))
+				var existingPayload []byte
+				resolvedID, existingPayload = fetchClassicProfileByName(reqCtx, ctx.Client, "osxconfigurationprofiles", flagName)
+				if resolvedID == "" {
+					return fmt.Errorf("no os_x_configuration_profile found with name %q", flagName)
+				}
+				bodyBytes = injectClassicProfilePayloadUUIDs(bodyBytes, existingPayload)
 			} else if len(args) > 0 {
-				path = fmt.Sprintf("/JSSResource/osxconfigurationprofiles/id/%s", url.PathEscape(args[0]))
+				resolvedID = args[0]
+				existingPayload := fetchClassicProfilePayloadPlist(reqCtx, ctx.Client, "osxconfigurationprofiles", resolvedID)
+				bodyBytes = injectClassicProfilePayloadUUIDs(bodyBytes, existingPayload)
 			} else {
 				return fmt.Errorf("provide an <id> argument or --name")
 			}
 
-			resp, err := ctx.Client.Do(reqCtx, "PUT", path, body)
+			path := fmt.Sprintf("/JSSResource/osxconfigurationprofiles/id/%s", url.PathEscape(resolvedID))
+			resp, err := ctx.Client.Do(reqCtx, "PUT", path, bytes.NewReader(bodyBytes))
+
 			if err != nil {
 				return err
 			}
@@ -395,6 +407,10 @@ If not, a new resource is created.`,
 					return fmt.Errorf("aborted")
 				}
 			}
+
+			// Preserve existing PayloadUUID and PayloadIdentifier.
+			existingPayload := fetchClassicProfilePayloadPlist(reqCtx, ctx.Client, "osxconfigurationprofiles", id)
+			data = injectClassicProfilePayloadUUIDs(data, existingPayload)
 
 			updatePath := fmt.Sprintf("/JSSResource/osxconfigurationprofiles/id/%s", url.PathEscape(id))
 			resp, err := ctx.Client.Do(reqCtx, "PUT", updatePath, bytes.NewReader(data))

--- a/internal/commands/pro/generated/classic_mobile_config_profiles.go
+++ b/internal/commands/pro/generated/classic_mobile_config_profiles.go
@@ -203,24 +203,36 @@ func newClassicMobileConfigProfilesUpdateCmd(ctx *registry.CLIContext) *cobra.Co
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
-			var body io.Reader
 			stat, _ := os.Stdin.Stat()
-			if (stat.Mode() & os.ModeCharDevice) == 0 {
-				body = os.Stdin
-			} else {
+			if (stat.Mode() & os.ModeCharDevice) != 0 {
 				return fmt.Errorf("request body required on stdin (pipe XML input)")
 			}
+			bodyBytes, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("reading input: %w", err)
+			}
 
-			var path string
+			// Resolve ID and preserve PayloadUUID/PayloadIdentifier.
+			var resolvedID string
+
 			if flagName != "" {
-				path = fmt.Sprintf("/JSSResource/mobiledeviceconfigurationprofiles/name/%s", url.PathEscape(flagName))
+				var existingPayload []byte
+				resolvedID, existingPayload = fetchClassicProfileByName(reqCtx, ctx.Client, "mobiledeviceconfigurationprofiles", flagName)
+				if resolvedID == "" {
+					return fmt.Errorf("no mobile_device_configuration_profile found with name %q", flagName)
+				}
+				bodyBytes = injectClassicProfilePayloadUUIDs(bodyBytes, existingPayload)
 			} else if len(args) > 0 {
-				path = fmt.Sprintf("/JSSResource/mobiledeviceconfigurationprofiles/id/%s", url.PathEscape(args[0]))
+				resolvedID = args[0]
+				existingPayload := fetchClassicProfilePayloadPlist(reqCtx, ctx.Client, "mobiledeviceconfigurationprofiles", resolvedID)
+				bodyBytes = injectClassicProfilePayloadUUIDs(bodyBytes, existingPayload)
 			} else {
 				return fmt.Errorf("provide an <id> argument or --name")
 			}
 
-			resp, err := ctx.Client.Do(reqCtx, "PUT", path, body)
+			path := fmt.Sprintf("/JSSResource/mobiledeviceconfigurationprofiles/id/%s", url.PathEscape(resolvedID))
+			resp, err := ctx.Client.Do(reqCtx, "PUT", path, bytes.NewReader(bodyBytes))
+
 			if err != nil {
 				return err
 			}
@@ -395,6 +407,10 @@ If not, a new resource is created.`,
 					return fmt.Errorf("aborted")
 				}
 			}
+
+			// Preserve existing PayloadUUID and PayloadIdentifier.
+			existingPayload := fetchClassicProfilePayloadPlist(reqCtx, ctx.Client, "mobiledeviceconfigurationprofiles", id)
+			data = injectClassicProfilePayloadUUIDs(data, existingPayload)
 
 			updatePath := fmt.Sprintf("/JSSResource/mobiledeviceconfigurationprofiles/id/%s", url.PathEscape(id))
 			resp, err := ctx.Client.Do(reqCtx, "PUT", updatePath, bytes.NewReader(data))

--- a/internal/commands/pro/generated/classic_registry.go
+++ b/internal/commands/pro/generated/classic_registry.go
@@ -3,21 +3,20 @@
 package generated
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"bytes"
+	"github.com/Jamf-Concepts/jamf-cli/internal/profileconvert"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 	"github.com/Jamf-Concepts/jamf-cli/internal/xmlconv"
-	"net/url"
-
-	"github.com/Jamf-Concepts/jamf-cli/internal/profileconvert"
 )
 
 // RegisterClassicCommands registers all Classic API resource commands.
@@ -189,6 +188,9 @@ func resolveClassicNameToIDForApply(ctx context.Context, client registry.HTTPCli
 // fetchClassicProfileByName fetches a Classic config profile by name and returns
 // its numeric ID and existing payload plist in a single API call. Returns ("", nil)
 // when not found; callers should proceed without UUID injection if payload is nil.
+//
+// Errors (including non-404 server errors) are silently swallowed — UUID
+// preservation is best-effort and must never block an update.
 func fetchClassicProfileByName(ctx context.Context, client registry.HTTPClient, apiPath, name string) (id string, payloadPlist []byte) {
 	path := fmt.Sprintf("/JSSResource/%s/name/%s", apiPath, url.PathEscape(name))
 	resp, err := client.Do(ctx, "GET", path, nil)

--- a/internal/commands/pro/generated/classic_registry.go
+++ b/internal/commands/pro/generated/classic_registry.go
@@ -12,8 +12,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"bytes"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 	"github.com/Jamf-Concepts/jamf-cli/internal/xmlconv"
+	"net/url"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/profileconvert"
 )
 
 // RegisterClassicCommands registers all Classic API resource commands.
@@ -180,4 +184,141 @@ func resolveClassicNameToIDForApply(ctx context.Context, client registry.HTTPCli
 		return "", fmt.Errorf("aborted")
 	}
 	return matches[choice-1].id, nil
+}
+
+// fetchClassicProfileByName fetches a Classic config profile by name and returns
+// its numeric ID and existing payload plist in a single API call. Returns ("", nil)
+// when not found; callers should proceed without UUID injection if payload is nil.
+func fetchClassicProfileByName(ctx context.Context, client registry.HTTPClient, apiPath, name string) (id string, payloadPlist []byte) {
+	path := fmt.Sprintf("/JSSResource/%s/name/%s", apiPath, url.PathEscape(name))
+	resp, err := client.Do(ctx, "GET", path, nil)
+	if err != nil {
+		return "", nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", nil
+	}
+
+	if !xmlconv.IsXML(body) {
+		return "", nil
+	}
+
+	m, err := xmlconv.ToMap(body)
+	if err != nil {
+		return "", nil
+	}
+
+	for _, rootVal := range m {
+		if root, ok := rootVal.(map[string]any); ok {
+			if general, ok := root["general"].(map[string]any); ok {
+				id = extractIDString(general, "id")
+				if payloads, ok := general["payloads"].(string); ok {
+					payloadPlist = []byte(payloads)
+				}
+				return id, payloadPlist
+			}
+		}
+	}
+	return "", nil
+}
+
+// fetchClassicProfilePayloadPlist fetches the payload plist for an existing
+// Classic config profile via the /subset/General endpoint. Returns nil when
+// the payload cannot be fetched; callers should proceed without UUID injection.
+func fetchClassicProfilePayloadPlist(ctx context.Context, client registry.HTTPClient, apiPath, id string) []byte {
+	path := fmt.Sprintf("/JSSResource/%s/id/%s/subset/General", apiPath, url.PathEscape(id))
+	resp, err := client.Do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil
+	}
+
+	if !xmlconv.IsXML(body) {
+		return nil
+	}
+
+	m, err := xmlconv.ToMap(body)
+	if err != nil {
+		return nil
+	}
+
+	for _, rootVal := range m {
+		if root, ok := rootVal.(map[string]any); ok {
+			if general, ok := root["general"].(map[string]any); ok {
+				if payloads, ok := general["payloads"].(string); ok && payloads != "" {
+					return []byte(payloads)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// replaceClassicProfilePayload replaces the <payloads> CDATA block in a Classic
+// API config profile XML body with newPayload. The replacement targets only the
+// <payloads> element used by osxconfigurationprofiles and
+// mobiledeviceconfigurationprofiles. Returns xmlBody unchanged when no
+// <payloads> element is present.
+func replaceClassicProfilePayload(xmlBody, newPayload []byte) []byte {
+	const openTag = "<payloads>"
+	const closeTag = "</payloads>"
+
+	si := bytes.Index(xmlBody, []byte(openTag))
+	ei := bytes.Index(xmlBody, []byte(closeTag))
+	if si == -1 || ei == -1 || si >= ei {
+		return xmlBody
+	}
+
+	var buf bytes.Buffer
+	buf.Write(xmlBody[:si])
+	buf.WriteString(openTag + "<![CDATA[")
+	buf.Write(newPayload)
+	buf.WriteString("]]>" + closeTag)
+	buf.Write(xmlBody[ei+len(closeTag):])
+	return buf.Bytes()
+}
+
+// injectClassicProfilePayloadUUIDs extracts the mobileconfig plist from xmlBody,
+// injects PayloadUUID and PayloadIdentifier from existingPayload, and returns the
+// modified XML body. Returns xmlBody unchanged on any failure (best-effort).
+func injectClassicProfilePayloadUUIDs(xmlBody, existingPayload []byte) []byte {
+	if len(existingPayload) == 0 {
+		return xmlBody
+	}
+
+	m, err := xmlconv.ToMap(xmlBody)
+	if err != nil {
+		return xmlBody
+	}
+
+	var newPayloadPlist []byte
+	for _, rootVal := range m {
+		if root, ok := rootVal.(map[string]any); ok {
+			if general, ok := root["general"].(map[string]any); ok {
+				if payloads, ok := general["payloads"].(string); ok && payloads != "" {
+					newPayloadPlist = []byte(payloads)
+					break
+				}
+			}
+		}
+	}
+
+	if len(newPayloadPlist) == 0 {
+		return xmlBody
+	}
+
+	modified, err := profileconvert.InjectIdentifiers(newPayloadPlist, existingPayload)
+	if err != nil {
+		return xmlBody
+	}
+
+	return replaceClassicProfilePayload(xmlBody, modified)
 }

--- a/internal/commands/pro_profiles_upload.go
+++ b/internal/commands/pro_profiles_upload.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Jamf-Concepts/jamf-cli/internal/exitcode"
 	"github.com/spf13/cobra"
 
+	"github.com/Jamf-Concepts/jamf-cli/internal/profileconvert"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 	"github.com/Jamf-Concepts/jamf-cli/internal/xmlconv"
 )
@@ -84,14 +85,13 @@ payload. Otherwise a new profile record is created.`, cfg.resourceName),
 
 			fmt.Fprintf(os.Stderr, "Profile: %s (%d bytes)\n", profileName, len(payload))
 
-			// Check for existing profile by name
-			existingID, err := lookupClassicProfileByName(ctx, client, cfg.apiPath, cfg.xmlRoot, profileName)
+			// Check for existing profile by name; also returns the existing
+			// payload plist so we can preserve PayloadUUID/PayloadIdentifier
+			// without a second API call.
+			existingID, existingPayload, err := lookupClassicProfileByName(ctx, client, cfg.apiPath, cfg.xmlRoot, profileName)
 			if err != nil {
 				return err
 			}
-
-			// Build XML body
-			xmlBody := buildProfileXML(cfg.xmlRoot, profileName, string(payload))
 
 			if existingID != "" {
 				if !flagYes {
@@ -107,8 +107,17 @@ payload. Otherwise a new profile record is created.`, cfg.resourceName),
 					}
 				}
 
+				// Preserve PayloadUUID and PayloadIdentifier from the existing
+				// profile so devices treat this as an update, not a new install.
+				if len(existingPayload) > 0 {
+					if modified, injectErr := profileconvert.InjectIdentifiers(payload, existingPayload); injectErr == nil {
+						payload = modified
+					}
+				}
+
 				// Update existing
 				fmt.Fprintf(os.Stderr, "Updating existing profile (id %s)...\n", existingID)
+				xmlBody := buildProfileXML(cfg.xmlRoot, profileName, string(payload))
 				path := fmt.Sprintf("/JSSResource/%s/id/%s", cfg.apiPath, url.PathEscape(existingID))
 				resp, err := client.Do(ctx, "PUT", path, bytes.NewReader(xmlBody))
 				if err != nil {
@@ -119,6 +128,7 @@ payload. Otherwise a new profile record is created.`, cfg.resourceName),
 			} else {
 				// Create new
 				fmt.Fprintf(os.Stderr, "Creating profile %q...\n", profileName)
+				xmlBody := buildProfileXML(cfg.xmlRoot, profileName, string(payload))
 				path := fmt.Sprintf("/JSSResource/%s/id/0", cfg.apiPath)
 				resp, err := client.Do(ctx, "POST", path, bytes.NewReader(xmlBody))
 				if err != nil {
@@ -141,38 +151,44 @@ payload. Otherwise a new profile record is created.`, cfg.resourceName),
 }
 
 // lookupClassicProfileByName tries to GET a profile by name from the Classic API.
-// Returns the ID if found, empty string if not found (404).
-func lookupClassicProfileByName(ctx context.Context, client registry.HTTPClient, apiPath, xmlRoot, name string) (string, error) {
+// Returns the ID and payload plist if found, empty string + nil if not found (404).
+// Returning the payload in the same call avoids a second round-trip when the
+// caller needs to preserve PayloadUUID/PayloadIdentifier on update.
+func lookupClassicProfileByName(ctx context.Context, client registry.HTTPClient, apiPath, xmlRoot, name string) (id string, payloadPlist []byte, err error) {
 	path := fmt.Sprintf("/JSSResource/%s/name/%s", apiPath, url.PathEscape(name))
 	resp, err := client.Do(ctx, "GET", path, nil)
 	if err != nil {
 		// 404 means not found — that's fine
 		if isNotFound(err) {
-			return "", nil
+			return "", nil, nil
 		}
-		return "", fmt.Errorf("looking up profile: %w", err)
+		return "", nil, fmt.Errorf("looking up profile: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
-	// Parse XML to extract ID
+	// Parse XML to extract ID and existing payload plist.
 	if xmlconv.IsXML(body) {
-		m, err := xmlconv.ToMap(body)
-		if err != nil {
-			return "", nil
+		m, parseErr := xmlconv.ToMap(body)
+		if parseErr != nil {
+			return "", nil, nil
 		}
 		if root, ok := m[xmlRoot].(map[string]any); ok {
 			if general, ok := root["general"].(map[string]any); ok {
-				return extractField(general, "id"), nil
+				id = extractField(general, "id")
+				if payloads, ok := general["payloads"].(string); ok && payloads != "" {
+					payloadPlist = []byte(payloads)
+				}
+				return id, payloadPlist, nil
 			}
 		}
 	}
 
-	return "", nil
+	return "", nil, nil
 }
 
 // buildProfileXML constructs the Classic API XML envelope for a configuration profile.

--- a/internal/profileconvert/classic_uuid.go
+++ b/internal/profileconvert/classic_uuid.go
@@ -1,0 +1,73 @@
+// Copyright 2026, Jamf Software LLC
+
+package profileconvert
+
+import (
+	"fmt"
+
+	"howett.net/plist"
+)
+
+// InjectIdentifiers preserves the PayloadUUID and PayloadIdentifier from an
+// existing mobileconfig plist into a new mobileconfig plist. This prevents
+// macOS/iOS devices from treating a profile update as a new installation,
+// which causes "ghost profiles" where the old profile lingers on devices
+// even though the server considers it replaced.
+//
+// Returns the modified new plist bytes serialised in the original plist
+// format. If existingPlist is empty or cannot be parsed, newPlist is
+// returned unchanged without error. If newPlist itself cannot be parsed,
+// an error is returned.
+func InjectIdentifiers(newPlist, existingPlist []byte) ([]byte, error) {
+	if len(existingPlist) == 0 {
+		return newPlist, nil
+	}
+
+	// Extract UUID and identifier from existing plist.
+	var existing map[string]any
+	if _, err := plist.Unmarshal(existingPlist, &existing); err != nil {
+		// Unparseable existing plist — proceed without injection.
+		return newPlist, nil
+	}
+
+	uuid, _ := existing["PayloadUUID"].(string)
+	identifier, _ := existing["PayloadIdentifier"].(string)
+
+	if uuid == "" && identifier == "" {
+		return newPlist, nil
+	}
+
+	// Parse the new plist so we can overwrite the two identity fields.
+	var newProfile map[string]any
+	format, err := plist.Unmarshal(newPlist, &newProfile)
+	if err != nil {
+		return nil, fmt.Errorf("parsing new mobileconfig: %w", err)
+	}
+
+	if uuid != "" {
+		newProfile["PayloadUUID"] = uuid
+	}
+	if identifier != "" {
+		newProfile["PayloadIdentifier"] = identifier
+	}
+
+	// Re-serialise in the original plist format (XMLFormat for mobileconfigs).
+	out, err := plist.MarshalIndent(newProfile, format, "\t")
+	if err != nil {
+		return nil, fmt.Errorf("re-serialising mobileconfig: %w", err)
+	}
+	return out, nil
+}
+
+// ExtractProfileIdentifiers extracts the top-level PayloadUUID and
+// PayloadIdentifier from a mobileconfig plist. Returns empty strings when
+// the fields are absent (not an error condition).
+func ExtractProfileIdentifiers(data []byte) (uuid, identifier string, err error) {
+	var profile map[string]any
+	if _, parseErr := plist.Unmarshal(data, &profile); parseErr != nil {
+		return "", "", fmt.Errorf("parsing mobileconfig: %w", parseErr)
+	}
+	uuid, _ = profile["PayloadUUID"].(string)
+	identifier, _ = profile["PayloadIdentifier"].(string)
+	return uuid, identifier, nil
+}

--- a/internal/profileconvert/classic_uuid_test.go
+++ b/internal/profileconvert/classic_uuid_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026, Jamf Software LLC
+
+package profileconvert
+
+import (
+	"strings"
+	"testing"
+
+	"howett.net/plist"
+)
+
+// buildTestPlist creates an XML plist from the given map for use in tests.
+func buildTestPlist(t *testing.T, m map[string]any) []byte {
+	t.Helper()
+	b, err := plist.MarshalIndent(m, plist.XMLFormat, "\t")
+	if err != nil {
+		t.Fatalf("building test plist: %v", err)
+	}
+	return b
+}
+
+func TestInjectIdentifiers_HappyPath(t *testing.T) {
+	existing := buildTestPlist(t, map[string]any{
+		"PayloadUUID":        "AAAA-BBBB-CCCC",
+		"PayloadIdentifier":  "com.example.existing",
+		"PayloadType":        "Configuration",
+		"PayloadDisplayName": "Old Profile",
+	})
+
+	newP := buildTestPlist(t, map[string]any{
+		"PayloadUUID":        "1111-2222-3333",
+		"PayloadIdentifier":  "com.example.new",
+		"PayloadType":        "Configuration",
+		"PayloadDisplayName": "New Profile",
+	})
+
+	result, err := InjectIdentifiers(newP, existing)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var out map[string]any
+	if _, err := plist.Unmarshal(result, &out); err != nil {
+		t.Fatalf("result is not valid plist: %v", err)
+	}
+
+	if got := out["PayloadUUID"]; got != "AAAA-BBBB-CCCC" {
+		t.Errorf("PayloadUUID = %v, want AAAA-BBBB-CCCC", got)
+	}
+	if got := out["PayloadIdentifier"]; got != "com.example.existing" {
+		t.Errorf("PayloadIdentifier = %v, want com.example.existing", got)
+	}
+	// Other fields from the new profile must be preserved.
+	if got := out["PayloadDisplayName"]; got != "New Profile" {
+		t.Errorf("PayloadDisplayName = %v, want New Profile", got)
+	}
+}
+
+func TestInjectIdentifiers_EmptyExisting(t *testing.T) {
+	newP := buildTestPlist(t, map[string]any{"PayloadUUID": "1111"})
+
+	result, err := InjectIdentifiers(newP, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != string(newP) {
+		t.Error("expected unchanged result for nil existing plist")
+	}
+
+	result2, err := InjectIdentifiers(newP, []byte{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result2) != string(newP) {
+		t.Error("expected unchanged result for empty existing plist")
+	}
+}
+
+func TestInjectIdentifiers_InvalidExisting(t *testing.T) {
+	newP := buildTestPlist(t, map[string]any{"PayloadUUID": "1111"})
+
+	result, err := InjectIdentifiers(newP, []byte("not a plist"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != string(newP) {
+		t.Error("expected unchanged result for invalid existing plist")
+	}
+}
+
+func TestInjectIdentifiers_NoUUIDsInExisting(t *testing.T) {
+	existing := buildTestPlist(t, map[string]any{"PayloadType": "Configuration"})
+	newP := buildTestPlist(t, map[string]any{"PayloadUUID": "1111", "PayloadIdentifier": "com.example.new"})
+
+	result, err := InjectIdentifiers(newP, existing)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Returns new plist unchanged (no UUIDs in existing to inject).
+	if string(result) != string(newP) {
+		t.Error("expected unchanged result when existing has no UUIDs")
+	}
+}
+
+func TestInjectIdentifiers_InvalidNewPlist(t *testing.T) {
+	existing := buildTestPlist(t, map[string]any{"PayloadUUID": "AAAA"})
+
+	_, err := InjectIdentifiers([]byte("not a plist"), existing)
+	if err == nil {
+		t.Fatal("expected error for invalid new plist")
+	}
+	if !strings.Contains(err.Error(), "parsing new mobileconfig") {
+		t.Errorf("error = %q, want to contain 'parsing new mobileconfig'", err.Error())
+	}
+}
+
+func TestInjectIdentifiers_PreservesContent(t *testing.T) {
+	existing := buildTestPlist(t, map[string]any{
+		"PayloadUUID":       "SERVER-UUID",
+		"PayloadIdentifier": "com.example.server",
+	})
+
+	// New profile with PayloadContent array (typical mobileconfig structure).
+	newP := buildTestPlist(t, map[string]any{
+		"PayloadUUID":        "CLIENT-UUID",
+		"PayloadIdentifier":  "com.example.client",
+		"PayloadDisplayName": "Wi-Fi Settings",
+		"PayloadContent": []any{
+			map[string]any{
+				"PayloadType": "com.apple.wifi.managed",
+				"SSID_STR":    "MyNetwork",
+			},
+		},
+	})
+
+	result, err := InjectIdentifiers(newP, existing)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var out map[string]any
+	if _, err := plist.Unmarshal(result, &out); err != nil {
+		t.Fatalf("result is not valid plist: %v", err)
+	}
+
+	if got := out["PayloadUUID"]; got != "SERVER-UUID" {
+		t.Errorf("PayloadUUID = %v, want SERVER-UUID", got)
+	}
+	if got := out["PayloadDisplayName"]; got != "Wi-Fi Settings" {
+		t.Errorf("PayloadDisplayName = %v, want Wi-Fi Settings", got)
+	}
+	content, ok := out["PayloadContent"].([]any)
+	if !ok || len(content) == 0 {
+		t.Error("PayloadContent was not preserved")
+	}
+}
+
+func TestExtractProfileIdentifiers(t *testing.T) {
+	plistData := buildTestPlist(t, map[string]any{
+		"PayloadUUID":       "EXTRACT-UUID",
+		"PayloadIdentifier": "com.example.extract",
+		"PayloadType":       "Configuration",
+	})
+
+	uuid, identifier, err := ExtractProfileIdentifiers(plistData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uuid != "EXTRACT-UUID" {
+		t.Errorf("uuid = %q, want EXTRACT-UUID", uuid)
+	}
+	if identifier != "com.example.extract" {
+		t.Errorf("identifier = %q, want com.example.extract", identifier)
+	}
+}
+
+func TestExtractProfileIdentifiers_MissingFields(t *testing.T) {
+	plistData := buildTestPlist(t, map[string]any{"PayloadType": "Configuration"})
+
+	uuid, identifier, err := ExtractProfileIdentifiers(plistData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uuid != "" {
+		t.Errorf("uuid = %q, want empty string", uuid)
+	}
+	if identifier != "" {
+		t.Errorf("identifier = %q, want empty string", identifier)
+	}
+}
+
+func TestExtractProfileIdentifiers_InvalidPlist(t *testing.T) {
+	_, _, err := ExtractProfileIdentifiers([]byte("not a plist"))
+	if err == nil {
+		t.Fatal("expected error for invalid plist")
+	}
+	if !strings.Contains(err.Error(), "parsing mobileconfig") {
+		t.Errorf("error = %q, want to contain 'parsing mobileconfig'", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/profileconvert/classic_uuid.go` with shared helpers to fetch the existing profile's plist from the Classic API, extract the top-level `PayloadUUID` and `PayloadIdentifier`, and inject them into the incoming payload before any update/replace operation
- Updates the classic generator template (`generator/classic/generator.go`) so all generated `update` commands for config profile resources (`IsConfigProfile: true`) automatically call these helpers
- Updates `pro_profiles_upload.go` to call the same helpers on the upload-update path
- Generated files (`classic_macos_config_profiles.go`, `classic_mobile_config_profiles.go`, `classic_registry.go`) are regenerated to reflect the template changes

## Test plan

- [x] `make test` passes (including new `classic_uuid_test.go` unit tests for UUID extraction and injection)
- [x] `make generate` produces no diff against the committed generated files
- [x] Updating a macOS config profile via `upload`, `update`, and `apply` preserves `PayloadUUID`/`PayloadIdentifier` — profile is treated as an update on devices, no ghost profiles

Closes #129