### PR TITLE
feat: implement jamfprotect-go-sdk v0.3.0 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.2.0
-	github.com/Jamf-Concepts/jamfprotect-go-sdk v0.2.0
+	github.com/Jamf-Concepts/jamfprotect-go-sdk v0.3.0
 	github.com/getkin/kin-openapi v0.135.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Jamf-Concepts/jamfplatform-go-sdk v0.2.0 h1:OUOwROc/5yz7X7IREDd6709U+
 github.com/Jamf-Concepts/jamfplatform-go-sdk v0.2.0/go.mod h1:aNjapJAdC8d/9KsGnMK8ouZU7KBl9sS1RF/yLQkHgO8=
 github.com/Jamf-Concepts/jamfprotect-go-sdk v0.2.0 h1:pc4BE3W+K0ihmT8GG2gplQuk+LT7PRmPWzR7lmxP0Ic=
 github.com/Jamf-Concepts/jamfprotect-go-sdk v0.2.0/go.mod h1:B7fH/nVg1fq44E1Q/hzhnJ+H9VjBslt9Wj39gRWR8Bc=
+github.com/Jamf-Concepts/jamfprotect-go-sdk v0.3.0 h1:MKgLA8y5+Q0JwqhoRebmtaZpd5yWZu56fynKqzH8YOI=
+github.com/Jamf-Concepts/jamfprotect-go-sdk v0.3.0/go.mod h1:B7fH/nVg1fq44E1Q/hzhnJ+H9VjBslt9Wj39gRWR8Bc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=

--- a/internal/commands/aliases.go
+++ b/internal/commands/aliases.go
@@ -65,6 +65,8 @@ var protectAliases = map[string][]string{
 	"computers":                      {"comp"},
 	"data-forwarding":                {"df"},
 	"data-retention":                 {"dr"},
+	"audit-logs":                     {"al"},
+	"insights":                       {"ins"},
 }
 
 // applyProtectAliases appends aliases to protect subcommands.

--- a/internal/commands/groups.go
+++ b/internal/commands/groups.go
@@ -386,19 +386,23 @@ var protectGroupMap = map[string]string{
 	"telemetry":                      groupProtectSecurity,
 	"custom-prevent-lists":           groupProtectSecurity,
 	"unified-logging-filters":        groupProtectSecurity,
+	"insights":                       groupProtectSecurity,
 
 	"computers": groupProtectEndpoint,
+	"alerts":    groupProtectEndpoint,
 
 	"data-forwarding": groupProtectOrg,
 	"data-retention":  groupProtectOrg,
 	"downloads":       groupProtectOrg,
 	"config-freeze":   groupProtectOrg,
 	"connections":     groupProtectOrg,
+	"audit-logs":      groupProtectOrg,
 
 	"roles":       groupProtectAccess,
 	"users":       groupProtectAccess,
 	"groups":      groupProtectAccess,
 	"api-clients": groupProtectAccess,
+	"permissions": groupProtectAccess,
 }
 
 func applyProtectGroups(protect *cobra.Command) {

--- a/internal/commands/protect.go
+++ b/internal/commands/protect.go
@@ -33,6 +33,10 @@ func newProtectCmd(cliCtx *registry.CLIContext) *cobra.Command {
 
 	// Endpoints
 	cmd.AddCommand(newProtectComputersCmd(cliCtx))
+	cmd.AddCommand(newProtectAlertsCmd(cliCtx))
+
+	// Security Configuration (compliance)
+	cmd.AddCommand(newProtectInsightsCmd(cliCtx))
 
 	// Organization
 	cmd.AddCommand(newProtectDataForwardingCmd(cliCtx))
@@ -40,12 +44,14 @@ func newProtectCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	cmd.AddCommand(newProtectDownloadsCmd(cliCtx))
 	cmd.AddCommand(newProtectConfigFreezeCmd(cliCtx))
 	cmd.AddCommand(newProtectConnectionsCmd(cliCtx))
+	cmd.AddCommand(newProtectAuditLogsCmd(cliCtx))
 
 	// Access & Identity
 	cmd.AddCommand(newProtectRolesCmd(cliCtx))
 	cmd.AddCommand(newProtectUsersCmd(cliCtx))
 	cmd.AddCommand(newProtectGroupsCmd(cliCtx))
 	cmd.AddCommand(newProtectApiClientsCmd(cliCtx))
+	cmd.AddCommand(newProtectPermissionsCmd(cliCtx))
 
 	// Apply aliases and groups
 	applyProtectAliases(cmd)

--- a/internal/commands/protect_alerts.go
+++ b/internal/commands/protect_alerts.go
@@ -1,0 +1,152 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamfprotect-go-sdk/jamfprotect"
+)
+
+func newProtectAlertsCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "alerts",
+		Short: "Manage Jamf Protect alerts",
+	}
+
+	cmd.AddCommand(newProtectAlertsListCmd(cliCtx))
+	cmd.AddCommand(newProtectAlertsGetCmd(cliCtx))
+	cmd.AddCommand(newProtectAlertsUpdateStatusCmd(cliCtx))
+	cmd.AddCommand(newProtectAlertsStatusCountsCmd(cliCtx))
+
+	return cmd
+}
+
+func newProtectAlertsListCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all alerts",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			alerts, err := cliCtx.ProtectClient.ListAlerts(cmd.Context())
+			if err != nil {
+				return err
+			}
+			rows := make([]map[string]any, 0, len(alerts))
+			for _, a := range alerts {
+				rows = append(rows, flattenAlert(a))
+			}
+			data, err := json.Marshal(rows)
+			if err != nil {
+				return fmt.Errorf("marshalling output: %w", err)
+			}
+			return cliCtx.Output.PrintRaw(data)
+		},
+	}
+}
+
+func newProtectAlertsGetCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <uuid>",
+		Short: "Get an alert by UUID",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			alert, err := cliCtx.ProtectClient.GetAlert(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return printResult(cliCtx.Output, alert, flattenAlert(*alert))
+		},
+	}
+}
+
+func newProtectAlertsUpdateStatusCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var uuids []string
+	var status string
+
+	cmd := &cobra.Command{
+		Use:   "update-status",
+		Short: "Bulk-update alert status",
+		Long: `Bulk-update the status of one or more alerts.
+
+Valid statuses: New, InProgress, Resolved`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if len(uuids) == 0 {
+				return fmt.Errorf("--uuid is required (may be specified multiple times)")
+			}
+			updated, err := cliCtx.ProtectClient.UpdateAlerts(cmd.Context(), jamfprotect.AlertUpdateInput{
+				UUIDs:  uuids,
+				Status: status,
+			})
+			if err != nil {
+				return err
+			}
+			rows := make([]map[string]any, 0, len(updated))
+			for _, a := range updated {
+				rows = append(rows, flattenAlert(a))
+			}
+			data, err := json.Marshal(rows)
+			if err != nil {
+				return fmt.Errorf("marshalling output: %w", err)
+			}
+			return cliCtx.Output.PrintRaw(data)
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&uuids, "uuid", nil, "Alert UUID to update (repeatable)")
+	cmd.Flags().StringVar(&status, "status", "", "New status: New, InProgress, or Resolved")
+	_ = cmd.MarkFlagRequired("status")
+
+	return cmd
+}
+
+func newProtectAlertsStatusCountsCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status-counts",
+		Short: "Show alert counts by status",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			counts, err := cliCtx.ProtectClient.GetAlertStatusCounts(cmd.Context())
+			if err != nil {
+				return err
+			}
+			row := map[string]any{
+				"new":          counts.New,
+				"inProgress":   counts.InProgress,
+				"resolved":     counts.Resolved,
+				"autoResolved": counts.AutoResolved,
+			}
+			data, err := json.Marshal([]map[string]any{row})
+			if err != nil {
+				return fmt.Errorf("marshalling output: %w", err)
+			}
+			return cliCtx.Output.PrintRaw(data)
+		},
+	}
+}
+
+// flattenAlert converts an Alert to a map for table output.
+func flattenAlert(a jamfprotect.Alert) map[string]any {
+	m := map[string]any{
+		"uuid":      a.UUID,
+		"status":    a.Status,
+		"severity":  a.Severity,
+		"eventType": a.EventType,
+		"received":  a.Received,
+		"created":   a.Created,
+	}
+	if a.Computer != nil {
+		m["computer"] = a.Computer.HostName
+	}
+	if len(a.Analytics) > 0 {
+		names := make([]string, 0, len(a.Analytics))
+		for _, an := range a.Analytics {
+			names = append(names, an.Name)
+		}
+		m["analytics"] = strings.Join(names, ", ")
+	}
+	return m
+}

--- a/internal/commands/protect_alerts.go
+++ b/internal/commands/protect_alerts.go
@@ -78,6 +78,17 @@ Valid statuses: New, InProgress, Resolved`,
 			if len(uuids) == 0 {
 				return fmt.Errorf("--uuid is required (may be specified multiple times)")
 			}
+			validStatuses := []string{"New", "InProgress", "Resolved"}
+			statusOK := false
+			for _, v := range validStatuses {
+				if status == v {
+					statusOK = true
+					break
+				}
+			}
+			if !statusOK {
+				return fmt.Errorf("invalid --status %q: must be one of New, InProgress, Resolved", status)
+			}
 			updated, err := cliCtx.ProtectClient.UpdateAlerts(cmd.Context(), jamfprotect.AlertUpdateInput{
 				UUIDs:  uuids,
 				Status: status,

--- a/internal/commands/protect_audit_logs.go
+++ b/internal/commands/protect_audit_logs.go
@@ -1,0 +1,102 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamfprotect-go-sdk/jamfprotect"
+)
+
+func newProtectAuditLogsCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "audit-logs",
+		Short: "View Jamf Protect audit logs",
+	}
+
+	cmd.AddCommand(newProtectAuditLogsListCmd(cliCtx))
+
+	return cmd
+}
+
+func newProtectAuditLogsListCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var startStr, endStr string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List audit logs",
+		Long: `List audit log entries within a date range.
+
+Defaults to the last 7 days. The SDK enforces a maximum window of 7 days.
+Dates must be in RFC3339 format (e.g. 2026-04-06T00:00:00Z).`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+
+			var dateRange *jamfprotect.AuditLogDateRange
+			if startStr != "" || endStr != "" {
+				dr := &jamfprotect.AuditLogDateRange{}
+				if startStr != "" {
+					t, err := time.Parse(time.RFC3339, startStr)
+					if err != nil {
+						return fmt.Errorf("invalid --start value %q: must be RFC3339 (e.g. 2026-04-06T00:00:00Z)", startStr)
+					}
+					dr.StartDate = t
+				}
+				if endStr != "" {
+					t, err := time.Parse(time.RFC3339, endStr)
+					if err != nil {
+						return fmt.Errorf("invalid --end value %q: must be RFC3339 (e.g. 2026-04-13T00:00:00Z)", endStr)
+					}
+					dr.EndDate = t
+				} else {
+					dr.EndDate = time.Now().UTC()
+				}
+				if dr.StartDate.IsZero() {
+					dr.StartDate = dr.EndDate.AddDate(0, 0, -jamfprotect.MaxAuditLogDays)
+				}
+				dateRange = dr
+			}
+
+			logs, err := cliCtx.ProtectClient.ListAuditLogsByDate(ctx, dateRange)
+			if err != nil {
+				return err
+			}
+			rows := make([]map[string]any, 0, len(logs))
+			for _, l := range logs {
+				rows = append(rows, flattenAuditLog(l))
+			}
+			data, err := json.Marshal(rows)
+			if err != nil {
+				return fmt.Errorf("marshalling output: %w", err)
+			}
+			return cliCtx.Output.PrintRaw(data)
+		},
+	}
+
+	cmd.Flags().StringVar(&startStr, "start", "", "Start date in RFC3339 format (default: 7 days ago)")
+	cmd.Flags().StringVar(&endStr, "end", "", "End date in RFC3339 format (default: now)")
+
+	return cmd
+}
+
+// flattenAuditLog converts an AuditLog to a map for table output.
+func flattenAuditLog(l jamfprotect.AuditLog) map[string]any {
+	m := map[string]any{
+		"date": l.Date,
+		"op":   l.Op,
+		"user": l.User,
+		"ips":  l.IPs,
+	}
+	if l.ResourceID != "" {
+		m["resourceId"] = l.ResourceID
+	}
+	if l.Error != nil {
+		m["error"] = *l.Error
+	}
+	return m
+}

--- a/internal/commands/protect_computers.go
+++ b/internal/commands/protect_computers.go
@@ -137,6 +137,9 @@ func newProtectComputersUpdateCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Update a computer's label and/or tags",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("label") && !cmd.Flags().Changed("tags") {
+				return fmt.Errorf("at least one of --label or --tags must be specified")
+			}
 			ctx := cmd.Context()
 			r := protect.NewResolver(cliCtx.ProtectClient)
 			uuid, err := r.ResolveComputerUUID(ctx, args[0])

--- a/internal/commands/protect_computers.go
+++ b/internal/commands/protect_computers.go
@@ -21,6 +21,9 @@ func newProtectComputersCmd(cliCtx *registry.CLIContext) *cobra.Command {
 
 	cmd.AddCommand(newProtectComputersListCmd(cliCtx))
 	cmd.AddCommand(newProtectComputersGetCmd(cliCtx))
+	cmd.AddCommand(newProtectComputersDeleteCmd(cliCtx))
+	cmd.AddCommand(newProtectComputersSetPlanCmd(cliCtx))
+	cmd.AddCommand(newProtectComputersUpdateCmd(cliCtx))
 
 	return cmd
 }
@@ -49,7 +52,7 @@ func newProtectComputersListCmd(cliCtx *registry.CLIContext) *cobra.Command {
 
 func newProtectComputersGetCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	return &cobra.Command{
-		Use:   "get <name>",
+		Use:   "get <hostname|serial>",
 		Short: "Get a computer by hostname or serial number",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -68,6 +71,97 @@ func newProtectComputersGetCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			return protect.PrintOne(cliCtx.Output, computer)
 		},
 	}
+}
+
+func newProtectComputersDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <hostname|serial>",
+		Short: "Delete a computer by hostname or serial number",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			r := protect.NewResolver(cliCtx.ProtectClient)
+			uuid, err := r.ResolveComputerUUID(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			proceed, err := confirmDelete("computer", args[0], yes)
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return nil
+			}
+			return cliCtx.ProtectClient.DeleteComputer(ctx, uuid)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func newProtectComputersSetPlanCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-plan <hostname|serial> <plan-name>",
+		Short: "Assign a plan to a computer by hostname or serial number",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			r := protect.NewResolver(cliCtx.ProtectClient)
+			computerUUID, err := r.ResolveComputerUUID(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			planID, err := r.ResolvePlanID(ctx, args[1])
+			if err != nil {
+				return err
+			}
+			computer, err := cliCtx.ProtectClient.SetComputerPlan(ctx, computerUUID, planID)
+			if err != nil {
+				return err
+			}
+			return protect.PrintOne(cliCtx.Output, computer)
+		},
+	}
+}
+
+func newProtectComputersUpdateCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var label string
+	var tags []string
+
+	cmd := &cobra.Command{
+		Use:   "update <hostname|serial>",
+		Short: "Update a computer's label and/or tags",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			r := protect.NewResolver(cliCtx.ProtectClient)
+			uuid, err := r.ResolveComputerUUID(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			input := jamfprotect.ComputerUpdateInput{}
+			if cmd.Flags().Changed("label") {
+				input.Label = &label
+			}
+			if cmd.Flags().Changed("tags") {
+				input.Tags = tags
+			}
+			computer, err := cliCtx.ProtectClient.UpdateComputer(ctx, uuid, input)
+			if err != nil {
+				return err
+			}
+			return protect.PrintOne(cliCtx.Output, computer)
+		},
+	}
+
+	cmd.Flags().StringVar(&label, "label", "", "New label for the computer")
+	cmd.Flags().StringArrayVar(&tags, "tags", nil, "Tags to set (replaces existing tags)")
+
+	return cmd
 }
 
 // flattenComputer converts a Computer with pointer fields into a clean map,

--- a/internal/commands/protect_conversions_test.go
+++ b/internal/commands/protect_conversions_test.go
@@ -352,3 +352,190 @@ func TestAnalyticToYAML_RoundTrip(t *testing.T) {
 		t.Errorf("Context[0].Name = %q, want %q", input.Context[0].Name, "proc")
 	}
 }
+
+// ─── flattenAlert ────────────────────────────────────────────────────────────
+
+func TestFlattenAlert_BasicFields(t *testing.T) {
+	a := jamfprotect.Alert{
+		UUID:      "alert-uuid-1",
+		Status:    "New",
+		Severity:  "HIGH",
+		EventType: "GPUProcessLaunch",
+		Received:  "2026-04-13T10:00:00Z",
+		Created:   "2026-04-13T10:00:00Z",
+	}
+	m := flattenAlert(a)
+
+	if m["uuid"] != "alert-uuid-1" {
+		t.Errorf("uuid = %v, want %q", m["uuid"], "alert-uuid-1")
+	}
+	if m["status"] != "New" {
+		t.Errorf("status = %v, want %q", m["status"], "New")
+	}
+	if m["severity"] != "HIGH" {
+		t.Errorf("severity = %v, want %q", m["severity"], "HIGH")
+	}
+	if m["eventType"] != "GPUProcessLaunch" {
+		t.Errorf("eventType = %v, want %q", m["eventType"], "GPUProcessLaunch")
+	}
+}
+
+func TestFlattenAlert_WithComputer(t *testing.T) {
+	a := jamfprotect.Alert{
+		UUID: "alert-uuid-2",
+		Computer: &jamfprotect.AlertComputer{
+			UUID:     "computer-uuid-1",
+			HostName: "my-mac.local",
+		},
+	}
+	m := flattenAlert(a)
+
+	if m["computer"] != "my-mac.local" {
+		t.Errorf("computer = %v, want %q", m["computer"], "my-mac.local")
+	}
+}
+
+func TestFlattenAlert_NoComputer(t *testing.T) {
+	a := jamfprotect.Alert{UUID: "alert-uuid-3"}
+	m := flattenAlert(a)
+
+	if _, ok := m["computer"]; ok {
+		t.Error("computer should be absent when nil")
+	}
+}
+
+func TestFlattenAlert_AnalyticsJoined(t *testing.T) {
+	a := jamfprotect.Alert{
+		UUID: "alert-uuid-4",
+		Analytics: []jamfprotect.AlertAnalytic{
+			{Name: "Analytic One"},
+			{Name: "Analytic Two"},
+		},
+	}
+	m := flattenAlert(a)
+
+	if m["analytics"] != "Analytic One, Analytic Two" {
+		t.Errorf("analytics = %v, want %q", m["analytics"], "Analytic One, Analytic Two")
+	}
+}
+
+// ─── flattenInsight ──────────────────────────────────────────────────────────
+
+func TestFlattenInsight_BasicFields(t *testing.T) {
+	i := jamfprotect.Insight{
+		UUID:      "insight-uuid-1",
+		Label:     "Ensure FileVault Is Enabled",
+		Section:   "5",
+		Enabled:   true,
+		TotalPass: 42,
+		TotalFail: 3,
+		TotalNone: 1,
+		CisID:     []jamfprotect.InsightCisID{{ID: "5.1.1", OSVersion: "14"}},
+	}
+	m := flattenInsight(i)
+
+	if m["label"] != "Ensure FileVault Is Enabled" {
+		t.Errorf("label = %v, want %q", m["label"], "Ensure FileVault Is Enabled")
+	}
+	if m["enabled"] != true {
+		t.Errorf("enabled = %v, want true", m["enabled"])
+	}
+	if m["totalPass"] != int64(42) {
+		t.Errorf("totalPass = %v, want 42", m["totalPass"])
+	}
+	if m["totalFail"] != int64(3) {
+		t.Errorf("totalFail = %v, want 3", m["totalFail"])
+	}
+	if m["cisIDs"] != "5.1.1" {
+		t.Errorf("cisIDs = %v, want %q", m["cisIDs"], "5.1.1")
+	}
+}
+
+func TestFlattenInsight_MultipleCISIDs(t *testing.T) {
+	i := jamfprotect.Insight{
+		CisID: []jamfprotect.InsightCisID{
+			{ID: "1.1", OSVersion: "14"},
+			{ID: "1.2", OSVersion: "15"},
+		},
+	}
+	m := flattenInsight(i)
+
+	if m["cisIDs"] != "1.1, 1.2" {
+		t.Errorf("cisIDs = %v, want %q", m["cisIDs"], "1.1, 1.2")
+	}
+}
+
+// ─── flattenInsightComputer ──────────────────────────────────────────────────
+
+func TestFlattenInsightComputer_BasicFields(t *testing.T) {
+	c := jamfprotect.InsightComputer{
+		UUID:                 "comp-uuid-1",
+		HostName:             "mac-01.local",
+		InsightsStatsFail:    5,
+		InsightsStatsPass:    10,
+		InsightsStatsUnknown: 2,
+		InsightsUpdated:      "2026-04-13T09:00:00Z",
+	}
+	m := flattenInsightComputer(c)
+
+	if m["uuid"] != "comp-uuid-1" {
+		t.Errorf("uuid = %v, want %q", m["uuid"], "comp-uuid-1")
+	}
+	if m["hostName"] != "mac-01.local" {
+		t.Errorf("hostName = %v, want %q", m["hostName"], "mac-01.local")
+	}
+	if m["statsFail"] != int64(5) {
+		t.Errorf("statsFail = %v, want 5", m["statsFail"])
+	}
+	if m["statsPass"] != int64(10) {
+		t.Errorf("statsPass = %v, want 10", m["statsPass"])
+	}
+}
+
+// ─── flattenAuditLog ─────────────────────────────────────────────────────────
+
+func TestFlattenAuditLog_BasicFields(t *testing.T) {
+	l := jamfprotect.AuditLog{
+		Date:       "2026-04-13T10:00:00Z",
+		Op:         "createAnalytic",
+		User:       "admin@example.com",
+		IPs:        "192.168.1.1",
+		ResourceID: "analytic-uuid-1",
+	}
+	m := flattenAuditLog(l)
+
+	if m["date"] != "2026-04-13T10:00:00Z" {
+		t.Errorf("date = %v, want %q", m["date"], "2026-04-13T10:00:00Z")
+	}
+	if m["op"] != "createAnalytic" {
+		t.Errorf("op = %v, want %q", m["op"], "createAnalytic")
+	}
+	if m["user"] != "admin@example.com" {
+		t.Errorf("user = %v, want %q", m["user"], "admin@example.com")
+	}
+	if m["resourceId"] != "analytic-uuid-1" {
+		t.Errorf("resourceId = %v, want %q", m["resourceId"], "analytic-uuid-1")
+	}
+}
+
+func TestFlattenAuditLog_NilError(t *testing.T) {
+	l := jamfprotect.AuditLog{Op: "listPlans"}
+	m := flattenAuditLog(l)
+
+	if _, ok := m["error"]; ok {
+		t.Error("error should be absent when nil")
+	}
+}
+
+func TestFlattenAuditLog_WithError(t *testing.T) {
+	errMsg := "permission denied"
+	l := jamfprotect.AuditLog{
+		Op:    "deletePlan",
+		Error: &errMsg,
+	}
+	m := flattenAuditLog(l)
+
+	if m["error"] != "permission denied" {
+		t.Errorf("error = %v, want %q", m["error"], "permission denied")
+	}
+}

--- a/internal/commands/protect_insights.go
+++ b/internal/commands/protect_insights.go
@@ -1,0 +1,183 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/protect"
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamfprotect-go-sdk/jamfprotect"
+)
+
+func newProtectInsightsCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "insights",
+		Short: "Manage Jamf Protect CIS benchmark insights",
+	}
+
+	cmd.AddCommand(newProtectInsightsListCmd(cliCtx))
+	cmd.AddCommand(newProtectInsightsEnableCmd(cliCtx))
+	cmd.AddCommand(newProtectInsightsDisableCmd(cliCtx))
+	cmd.AddCommand(newProtectInsightsComputersCmd(cliCtx))
+	cmd.AddCommand(newProtectInsightsComplianceScoreCmd(cliCtx))
+
+	return cmd
+}
+
+func newProtectInsightsListCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all CIS benchmark insights",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			insights, err := cliCtx.ProtectClient.ListInsights(cmd.Context())
+			if err != nil {
+				return err
+			}
+			rows := make([]map[string]any, 0, len(insights))
+			for _, i := range insights {
+				rows = append(rows, flattenInsight(i))
+			}
+			data, err := json.Marshal(rows)
+			if err != nil {
+				return fmt.Errorf("marshalling output: %w", err)
+			}
+			return cliCtx.Output.PrintRaw(data)
+		},
+	}
+}
+
+func newProtectInsightsEnableCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "enable <label>",
+		Short: "Enable an insight by label",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			r := protect.NewResolver(cliCtx.ProtectClient)
+			uuid, err := r.ResolveInsightUUID(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			insight, err := cliCtx.ProtectClient.UpdateInsightStatus(ctx, uuid, true)
+			if err != nil {
+				return err
+			}
+			return printResult(cliCtx.Output, insight, flattenInsight(insight))
+		},
+	}
+}
+
+func newProtectInsightsDisableCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "disable <label>",
+		Short: "Disable an insight by label",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			r := protect.NewResolver(cliCtx.ProtectClient)
+			uuid, err := r.ResolveInsightUUID(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			insight, err := cliCtx.ProtectClient.UpdateInsightStatus(ctx, uuid, false)
+			if err != nil {
+				return err
+			}
+			return printResult(cliCtx.Output, insight, flattenInsight(insight))
+		},
+	}
+}
+
+func newProtectInsightsComputersCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "computers <label>",
+		Short: "List computers affected by an insight",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			r := protect.NewResolver(cliCtx.ProtectClient)
+			uuid, err := r.ResolveInsightUUID(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			computers, err := cliCtx.ProtectClient.ListInsightComputers(ctx, uuid)
+			if err != nil {
+				return err
+			}
+			rows := make([]map[string]any, 0, len(computers))
+			for _, c := range computers {
+				rows = append(rows, flattenInsightComputer(c))
+			}
+			data, err := json.Marshal(rows)
+			if err != nil {
+				return fmt.Errorf("marshalling output: %w", err)
+			}
+			return cliCtx.Output.PrintRaw(data)
+		},
+	}
+}
+
+func newProtectInsightsComplianceScoreCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var date string
+
+	cmd := &cobra.Command{
+		Use:   "compliance-score",
+		Short: "Get fleet CIS compliance baseline score",
+		Long: `Get the fleet CIS compliance baseline score.
+
+Omit --date for today's score, or pass an ISO date (e.g. 2026-03-12) for a historical score.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			score, err := cliCtx.ProtectClient.GetFleetComplianceScore(cmd.Context(), date)
+			if err != nil {
+				return err
+			}
+			row := map[string]any{
+				"score":   fmt.Sprintf("%.1f%%", score.Score),
+				"updated": score.Updated,
+			}
+			data, err := json.Marshal([]map[string]any{row})
+			if err != nil {
+				return fmt.Errorf("marshalling output: %w", err)
+			}
+			return cliCtx.Output.PrintRaw(data)
+		},
+	}
+
+	cmd.Flags().StringVar(&date, "date", "", "ISO date for historical score (e.g. 2026-03-12); omit for today")
+
+	return cmd
+}
+
+// flattenInsight converts an Insight to a map for table output.
+func flattenInsight(i jamfprotect.Insight) map[string]any {
+	cisIDs := make([]string, 0, len(i.CisID))
+	for _, c := range i.CisID {
+		cisIDs = append(cisIDs, c.ID)
+	}
+	return map[string]any{
+		"label":     i.Label,
+		"section":   i.Section,
+		"enabled":   i.Enabled,
+		"totalPass": i.TotalPass,
+		"totalFail": i.TotalFail,
+		"totalNone": i.TotalNone,
+		"cisIDs":    strings.Join(cisIDs, ", "),
+	}
+}
+
+// flattenInsightComputer converts an InsightComputer to a map for table output.
+func flattenInsightComputer(c jamfprotect.InsightComputer) map[string]any {
+	return map[string]any{
+		"uuid":            c.UUID,
+		"hostName":        c.HostName,
+		"statsFail":       c.InsightsStatsFail,
+		"statsPass":       c.InsightsStatsPass,
+		"statsUnknown":    c.InsightsStatsUnknown,
+		"insightsUpdated": c.InsightsUpdated,
+	}
+}

--- a/internal/commands/protect_insights.go
+++ b/internal/commands/protect_insights.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -132,6 +133,11 @@ func newProtectInsightsComplianceScoreCmd(cliCtx *registry.CLIContext) *cobra.Co
 
 Omit --date for today's score, or pass an ISO date (e.g. 2026-03-12) for a historical score.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if date != "" {
+				if _, err := time.Parse("2006-01-02", date); err != nil {
+					return fmt.Errorf("invalid --date %q: must be YYYY-MM-DD (e.g. 2026-03-12)", date)
+				}
+			}
 			score, err := cliCtx.ProtectClient.GetFleetComplianceScore(cmd.Context(), date)
 			if err != nil {
 				return err

--- a/internal/commands/protect_overview.go
+++ b/internal/commands/protect_overview.go
@@ -102,6 +102,31 @@ func runProtectOverview(cmd *cobra.Command, cliCtx *registry.CLIContext) ([]over
 		send("computers", formatCount(len(computers)), err)
 	})
 
+	wg.Go(func() {
+		counts, err := client.GetAlertStatusCounts(ctx)
+		if err != nil {
+			send("alerts_new", "", err)
+			send("alerts_inprogress", "", err)
+			return
+		}
+		total := counts.New + counts.InProgress + counts.Resolved + counts.AutoResolved
+		send("alerts_total", formatCount(int(total)), nil)
+		if counts.New > 0 {
+			sendWithColor("alerts_new", fmt.Sprintf("%d New  %d In Progress", counts.New, counts.InProgress), "yellow", nil)
+		} else {
+			send("alerts_new", fmt.Sprintf("%d New  %d In Progress", counts.New, counts.InProgress), nil)
+		}
+	})
+
+	wg.Go(func() {
+		score, err := client.GetFleetComplianceScore(ctx, "")
+		if err != nil {
+			send("compliance_score", "", err)
+			return
+		}
+		send("compliance_score", fmt.Sprintf("%.1f%%", score.Score), nil)
+	})
+
 	// Organization
 
 	wg.Go(func() {
@@ -175,6 +200,8 @@ func runProtectOverview(cmd *cobra.Command, cliCtx *registry.CLIContext) ([]over
 			Name: "Endpoints",
 			Items: []overviewItem{
 				item("Computers", get("computers")),
+				getItem("Alerts", "alerts_new"),
+				item("CIS Compliance Score", get("compliance_score")),
 			},
 		},
 		{

--- a/internal/commands/protect_overview.go
+++ b/internal/commands/protect_overview.go
@@ -106,11 +106,8 @@ func runProtectOverview(cmd *cobra.Command, cliCtx *registry.CLIContext) ([]over
 		counts, err := client.GetAlertStatusCounts(ctx)
 		if err != nil {
 			send("alerts_new", "", err)
-			send("alerts_inprogress", "", err)
 			return
 		}
-		total := counts.New + counts.InProgress + counts.Resolved + counts.AutoResolved
-		send("alerts_total", formatCount(int(total)), nil)
 		if counts.New > 0 {
 			sendWithColor("alerts_new", fmt.Sprintf("%d New  %d In Progress", counts.New, counts.InProgress), "yellow", nil)
 		} else {

--- a/internal/commands/protect_permissions.go
+++ b/internal/commands/protect_permissions.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+)
+
+func newProtectPermissionsCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "permissions",
+		Short: "Show RBAC permissions for the current API client",
+		Long:  `Display the read and write permissions granted to the currently authenticated API client.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			perms, err := cliCtx.ProtectClient.GetCurrentPermissions(cmd.Context())
+			if err != nil {
+				return err
+			}
+			row := map[string]any{
+				"read":  fmt.Sprintf("%v", perms.Read),
+				"write": fmt.Sprintf("%v", perms.Write),
+			}
+			data, err := json.Marshal([]map[string]any{row})
+			if err != nil {
+				return fmt.Errorf("marshalling output: %w", err)
+			}
+			return cliCtx.Output.PrintRaw(data)
+		},
+	}
+}

--- a/internal/commands/protect_permissions.go
+++ b/internal/commands/protect_permissions.go
@@ -5,6 +5,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -22,8 +23,8 @@ func newProtectPermissionsCmd(cliCtx *registry.CLIContext) *cobra.Command {
 				return err
 			}
 			row := map[string]any{
-				"read":  fmt.Sprintf("%v", perms.Read),
-				"write": fmt.Sprintf("%v", perms.Write),
+				"read":  strings.Join(perms.Read, ", "),
+				"write": strings.Join(perms.Write, ", "),
 			}
 			data, err := json.Marshal([]map[string]any{row})
 			if err != nil {

--- a/internal/commands/protect_test.go
+++ b/internal/commands/protect_test.go
@@ -77,6 +77,8 @@ func TestProtectAliases(t *testing.T) {
 		{"cf", "config-freeze"},
 		{"df", "data-forwarding"},
 		{"dr", "data-retention"},
+		{"al", "audit-logs"},
+		{"ins", "insights"},
 	}
 
 	for _, tc := range tests {
@@ -101,6 +103,8 @@ func TestProtectSubcommands(t *testing.T) {
 		"auth",
 		"plans",
 		"computers",
+		"alerts",
+		"insights",
 		"analytics",
 		"analytic-sets",
 		"exception-sets",
@@ -118,12 +122,82 @@ func TestProtectSubcommands(t *testing.T) {
 		"downloads",
 		"config-freeze",
 		"connections",
+		"audit-logs",
+		"permissions",
 	}
 
 	for _, name := range expected {
 		t.Run(name, func(t *testing.T) {
 			if findSubcommand(protect, name) == nil {
 				t.Errorf("expected protect subcommand %q", name)
+			}
+		})
+	}
+}
+
+func TestProtectAlertsSubcommands(t *testing.T) {
+	protect := findProtectCmd(t)
+	alerts := findSubcommand(protect, "alerts")
+	if alerts == nil {
+		t.Fatal("alerts subcommand not found")
+	}
+
+	expected := []string{"list", "get", "update-status", "status-counts"}
+	for _, name := range expected {
+		t.Run(name, func(t *testing.T) {
+			if findSubcommand(alerts, name) == nil {
+				t.Errorf("expected alerts subcommand %q", name)
+			}
+		})
+	}
+}
+
+func TestProtectInsightsSubcommands(t *testing.T) {
+	protect := findProtectCmd(t)
+	insights := findSubcommand(protect, "insights")
+	if insights == nil {
+		t.Fatal("insights subcommand not found")
+	}
+
+	expected := []string{"list", "enable", "disable", "computers", "compliance-score"}
+	for _, name := range expected {
+		t.Run(name, func(t *testing.T) {
+			if findSubcommand(insights, name) == nil {
+				t.Errorf("expected insights subcommand %q", name)
+			}
+		})
+	}
+}
+
+func TestProtectAuditLogsSubcommands(t *testing.T) {
+	protect := findProtectCmd(t)
+	al := findSubcommand(protect, "audit-logs")
+	if al == nil {
+		t.Fatal("audit-logs subcommand not found")
+	}
+
+	expected := []string{"list"}
+	for _, name := range expected {
+		t.Run(name, func(t *testing.T) {
+			if findSubcommand(al, name) == nil {
+				t.Errorf("expected audit-logs subcommand %q", name)
+			}
+		})
+	}
+}
+
+func TestProtectComputersSubcommands(t *testing.T) {
+	protect := findProtectCmd(t)
+	computers := findSubcommand(protect, "computers")
+	if computers == nil {
+		t.Fatal("computers subcommand not found")
+	}
+
+	expected := []string{"list", "get", "delete", "set-plan", "update"}
+	for _, name := range expected {
+		t.Run(name, func(t *testing.T) {
+			if findSubcommand(computers, name) == nil {
+				t.Errorf("expected computers subcommand %q", name)
 			}
 		})
 	}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -831,9 +831,14 @@ func resolveProtectClient(cfg *config.Config, cliCtx *registry.CLIContext) error
 	rc.HTTPClient.Timeout = 60 * time.Second
 	rc.HTTPClient.Jar = jar
 
+	stdClient := rc.StandardClient()
+	if !quiet && !verbose {
+		stdClient.Transport = &spinnerTransport{inner: stdClient.Transport}
+	}
+
 	protectOpts := []jamfprotect.Option{
 		jamfprotect.WithUserAgent("jamf-cli/" + cliVersion),
-		jamfprotect.WithHTTPClient(rc.StandardClient()),
+		jamfprotect.WithHTTPClient(stdClient),
 	}
 	if cacheDir, err := os.UserCacheDir(); err == nil {
 		protectOpts = append(protectOpts, jamfprotect.WithFileTokenCache(filepath.Join(cacheDir, "jamf-cli")))

--- a/internal/protect/resolve.go
+++ b/internal/protect/resolve.go
@@ -29,6 +29,7 @@ type Resolver struct {
 	apiClients     map[string]string
 	computers      map[string]string // hostname -> uuid
 	computerSerial map[string]string // serial -> uuid
+	insights       map[string]string // label -> uuid
 }
 
 // NewResolver creates a Resolver for the given Protect client.
@@ -279,6 +280,25 @@ func (r *Resolver) ResolveApiClientID(ctx context.Context, name string) (string,
 	id, ok := r.apiClients[name]
 	if !ok {
 		return "", fmt.Errorf("API client %q not found; use 'protect api-clients list' to see available names", name)
+	}
+	return id, nil
+}
+
+// ResolveInsightUUID returns the UUID for an insight given its label.
+func (r *Resolver) ResolveInsightUUID(ctx context.Context, label string) (string, error) {
+	if r.insights == nil {
+		items, err := r.client.ListInsights(ctx)
+		if err != nil {
+			return "", fmt.Errorf("listing insights: %w", err)
+		}
+		r.insights = make(map[string]string, len(items))
+		for _, i := range items {
+			r.insights[i.Label] = i.UUID
+		}
+	}
+	id, ok := r.insights[label]
+	if !ok {
+		return "", fmt.Errorf("insight %q not found; use 'protect insights list' to see available labels", label)
 	}
 	return id, nil
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -83,6 +83,31 @@ type ProtectClient interface {
 	// Computers
 	ListComputers(ctx context.Context) ([]jamfprotect.Computer, error)
 	GetComputer(ctx context.Context, uuid string) (*jamfprotect.Computer, error)
+	DeleteComputer(ctx context.Context, uuid string) error
+	SetComputerPlan(ctx context.Context, uuid string, planID string) (*jamfprotect.Computer, error)
+	UpdateComputer(ctx context.Context, uuid string, input jamfprotect.ComputerUpdateInput) (*jamfprotect.Computer, error)
+
+	// Alerts
+	ListAlerts(ctx context.Context) ([]jamfprotect.Alert, error)
+	GetAlert(ctx context.Context, uuid string) (*jamfprotect.Alert, error)
+	GetAlertStatusCounts(ctx context.Context) (jamfprotect.AlertStatusCounts, error)
+	UpdateAlerts(ctx context.Context, input jamfprotect.AlertUpdateInput) ([]jamfprotect.Alert, error)
+
+	// Insights
+	ListInsights(ctx context.Context) ([]jamfprotect.Insight, error)
+	UpdateInsightStatus(ctx context.Context, uuid string, enabled bool) (jamfprotect.Insight, error)
+	ListInsightComputers(ctx context.Context, uuid string) ([]jamfprotect.InsightComputer, error)
+	GetFleetComplianceScore(ctx context.Context, date string) (jamfprotect.ComplianceBaselineScore, error)
+
+	// Audit Logs
+	ListAuditLogsByDate(ctx context.Context, dateRange *jamfprotect.AuditLogDateRange) ([]jamfprotect.AuditLog, error)
+
+	// Dashboard
+	GetCount(ctx context.Context) (jamfprotect.CountResponse, error)
+	ListRiskiestComputers(ctx context.Context, limit int, createdInterval string) ([]jamfprotect.RiskyComputer, error)
+
+	// RBAC
+	GetCurrentPermissions(ctx context.Context) (jamfprotect.RolePermissions, error)
 
 	// Analytics
 	ListAnalytics(ctx context.Context) ([]jamfprotect.Analytic, error)


### PR DESCRIPTION
## Summary

- Bumps `jamfprotect-go-sdk` v0.2.0 → v0.3.0
- Implements all new SDK capabilities as CLI commands
- Adds spinner to Protect SDK HTTP transport (was missing, unlike Pro/Platform)

## New commands

| Command | Description |
|---|---|
| `protect alerts list/get` | List and get security alerts |
| `protect alerts update-status` | Bulk-update alert status (New/InProgress/Resolved) |
| `protect alerts status-counts` | Dashboard counts per status |
| `protect insights list` | All CIS benchmark insights |
| `protect insights enable/disable <label>` | Toggle insight by label |
| `protect insights computers <label>` | Computers failing a specific insight |
| `protect insights compliance-score` | Fleet CIS score (current or historical `--date`) |
| `protect audit-logs list` | Last 7 days by default; `--start`/`--end` for custom range |
| `protect permissions` | Current API client RBAC read/write permissions |

Aliases: `ins` for insights, `al` for audit-logs.

## Expanded commands

- `protect computers delete <hostname\|serial>` — with `--yes` confirmation
- `protect computers set-plan <hostname\|serial> <plan-name>` — assign plan by name
- `protect computers update <hostname\|serial>` — set `--label` and/or `--tags`

## Overview enriched

- Alert status counts (New + In Progress, highlighted yellow when non-zero)
- CIS compliance score added to Endpoints section

## Test plan

- [x] `make test` — all pass
- [x] `protect alerts list` returns alerts table
- [x] `protect insights list` returns CIS insights
- [x] `protect insights enable/disable` toggles an insight
- [x] `protect insights compliance-score` returns a score
- [x] `protect audit-logs list` returns last 7 days of logs
- [x] `protect computers set-plan` assigns plan by hostname and serial
- [x] `protect computers delete` prompts for confirmation
- [x] `protect permissions` shows read/write permission lists
- [x] `protect overview` shows alert counts and compliance score
- [x] Spinner visible during all protect API calls

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)