### PR TITLE
feat: add auth token commands for pro, protect, and platform

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -34,6 +34,11 @@ type Refresher interface {
 	Refresh(ctx context.Context) (string, error)
 }
 
+// Expirer is implemented by auth providers that expose token expiry information.
+type Expirer interface {
+	ExpiresAt() time.Time
+}
+
 // TokenProvider uses a pre-existing bearer token
 type TokenProvider struct {
 	token string

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -27,6 +27,13 @@ type Provider interface {
 	Name() string
 }
 
+// Refresher is implemented by auth providers that support forced token refresh.
+// Calling Refresh clears any cached state (in-memory and on-disk) and exchanges
+// credentials for a brand-new token.
+type Refresher interface {
+	Refresh(ctx context.Context) (string, error)
+}
+
 // TokenProvider uses a pre-existing bearer token
 type TokenProvider struct {
 	token string
@@ -387,6 +394,28 @@ func (p *OAuth2Provider) exchangeToken(ctx context.Context) (string, int, error)
 	return tokenResp.AccessToken, tokenResp.ExpiresIn, nil
 }
 
+// ExpiresAt returns the expiry time of the last fetched token.
+// Returns zero if GetToken has not yet been called successfully.
+func (p *OAuth2Provider) ExpiresAt() time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.expiresAt
+}
+
+// Refresh clears the in-memory and disk token caches and exchanges credentials
+// for a new token. Implements auth.Refresher.
+func (p *OAuth2Provider) Refresh(ctx context.Context) (string, error) {
+	cachePath := tokenCachePath(p.baseURL, p.clientID)
+	p.mu.Lock()
+	p.token = ""
+	p.expiresAt = time.Time{}
+	p.mu.Unlock()
+	if cachePath != "" {
+		_ = os.Remove(cachePath)
+	}
+	return p.GetToken(ctx)
+}
+
 func (p *OAuth2Provider) Name() string {
 	return "oauth2"
 }
@@ -513,6 +542,14 @@ func (p *PlatformOAuth2Provider) exchangeToken(ctx context.Context) (string, int
 	return tokenResp.AccessToken, tokenResp.ExpiresIn, nil
 }
 
+// ExpiresAt returns the expiry time of the last fetched token.
+// Returns zero if GetToken has not yet been called successfully.
+func (p *PlatformOAuth2Provider) ExpiresAt() time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.expiresAt
+}
+
 // TenantID returns the tenant identifier used for gateway URL path rewriting.
 func (p *PlatformOAuth2Provider) TenantID() string {
 	return p.tenantID
@@ -528,6 +565,20 @@ func (p *PlatformOAuth2Provider) ClientID() string {
 // that manage their own token lifecycle (e.g., the Jamf Platform SDK).
 func (p *PlatformOAuth2Provider) ClientSecret() string {
 	return p.clientSecret
+}
+
+// Refresh clears the in-memory and disk token caches and exchanges credentials
+// for a new token. Implements auth.Refresher.
+func (p *PlatformOAuth2Provider) Refresh(ctx context.Context) (string, error) {
+	cachePath := tokenCachePath(p.baseURL, p.clientID)
+	p.mu.Lock()
+	p.token = ""
+	p.expiresAt = time.Time{}
+	p.mu.Unlock()
+	if cachePath != "" {
+		_ = os.Remove(cachePath)
+	}
+	return p.GetToken(ctx)
 }
 
 func (p *PlatformOAuth2Provider) Name() string {

--- a/internal/commands/groups.go
+++ b/internal/commands/groups.go
@@ -96,6 +96,7 @@ var proGroupMap = map[string]string{
 	// Core
 	"setup":    groupCore,
 	"overview": groupCore,
+	"auth":     groupCore,
 	"device":   groupCore,
 
 	// Power Commands

--- a/internal/commands/platform.go
+++ b/internal/commands/platform.go
@@ -14,10 +14,11 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/config"
 	"github.com/Jamf-Concepts/jamf-cli/internal/keychain"
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
 )
 
-func newPlatformCmd() *cobra.Command {
+func newPlatformCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "platform",
 		Short: "Jamf Platform commands",
@@ -25,6 +26,7 @@ func newPlatformCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newPlatformSetupCmd())
+	cmd.AddCommand(newPlatformAuthCmd(cliCtx))
 
 	return cmd
 }

--- a/internal/commands/platform_auth.go
+++ b/internal/commands/platform_auth.go
@@ -1,0 +1,78 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/auth"
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+)
+
+func newPlatformAuthCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Authentication utilities",
+	}
+
+	cmd.AddCommand(newPlatformAuthTokenCmd(cliCtx))
+
+	return cmd
+}
+
+func newPlatformAuthTokenCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var refresh bool
+	cmd := &cobra.Command{
+		Use:   "token",
+		Short: "Print a valid platform gateway access token",
+		Long: `Print a valid Jamf Platform Gateway access token.
+The token is automatically refreshed if expired.
+
+Output is JSON with token and expires_at fields. For token auth
+(pre-existing bearer token), expires_at is omitted since no expiry
+information is available. Use --field token to extract just the token string.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			p := cliCtx.AuthProvider
+			var tok string
+			var err error
+			if refresh {
+				if r, ok := p.(auth.Refresher); ok {
+					tok, err = r.Refresh(cmd.Context())
+				} else {
+					tok, err = p.GetToken(cmd.Context())
+				}
+			} else {
+				tok, err = p.GetToken(cmd.Context())
+			}
+			if err != nil {
+				return fmt.Errorf("obtaining access token: %w", err)
+			}
+
+			m := map[string]any{"token": tok}
+
+			// Expiry is only available for OAuth2-based providers.
+			switch ap := p.(type) {
+			case *auth.OAuth2Provider:
+				if exp := ap.ExpiresAt(); !exp.IsZero() {
+					m["expires_at"] = exp.UTC().Format(time.RFC3339)
+				}
+			case *auth.PlatformOAuth2Provider:
+				if exp := ap.ExpiresAt(); !exp.IsZero() {
+					m["expires_at"] = exp.UTC().Format(time.RFC3339)
+				}
+			}
+
+			out, err := json.MarshalIndent(m, "", "  ")
+			if err != nil {
+				return err
+			}
+			return cliCtx.Output.PrintRaw(out)
+		},
+	}
+	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force a new token exchange, ignoring any cached token")
+	return cmd
+}

--- a/internal/commands/platform_auth.go
+++ b/internal/commands/platform_auth.go
@@ -3,13 +3,8 @@
 package commands
 
 import (
-	"encoding/json"
-	"fmt"
-	"time"
-
 	"github.com/spf13/cobra"
 
-	"github.com/Jamf-Concepts/jamf-cli/internal/auth"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 )
 
@@ -36,41 +31,7 @@ Output is JSON with token and expires_at fields. For token auth
 (pre-existing bearer token), expires_at is omitted since no expiry
 information is available. Use --field token to extract just the token string.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			p := cliCtx.AuthProvider
-			var tok string
-			var err error
-			if refresh {
-				if r, ok := p.(auth.Refresher); ok {
-					tok, err = r.Refresh(cmd.Context())
-				} else {
-					tok, err = p.GetToken(cmd.Context())
-				}
-			} else {
-				tok, err = p.GetToken(cmd.Context())
-			}
-			if err != nil {
-				return fmt.Errorf("obtaining access token: %w", err)
-			}
-
-			m := map[string]any{"token": tok}
-
-			// Expiry is only available for OAuth2-based providers.
-			switch ap := p.(type) {
-			case *auth.OAuth2Provider:
-				if exp := ap.ExpiresAt(); !exp.IsZero() {
-					m["expires_at"] = exp.UTC().Format(time.RFC3339)
-				}
-			case *auth.PlatformOAuth2Provider:
-				if exp := ap.ExpiresAt(); !exp.IsZero() {
-					m["expires_at"] = exp.UTC().Format(time.RFC3339)
-				}
-			}
-
-			out, err := json.MarshalIndent(m, "", "  ")
-			if err != nil {
-				return err
-			}
-			return cliCtx.Output.PrintRaw(out)
+			return runAuthToken(cmd, cliCtx, refresh)
 		},
 	}
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force a new token exchange, ignoring any cached token")

--- a/internal/commands/pro.go
+++ b/internal/commands/pro.go
@@ -20,6 +20,7 @@ func newProCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	cmd.AddCommand(newConfigSetupCmd())
 
 	// Handwritten Jamf Pro commands
+	cmd.AddCommand(newProAuthCmd(cliCtx))
 	cmd.AddCommand(newOverviewCmd(cliCtx))
 	cmd.AddCommand(newBackupCmd(cliCtx))
 	cmd.AddCommand(newAuditCmd(cliCtx))

--- a/internal/commands/pro_auth.go
+++ b/internal/commands/pro_auth.go
@@ -36,43 +36,41 @@ Output is JSON with token and expires_at fields. For token auth
 (pre-existing bearer token), expires_at is omitted since no expiry
 information is available. Use --field token to extract just the token string.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			p := cliCtx.AuthProvider
-			var tok string
-			var err error
-			if refresh {
-				if r, ok := p.(auth.Refresher); ok {
-					tok, err = r.Refresh(cmd.Context())
-				} else {
-					tok, err = p.GetToken(cmd.Context())
-				}
-			} else {
-				tok, err = p.GetToken(cmd.Context())
-			}
-			if err != nil {
-				return fmt.Errorf("obtaining access token: %w", err)
-			}
-
-			m := map[string]any{"token": tok}
-
-			// Expiry is only available for OAuth2-based providers.
-			switch ap := p.(type) {
-			case *auth.OAuth2Provider:
-				if exp := ap.ExpiresAt(); !exp.IsZero() {
-					m["expires_at"] = exp.UTC().Format(time.RFC3339)
-				}
-			case *auth.PlatformOAuth2Provider:
-				if exp := ap.ExpiresAt(); !exp.IsZero() {
-					m["expires_at"] = exp.UTC().Format(time.RFC3339)
-				}
-			}
-
-			out, err := json.MarshalIndent(m, "", "  ")
-			if err != nil {
-				return err
-			}
-			return cliCtx.Output.PrintRaw(out)
+			return runAuthToken(cmd, cliCtx, refresh)
 		},
 	}
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force a new token exchange, ignoring any cached token")
 	return cmd
+}
+
+// runAuthToken is the shared RunE for pro and platform auth token commands.
+func runAuthToken(cmd *cobra.Command, cliCtx *registry.CLIContext, refresh bool) error {
+	p := cliCtx.AuthProvider
+	var tok string
+	var err error
+	if refresh {
+		if r, ok := p.(auth.Refresher); ok {
+			tok, err = r.Refresh(cmd.Context())
+		} else {
+			tok, err = p.GetToken(cmd.Context())
+		}
+	} else {
+		tok, err = p.GetToken(cmd.Context())
+	}
+	if err != nil {
+		return fmt.Errorf("obtaining access token: %w", err)
+	}
+
+	m := map[string]any{"token": tok}
+	if e, ok := p.(auth.Expirer); ok {
+		if exp := e.ExpiresAt(); !exp.IsZero() {
+			m["expires_at"] = exp.UTC().Format(time.RFC3339)
+		}
+	}
+
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return cliCtx.Output.PrintRaw(out)
 }

--- a/internal/commands/pro_auth.go
+++ b/internal/commands/pro_auth.go
@@ -1,0 +1,78 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/auth"
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+)
+
+func newProAuthCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Authentication utilities",
+	}
+
+	cmd.AddCommand(newProAuthTokenCmd(cliCtx))
+
+	return cmd
+}
+
+func newProAuthTokenCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var refresh bool
+	cmd := &cobra.Command{
+		Use:   "token",
+		Short: "Print a valid access token",
+		Long: `Print a valid Jamf Pro access token.
+The token is automatically refreshed if expired.
+
+Output is JSON with token and expires_at fields. For token auth
+(pre-existing bearer token), expires_at is omitted since no expiry
+information is available. Use --field token to extract just the token string.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			p := cliCtx.AuthProvider
+			var tok string
+			var err error
+			if refresh {
+				if r, ok := p.(auth.Refresher); ok {
+					tok, err = r.Refresh(cmd.Context())
+				} else {
+					tok, err = p.GetToken(cmd.Context())
+				}
+			} else {
+				tok, err = p.GetToken(cmd.Context())
+			}
+			if err != nil {
+				return fmt.Errorf("obtaining access token: %w", err)
+			}
+
+			m := map[string]any{"token": tok}
+
+			// Expiry is only available for OAuth2-based providers.
+			switch ap := p.(type) {
+			case *auth.OAuth2Provider:
+				if exp := ap.ExpiresAt(); !exp.IsZero() {
+					m["expires_at"] = exp.UTC().Format(time.RFC3339)
+				}
+			case *auth.PlatformOAuth2Provider:
+				if exp := ap.ExpiresAt(); !exp.IsZero() {
+					m["expires_at"] = exp.UTC().Format(time.RFC3339)
+				}
+			}
+
+			out, err := json.MarshalIndent(m, "", "  ")
+			if err != nil {
+				return err
+			}
+			return cliCtx.Output.PrintRaw(out)
+		},
+	}
+	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force a new token exchange, ignoring any cached token")
+	return cmd
+}

--- a/internal/commands/pro_auth_test.go
+++ b/internal/commands/pro_auth_test.go
@@ -1,0 +1,395 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/auth"
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+)
+
+// ─── Mock auth provider ──────────────────────────────────────────────────────
+
+// mockAuthProvider implements auth.Provider for testing without network calls.
+type mockAuthProvider struct {
+	token string
+	err   error
+}
+
+func (m *mockAuthProvider) GetToken(_ context.Context) (string, error) { return m.token, m.err }
+func (m *mockAuthProvider) Name() string                               { return "mock" }
+
+// ─── OAuth2 test server helpers ──────────────────────────────────────────────
+
+// newOAuth2TestServer starts an httptest.Server that serves a token response,
+// registers server.Close with t.Cleanup, and returns a configured OAuth2Provider.
+func newOAuth2TestServer(t *testing.T, token string, expiresIn int) *auth.OAuth2Provider {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": token,
+			"token_type":   "Bearer",
+			"expires_in":   expiresIn,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return auth.NewOAuth2Provider(srv.URL, "test-client-id", "test-secret")
+}
+
+// newPlatformOAuth2TestServer starts an httptest.Server for the platform
+// gateway token endpoint and returns a configured PlatformOAuth2Provider.
+func newPlatformOAuth2TestServer(t *testing.T, token string, expiresIn int) *auth.PlatformOAuth2Provider {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": token,
+			"token_type":   "Bearer",
+			"expires_in":   expiresIn,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return auth.NewPlatformOAuth2Provider(srv.URL, "test-client-id", "test-secret", "tenant-uuid")
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// parseAuthTokenOutput parses captured rawData bytes as a JSON object.
+func parseAuthTokenOutput(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	if len(data) == 0 {
+		t.Fatal("command produced no output")
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nraw: %s", err, data)
+	}
+	return m
+}
+
+// runProAuthToken builds a pro auth token command, runs RunE, and returns
+// the parsed JSON output map.
+func runProAuthToken(t *testing.T, provider auth.Provider) (map[string]any, error) {
+	t.Helper()
+	return runProAuthTokenCmd(t, provider, false)
+}
+
+// runProAuthTokenWithRefresh is like runProAuthToken but sets --refresh.
+func runProAuthTokenWithRefresh(t *testing.T, provider auth.Provider) (map[string]any, error) {
+	t.Helper()
+	return runProAuthTokenCmd(t, provider, true)
+}
+
+func runProAuthTokenCmd(t *testing.T, provider auth.Provider, refresh bool) (map[string]any, error) {
+	t.Helper()
+	out := &captureOutput{}
+	cliCtx := &registry.CLIContext{
+		Output:       out,
+		AuthProvider: provider,
+	}
+	cmd := newProAuthTokenCmd(cliCtx)
+	cmd.SetContext(context.Background())
+	if refresh {
+		if err := cmd.Flags().Set("refresh", "true"); err != nil {
+			t.Fatalf("setting --refresh flag: %v", err)
+		}
+	}
+	if err := cmd.RunE(cmd, nil); err != nil {
+		return nil, err
+	}
+	return parseAuthTokenOutput(t, out.rawData), nil
+}
+
+// runPlatformAuthToken mirrors runProAuthToken but uses the platform auth command.
+func runPlatformAuthToken(t *testing.T, provider auth.Provider) (map[string]any, error) {
+	t.Helper()
+	return runPlatformAuthTokenCmd(t, provider, false)
+}
+
+// runPlatformAuthTokenWithRefresh is like runPlatformAuthToken but sets --refresh.
+func runPlatformAuthTokenWithRefresh(t *testing.T, provider auth.Provider) (map[string]any, error) {
+	t.Helper()
+	return runPlatformAuthTokenCmd(t, provider, true)
+}
+
+func runPlatformAuthTokenCmd(t *testing.T, provider auth.Provider, refresh bool) (map[string]any, error) {
+	t.Helper()
+	out := &captureOutput{}
+	cliCtx := &registry.CLIContext{
+		Output:       out,
+		AuthProvider: provider,
+	}
+	cmd := newPlatformAuthTokenCmd(cliCtx)
+	cmd.SetContext(context.Background())
+	if refresh {
+		if err := cmd.Flags().Set("refresh", "true"); err != nil {
+			t.Fatalf("setting --refresh flag: %v", err)
+		}
+	}
+	if err := cmd.RunE(cmd, nil); err != nil {
+		return nil, err
+	}
+	return parseAuthTokenOutput(t, out.rawData), nil
+}
+
+// ─── Structure tests ─────────────────────────────────────────────────────────
+
+func TestProAuthCommandExists(t *testing.T) {
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+	pro := findSubcommand(root, "pro")
+	if pro == nil {
+		t.Fatal("pro command not found")
+	}
+	if findSubcommand(pro, "auth") == nil {
+		t.Fatal("expected 'auth' subcommand under 'pro'")
+	}
+}
+
+func TestProAuthTokenCommandExists(t *testing.T) {
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+	pro := findSubcommand(root, "pro")
+	if pro == nil {
+		t.Fatal("pro command not found")
+	}
+	authCmd := findSubcommand(pro, "auth")
+	if authCmd == nil {
+		t.Fatal("auth command not found under pro")
+	}
+	if findSubcommand(authCmd, "token") == nil {
+		t.Fatal("expected 'token' subcommand under 'pro auth'")
+	}
+}
+
+func TestProAuthGroupedInCore(t *testing.T) {
+	gid, ok := proGroupMap["auth"]
+	if !ok {
+		t.Fatal("'auth' not found in proGroupMap")
+	}
+	if gid != groupCore {
+		t.Errorf("proGroupMap[auth] = %q, want %q", gid, groupCore)
+	}
+}
+
+func TestPlatformAuthCommandExists(t *testing.T) {
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+	platform := findSubcommand(root, "platform")
+	if platform == nil {
+		t.Fatal("platform command not found")
+	}
+	if findSubcommand(platform, "auth") == nil {
+		t.Fatal("expected 'auth' subcommand under 'platform'")
+	}
+}
+
+func TestPlatformAuthTokenCommandExists(t *testing.T) {
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+	platform := findSubcommand(root, "platform")
+	if platform == nil {
+		t.Fatal("platform command not found")
+	}
+	authCmd := findSubcommand(platform, "auth")
+	if authCmd == nil {
+		t.Fatal("auth command not found under platform")
+	}
+	if findSubcommand(authCmd, "token") == nil {
+		t.Fatal("expected 'token' subcommand under 'platform auth'")
+	}
+}
+
+// ─── pro auth token ───────────────────────────────────────────────────────────
+
+func TestProAuthToken_TokenProvider_NoExpiry(t *testing.T) {
+	// TokenProvider has no expiry — output should have "token" but not "expires_at".
+	m, err := runProAuthToken(t, auth.NewTokenProvider("tok-abc123"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["token"] != "tok-abc123" {
+		t.Errorf("token = %v, want %q", m["token"], "tok-abc123")
+	}
+	if _, ok := m["expires_at"]; ok {
+		t.Error("expires_at must not be present for token auth (no expiry information)")
+	}
+}
+
+func TestProAuthToken_OAuth2Provider_WithExpiry(t *testing.T) {
+	// OAuth2Provider populates expiresAt after GetToken — output includes expires_at.
+	p := newOAuth2TestServer(t, "oauth2-jwt-token", 3600)
+	m, err := runProAuthToken(t, p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["token"] != "oauth2-jwt-token" {
+		t.Errorf("token = %v, want %q", m["token"], "oauth2-jwt-token")
+	}
+	expiresAt, ok := m["expires_at"]
+	if !ok {
+		t.Fatal("expires_at must be present for oauth2 auth")
+	}
+	ts, ok := expiresAt.(string)
+	if !ok {
+		t.Fatalf("expires_at is not a string: %T", expiresAt)
+	}
+	parsed, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		t.Fatalf("expires_at %q is not valid RFC3339: %v", ts, err)
+	}
+	if !parsed.After(time.Now()) {
+		t.Errorf("expires_at %v is not in the future", parsed)
+	}
+}
+
+func TestProAuthToken_Error(t *testing.T) {
+	p := &mockAuthProvider{err: fmt.Errorf("credential vault offline")}
+	_, err := runProAuthToken(t, p)
+	if err == nil {
+		t.Fatal("expected error from failing provider, got nil")
+	}
+}
+
+// ─── platform auth token ─────────────────────────────────────────────────────
+
+func TestPlatformAuthToken_PlatformOAuth2Provider_WithExpiry(t *testing.T) {
+	p := newPlatformOAuth2TestServer(t, "platform-jwt", 3600)
+	m, err := runPlatformAuthToken(t, p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["token"] != "platform-jwt" {
+		t.Errorf("token = %v, want %q", m["token"], "platform-jwt")
+	}
+	if _, ok := m["expires_at"]; !ok {
+		t.Error("expires_at must be present for platform oauth2 auth")
+	}
+}
+
+func TestPlatformAuthToken_Error(t *testing.T) {
+	p := &mockAuthProvider{err: fmt.Errorf("gateway unreachable")}
+	_, err := runPlatformAuthToken(t, p)
+	if err == nil {
+		t.Fatal("expected error from failing provider, got nil")
+	}
+}
+
+// ─── --refresh flag ───────────────────────────────────────────────────────────
+
+// newCountingOAuth2TestServer starts an httptest.Server that tracks how many
+// times it has been called, returning a distinct token each time.
+func newCountingOAuth2TestServer(t *testing.T, expiresIn int) (*auth.OAuth2Provider, *int) {
+	t.Helper()
+	var count int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": fmt.Sprintf("token-%d", count),
+			"token_type":   "Bearer",
+			"expires_in":   expiresIn,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return auth.NewOAuth2Provider(srv.URL, "test-client-id", "test-secret"), &count
+}
+
+func TestProAuthToken_Refresh_ForcesNewExchange(t *testing.T) {
+	p, calls := newCountingOAuth2TestServer(t, 3600)
+
+	// Prime the in-memory cache with an initial token exchange.
+	if _, err := p.GetToken(context.Background()); err != nil {
+		t.Fatalf("priming GetToken: %v", err)
+	}
+	if *calls != 1 {
+		t.Fatalf("expected 1 server call after priming, got %d", *calls)
+	}
+
+	// Without --refresh: returns the cached token, no extra server call.
+	m1, err := runProAuthToken(t, p)
+	if err != nil {
+		t.Fatalf("without refresh: %v", err)
+	}
+	if *calls != 1 {
+		t.Errorf("without refresh: expected 1 total server calls, got %d", *calls)
+	}
+	if m1["token"] != "token-1" {
+		t.Errorf("without refresh: token = %v, want %q", m1["token"], "token-1")
+	}
+
+	// With --refresh: bypasses cache and exchanges a new token.
+	m2, err := runProAuthTokenWithRefresh(t, p)
+	if err != nil {
+		t.Fatalf("with refresh: %v", err)
+	}
+	if *calls != 2 {
+		t.Errorf("with refresh: expected 2 total server calls, got %d", *calls)
+	}
+	if m2["token"] != "token-2" {
+		t.Errorf("with refresh: token = %v, want %q", m2["token"], "token-2")
+	}
+}
+
+func TestProAuthToken_Refresh_TokenProvider_Noop(t *testing.T) {
+	// TokenProvider doesn't implement Refresher — --refresh is accepted but has no effect.
+	p := auth.NewTokenProvider("static-token")
+	m, err := runProAuthTokenWithRefresh(t, p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["token"] != "static-token" {
+		t.Errorf("token = %v, want %q", m["token"], "static-token")
+	}
+}
+
+func TestPlatformAuthToken_Refresh_ForcesNewExchange(t *testing.T) {
+	var count int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": fmt.Sprintf("plat-token-%d", count),
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	p := auth.NewPlatformOAuth2Provider(srv.URL, "test-client-id", "test-secret", "tenant-uuid")
+
+	// Prime the in-memory cache.
+	if _, err := p.GetToken(context.Background()); err != nil {
+		t.Fatalf("priming GetToken: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 server call after priming, got %d", count)
+	}
+
+	// Without --refresh: returns the cached token.
+	m1, err := runPlatformAuthToken(t, p)
+	if err != nil {
+		t.Fatalf("without refresh: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("without refresh: expected 1 total server calls, got %d", count)
+	}
+	if m1["token"] != "plat-token-1" {
+		t.Errorf("without refresh: token = %v, want %q", m1["token"], "plat-token-1")
+	}
+
+	// With --refresh: forces a new exchange.
+	m2, err := runPlatformAuthTokenWithRefresh(t, p)
+	if err != nil {
+		t.Fatalf("with refresh: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("with refresh: expected 2 total server calls, got %d", count)
+	}
+	if m2["token"] != "plat-token-2" {
+		t.Errorf("with refresh: token = %v, want %q", m2["token"], "plat-token-2")
+	}
+}

--- a/internal/commands/protect_auth.go
+++ b/internal/commands/protect_auth.go
@@ -3,8 +3,9 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
-	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -23,19 +24,33 @@ func newProtectAuthCmd(cliCtx *registry.CLIContext) *cobra.Command {
 }
 
 func newProtectAuthTokenCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return &cobra.Command{
+	var refresh bool
+	cmd := &cobra.Command{
 		Use:   "token",
 		Short: "Print a valid access token",
-		Long: `Print a valid Jamf Protect access token to stdout.
-The token is automatically refreshed if expired. Useful for
-debugging API calls with curl or feeding into other tools.`,
+		Long: `Print a valid Jamf Protect access token.
+The token is automatically refreshed if expired.
+
+Output is JSON with token and expires_at fields. Use --field token to
+extract just the token string.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			token, err := cliCtx.ProtectClient.AccessToken(cmd.Context())
+			if refresh && cliCtx.ClearProtectToken != nil {
+				cliCtx.ClearProtectToken()
+			}
+			t, err := cliCtx.ProtectClient.AccessToken(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("obtaining access token: %w", err)
 			}
-			_, err = fmt.Fprintln(os.Stdout, token.AccessToken)
-			return err
+			out, err := json.MarshalIndent(map[string]any{
+				"token":      t.AccessToken,
+				"expires_at": t.Expiry.UTC().Format(time.RFC3339),
+			}, "", "  ")
+			if err != nil {
+				return err
+			}
+			return cliCtx.Output.PrintRaw(out)
 		},
 	}
+	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force a new token exchange, ignoring any cached token")
+	return cmd
 }

--- a/internal/commands/protect_auth_test.go
+++ b/internal/commands/protect_auth_test.go
@@ -1,0 +1,514 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamfprotect-go-sdk/jamfprotect"
+)
+
+// ─── Minimal ProtectClient stub ──────────────────────────────────────────────
+//
+// stubProtectClientBase satisfies registry.ProtectClient with zero-value no-ops.
+// Embed this in test clients and override only the methods you need.
+//
+// Embedding works because Go promotes the pointer-receiver methods of the
+// embedded *stubProtectClientBase into the outer struct.
+
+type stubProtectClientBase struct{}
+
+func (s *stubProtectClientBase) ListPlans(_ context.Context) ([]jamfprotect.Plan, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetPlan(_ context.Context, _ string) (*jamfprotect.Plan, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreatePlan(_ context.Context, _ jamfprotect.PlanInput) (jamfprotect.Plan, error) {
+	return jamfprotect.Plan{}, nil
+}
+
+func (s *stubProtectClientBase) UpdatePlan(_ context.Context, _ string, _ jamfprotect.PlanInput) (jamfprotect.Plan, error) {
+	return jamfprotect.Plan{}, nil
+}
+func (s *stubProtectClientBase) DeletePlan(_ context.Context, _ string) error { return nil }
+func (s *stubProtectClientBase) GetPlansConfigProfile(_ context.Context, _ string, _ *jamfprotect.PlanConfigProfileOptionsInput) (string, error) {
+	return "", nil
+}
+
+func (s *stubProtectClientBase) ListComputers(_ context.Context) ([]jamfprotect.Computer, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetComputer(_ context.Context, _ string) (*jamfprotect.Computer, error) {
+	return nil, nil
+}
+func (s *stubProtectClientBase) DeleteComputer(_ context.Context, _ string) error { return nil }
+func (s *stubProtectClientBase) SetComputerPlan(_ context.Context, _ string, _ string) (*jamfprotect.Computer, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) UpdateComputer(_ context.Context, _ string, _ jamfprotect.ComputerUpdateInput) (*jamfprotect.Computer, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) ListAlerts(_ context.Context) ([]jamfprotect.Alert, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetAlert(_ context.Context, _ string) (*jamfprotect.Alert, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetAlertStatusCounts(_ context.Context) (jamfprotect.AlertStatusCounts, error) {
+	return jamfprotect.AlertStatusCounts{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateAlerts(_ context.Context, _ jamfprotect.AlertUpdateInput) ([]jamfprotect.Alert, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) ListInsights(_ context.Context) ([]jamfprotect.Insight, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) UpdateInsightStatus(_ context.Context, _ string, _ bool) (jamfprotect.Insight, error) {
+	return jamfprotect.Insight{}, nil
+}
+
+func (s *stubProtectClientBase) ListInsightComputers(_ context.Context, _ string) ([]jamfprotect.InsightComputer, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetFleetComplianceScore(_ context.Context, _ string) (jamfprotect.ComplianceBaselineScore, error) {
+	return jamfprotect.ComplianceBaselineScore{}, nil
+}
+
+func (s *stubProtectClientBase) ListAuditLogsByDate(_ context.Context, _ *jamfprotect.AuditLogDateRange) ([]jamfprotect.AuditLog, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetCount(_ context.Context) (jamfprotect.CountResponse, error) {
+	return jamfprotect.CountResponse{}, nil
+}
+
+func (s *stubProtectClientBase) ListRiskiestComputers(_ context.Context, _ int, _ string) ([]jamfprotect.RiskyComputer, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetCurrentPermissions(_ context.Context) (jamfprotect.RolePermissions, error) {
+	return jamfprotect.RolePermissions{}, nil
+}
+
+func (s *stubProtectClientBase) ListAnalytics(_ context.Context) ([]jamfprotect.Analytic, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetAnalytic(_ context.Context, _ string) (*jamfprotect.Analytic, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreateAnalytic(_ context.Context, _ jamfprotect.AnalyticInput) (jamfprotect.Analytic, error) {
+	return jamfprotect.Analytic{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateAnalytic(_ context.Context, _ string, _ jamfprotect.AnalyticInput) (jamfprotect.Analytic, error) {
+	return jamfprotect.Analytic{}, nil
+}
+func (s *stubProtectClientBase) DeleteAnalytic(_ context.Context, _ string) error { return nil }
+
+func (s *stubProtectClientBase) ListAnalyticSets(_ context.Context) ([]jamfprotect.AnalyticSet, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetAnalyticSet(_ context.Context, _ string) (*jamfprotect.AnalyticSet, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreateAnalyticSet(_ context.Context, _ jamfprotect.AnalyticSetInput) (jamfprotect.AnalyticSet, error) {
+	return jamfprotect.AnalyticSet{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateAnalyticSet(_ context.Context, _ string, _ jamfprotect.AnalyticSetInput) (jamfprotect.AnalyticSet, error) {
+	return jamfprotect.AnalyticSet{}, nil
+}
+func (s *stubProtectClientBase) DeleteAnalyticSet(_ context.Context, _ string) error { return nil }
+
+func (s *stubProtectClientBase) ListExceptionSets(_ context.Context) ([]jamfprotect.ExceptionSetListItem, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetExceptionSet(_ context.Context, _ string) (*jamfprotect.ExceptionSet, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreateExceptionSet(_ context.Context, _ jamfprotect.ExceptionSetInput) (jamfprotect.ExceptionSet, error) {
+	return jamfprotect.ExceptionSet{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateExceptionSet(_ context.Context, _ string, _ jamfprotect.ExceptionSetInput) (jamfprotect.ExceptionSet, error) {
+	return jamfprotect.ExceptionSet{}, nil
+}
+func (s *stubProtectClientBase) DeleteExceptionSet(_ context.Context, _ string) error { return nil }
+
+func (s *stubProtectClientBase) ListRemovableStorageControlSets(_ context.Context) ([]jamfprotect.RemovableStorageControlSet, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetRemovableStorageControlSet(_ context.Context, _ string) (*jamfprotect.RemovableStorageControlSet, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreateRemovableStorageControlSet(_ context.Context, _ jamfprotect.RemovableStorageControlSetInput) (jamfprotect.RemovableStorageControlSet, error) {
+	return jamfprotect.RemovableStorageControlSet{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateRemovableStorageControlSet(_ context.Context, _ string, _ jamfprotect.RemovableStorageControlSetInput) (jamfprotect.RemovableStorageControlSet, error) {
+	return jamfprotect.RemovableStorageControlSet{}, nil
+}
+
+func (s *stubProtectClientBase) DeleteRemovableStorageControlSet(_ context.Context, _ string) error {
+	return nil
+}
+
+func (s *stubProtectClientBase) ListActionConfigs(_ context.Context) ([]jamfprotect.ActionConfigListItem, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetActionConfig(_ context.Context, _ string) (*jamfprotect.ActionConfig, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreateActionConfig(_ context.Context, _ jamfprotect.ActionConfigInput) (jamfprotect.ActionConfig, error) {
+	return jamfprotect.ActionConfig{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateActionConfig(_ context.Context, _ string, _ jamfprotect.ActionConfigInput) (jamfprotect.ActionConfig, error) {
+	return jamfprotect.ActionConfig{}, nil
+}
+func (s *stubProtectClientBase) DeleteActionConfig(_ context.Context, _ string) error { return nil }
+
+func (s *stubProtectClientBase) ListTelemetriesV2(_ context.Context) ([]jamfprotect.TelemetryV2, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetTelemetryV2(_ context.Context, _ string) (*jamfprotect.TelemetryV2, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreateTelemetryV2(_ context.Context, _ jamfprotect.TelemetryV2Input) (jamfprotect.TelemetryV2, error) {
+	return jamfprotect.TelemetryV2{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateTelemetryV2(_ context.Context, _ string, _ jamfprotect.TelemetryV2Input) (jamfprotect.TelemetryV2, error) {
+	return jamfprotect.TelemetryV2{}, nil
+}
+func (s *stubProtectClientBase) DeleteTelemetryV2(_ context.Context, _ string) error { return nil }
+
+func (s *stubProtectClientBase) ListCustomPreventLists(_ context.Context) ([]jamfprotect.CustomPreventList, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetCustomPreventList(_ context.Context, _ string) (*jamfprotect.CustomPreventList, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreateCustomPreventList(_ context.Context, _ jamfprotect.CustomPreventListInput) (jamfprotect.CustomPreventList, error) {
+	return jamfprotect.CustomPreventList{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateCustomPreventList(_ context.Context, _ string, _ jamfprotect.CustomPreventListInput) (jamfprotect.CustomPreventList, error) {
+	return jamfprotect.CustomPreventList{}, nil
+}
+
+func (s *stubProtectClientBase) DeleteCustomPreventList(_ context.Context, _ string) error {
+	return nil
+}
+
+func (s *stubProtectClientBase) ListUnifiedLoggingFilters(_ context.Context) ([]jamfprotect.UnifiedLoggingFilter, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetUnifiedLoggingFilter(_ context.Context, _ string) (*jamfprotect.UnifiedLoggingFilter, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreateUnifiedLoggingFilter(_ context.Context, _ jamfprotect.UnifiedLoggingFilterInput) (jamfprotect.UnifiedLoggingFilter, error) {
+	return jamfprotect.UnifiedLoggingFilter{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateUnifiedLoggingFilter(_ context.Context, _ string, _ jamfprotect.UnifiedLoggingFilterInput) (jamfprotect.UnifiedLoggingFilter, error) {
+	return jamfprotect.UnifiedLoggingFilter{}, nil
+}
+
+func (s *stubProtectClientBase) DeleteUnifiedLoggingFilter(_ context.Context, _ string) error {
+	return nil
+}
+
+func (s *stubProtectClientBase) ListRoles(_ context.Context) ([]jamfprotect.Role, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetRole(_ context.Context, _ string) (*jamfprotect.Role, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreateRole(_ context.Context, _ jamfprotect.RoleInput) (jamfprotect.Role, error) {
+	return jamfprotect.Role{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateRole(_ context.Context, _ string, _ jamfprotect.RoleInput) (jamfprotect.Role, error) {
+	return jamfprotect.Role{}, nil
+}
+func (s *stubProtectClientBase) DeleteRole(_ context.Context, _ string) error { return nil }
+
+func (s *stubProtectClientBase) ListUsers(_ context.Context) ([]jamfprotect.User, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetUser(_ context.Context, _ string) (*jamfprotect.User, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreateUser(_ context.Context, _ jamfprotect.UserInput) (jamfprotect.User, error) {
+	return jamfprotect.User{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateUser(_ context.Context, _ string, _ jamfprotect.UserInput) (jamfprotect.User, error) {
+	return jamfprotect.User{}, nil
+}
+func (s *stubProtectClientBase) DeleteUser(_ context.Context, _ string) error { return nil }
+
+func (s *stubProtectClientBase) ListGroups(_ context.Context) ([]jamfprotect.Group, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetGroup(_ context.Context, _ string) (*jamfprotect.Group, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreateGroup(_ context.Context, _ jamfprotect.GroupInput) (jamfprotect.Group, error) {
+	return jamfprotect.Group{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateGroup(_ context.Context, _ string, _ jamfprotect.GroupInput) (jamfprotect.Group, error) {
+	return jamfprotect.Group{}, nil
+}
+func (s *stubProtectClientBase) DeleteGroup(_ context.Context, _ string) error { return nil }
+
+func (s *stubProtectClientBase) ListApiClients(_ context.Context) ([]jamfprotect.ApiClient, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) GetApiClient(_ context.Context, _ string) (*jamfprotect.ApiClient, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) CreateApiClient(_ context.Context, _ jamfprotect.ApiClientInput) (jamfprotect.ApiClient, error) {
+	return jamfprotect.ApiClient{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateApiClient(_ context.Context, _ string, _ jamfprotect.ApiClientInput) (jamfprotect.ApiClient, error) {
+	return jamfprotect.ApiClient{}, nil
+}
+func (s *stubProtectClientBase) DeleteApiClient(_ context.Context, _ string) error { return nil }
+
+func (s *stubProtectClientBase) GetDataForwarding(_ context.Context) (jamfprotect.DataForwardingResult, error) {
+	return jamfprotect.DataForwardingResult{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateDataForwarding(_ context.Context, _ jamfprotect.DataForwardingInput) (jamfprotect.DataForwardingResult, error) {
+	return jamfprotect.DataForwardingResult{}, nil
+}
+
+func (s *stubProtectClientBase) GetDataRetention(_ context.Context) (jamfprotect.DataRetentionSettings, error) {
+	return jamfprotect.DataRetentionSettings{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateDataRetention(_ context.Context, _ jamfprotect.DataRetentionInput) (jamfprotect.DataRetentionSettings, error) {
+	return jamfprotect.DataRetentionSettings{}, nil
+}
+
+func (s *stubProtectClientBase) GetOrganizationDownloads(_ context.Context) (jamfprotect.OrganizationDownloads, error) {
+	return jamfprotect.OrganizationDownloads{}, nil
+}
+
+func (s *stubProtectClientBase) GetConfigFreeze(_ context.Context) (jamfprotect.ChangeManagementConfig, error) {
+	return jamfprotect.ChangeManagementConfig{}, nil
+}
+
+func (s *stubProtectClientBase) UpdateOrganizationConfigFreeze(_ context.Context, _ bool) (jamfprotect.ChangeManagementConfig, error) {
+	return jamfprotect.ChangeManagementConfig{}, nil
+}
+
+func (s *stubProtectClientBase) ListConnections(_ context.Context) ([]jamfprotect.Connection, error) {
+	return nil, nil
+}
+
+func (s *stubProtectClientBase) BaseURL() string { return "" }
+func (s *stubProtectClientBase) AccessToken(_ context.Context) (*jamfprotect.Token, error) {
+	return nil, nil
+}
+
+// ─── Test client ─────────────────────────────────────────────────────────────
+
+// protectTokenTestClient overrides AccessToken to return a controllable token.
+type protectTokenTestClient struct {
+	*stubProtectClientBase
+	token *jamfprotect.Token
+	err   error
+}
+
+func (c *protectTokenTestClient) AccessToken(_ context.Context) (*jamfprotect.Token, error) {
+	return c.token, c.err
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// runProtectAuthToken builds a protect auth token command, runs RunE, and
+// returns the parsed JSON output map.
+func runProtectAuthToken(t *testing.T, pc registry.ProtectClient) (map[string]any, error) {
+	t.Helper()
+	out := &captureOutput{}
+	cliCtx := &registry.CLIContext{
+		Output:        out,
+		ProtectClient: pc,
+	}
+	cmd := newProtectAuthTokenCmd(cliCtx)
+	cmd.SetContext(context.Background())
+	if err := cmd.RunE(cmd, nil); err != nil {
+		return nil, err
+	}
+	return parseAuthTokenOutput(t, out.rawData), nil
+}
+
+// ─── Structure test ───────────────────────────────────────────────────────────
+
+func TestProtectAuthTokenSubcommandExists(t *testing.T) {
+	protect := findProtectCmd(t)
+	authCmd := findSubcommand(protect, "auth")
+	if authCmd == nil {
+		t.Fatal("auth command not found under protect")
+	}
+	if findSubcommand(authCmd, "token") == nil {
+		t.Fatal("expected 'token' subcommand under 'protect auth'")
+	}
+}
+
+// ─── RunE tests ──────────────────────────────────────────────────────────────
+
+func TestProtectAuthToken_Output(t *testing.T) {
+	expiry := time.Now().Add(30 * time.Minute)
+	pc := &protectTokenTestClient{
+		stubProtectClientBase: &stubProtectClientBase{},
+		token: &jamfprotect.Token{
+			AccessToken: "protect-jwt",
+			TokenType:   "Bearer",
+			Expiry:      expiry,
+		},
+	}
+	m, err := runProtectAuthToken(t, pc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["token"] != "protect-jwt" {
+		t.Errorf("token = %v, want %q", m["token"], "protect-jwt")
+	}
+	expiresAt, ok := m["expires_at"]
+	if !ok {
+		t.Fatal("expires_at must be present in output")
+	}
+	ts, ok := expiresAt.(string)
+	if !ok {
+		t.Fatalf("expires_at is not a string: %T", expiresAt)
+	}
+	if _, err := time.Parse(time.RFC3339, ts); err != nil {
+		t.Errorf("expires_at %q is not valid RFC3339: %v", ts, err)
+	}
+}
+
+func TestProtectAuthToken_AccessTokenError(t *testing.T) {
+	pc := &protectTokenTestClient{
+		stubProtectClientBase: &stubProtectClientBase{},
+		err:                   fmt.Errorf("protect service unavailable"),
+	}
+	_, err := runProtectAuthToken(t, pc)
+	if err == nil {
+		t.Fatal("expected error from AccessToken failure, got nil")
+	}
+}
+
+// ─── --refresh flag ───────────────────────────────────────────────────────────
+
+func TestProtectAuthToken_Refresh_ClearsCacheBeforeAccessToken(t *testing.T) {
+	expiry := time.Now().Add(30 * time.Minute)
+	pc := &protectTokenTestClient{
+		stubProtectClientBase: &stubProtectClientBase{},
+		token: &jamfprotect.Token{
+			AccessToken: "fresh-protect-token",
+			TokenType:   "Bearer",
+			Expiry:      expiry,
+		},
+	}
+
+	var clearCalled bool
+	out := &captureOutput{}
+	cliCtx := &registry.CLIContext{
+		Output:            out,
+		ProtectClient:     pc,
+		ClearProtectToken: func() { clearCalled = true },
+	}
+	cmd := newProtectAuthTokenCmd(cliCtx)
+	cmd.SetContext(context.Background())
+	if err := cmd.Flags().Set("refresh", "true"); err != nil {
+		t.Fatalf("setting --refresh flag: %v", err)
+	}
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !clearCalled {
+		t.Error("expected ClearProtectToken to be called when --refresh is set")
+	}
+
+	m := parseAuthTokenOutput(t, out.rawData)
+	if m["token"] != "fresh-protect-token" {
+		t.Errorf("token = %v, want %q", m["token"], "fresh-protect-token")
+	}
+}
+
+func TestProtectAuthToken_Refresh_NilClearFunc_NoError(t *testing.T) {
+	// When ClearProtectToken is nil (no disk cache), --refresh is silently ignored.
+	expiry := time.Now().Add(30 * time.Minute)
+	pc := &protectTokenTestClient{
+		stubProtectClientBase: &stubProtectClientBase{},
+		token: &jamfprotect.Token{
+			AccessToken: "nocache-token",
+			Expiry:      expiry,
+		},
+	}
+	out := &captureOutput{}
+	cliCtx := &registry.CLIContext{
+		Output:            out,
+		ProtectClient:     pc,
+		ClearProtectToken: nil, // no cache configured
+	}
+	cmd := newProtectAuthTokenCmd(cliCtx)
+	cmd.SetContext(context.Background())
+	if err := cmd.Flags().Set("refresh", "true"); err != nil {
+		t.Fatalf("setting --refresh flag: %v", err)
+	}
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("unexpected error with nil ClearProtectToken: %v", err)
+	}
+	m := parseAuthTokenOutput(t, out.rawData)
+	if m["token"] != "nocache-token" {
+		t.Errorf("token = %v, want %q", m["token"], "nocache-token")
+	}
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -767,13 +767,16 @@ type clearableProtectCache struct {
 	dir     string
 	mu      sync.Mutex
 	cleared bool
+	lastKey string
 }
 
 func (c *clearableProtectCache) Load(key string) (string, time.Time, bool) {
 	c.mu.Lock()
 	cleared := c.cleared
+	c.lastKey = key
 	c.mu.Unlock()
 	if cleared {
+		_ = os.Remove(filepath.Join(c.dir, "jamfprotect-token-"+key))
 		return "", time.Time{}, false
 	}
 	data, err := os.ReadFile(filepath.Join(c.dir, "jamfprotect-token-"+key))
@@ -807,12 +810,17 @@ func (c *clearableProtectCache) Store(key string, token string, expiresAt time.T
 	return os.WriteFile(filepath.Join(c.dir, "jamfprotect-token-"+key), data, 0o600)
 }
 
-// Clear marks the cache as bypassed so the next Load returns nothing, forcing
-// the SDK to exchange fresh credentials. Store resets the bypass automatically.
+// Clear removes any cached token from disk (if the key is known) and marks the
+// cache as bypassed so the next Load returns nothing, forcing the SDK to
+// exchange fresh credentials. Store resets the bypass automatically.
 func (c *clearableProtectCache) Clear() {
 	c.mu.Lock()
 	c.cleared = true
+	key := c.lastKey
 	c.mu.Unlock()
+	if key != "" {
+		_ = os.Remove(filepath.Join(c.dir, "jamfprotect-token-"+key))
+	}
 }
 
 // resolveProtectClient constructs a Jamf Protect SDK client from config/flags/env

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -416,7 +417,6 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 				"config":     true,
 				"diff":       true,
 				"setup":      true,
-				"platform":   true,
 				"multi":      true,
 			}
 			for c := cmd; c != nil; c = c.Parent() {
@@ -498,6 +498,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 				httpClient = &spinnerClient{inner: httpClient}
 			}
 			cliCtx.Client = httpClient
+			cliCtx.AuthProvider = authProvider
 
 			// Resolve effective profile name and per-profile cooldown setting.
 			resolvedProfile := profile
@@ -585,7 +586,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 	cmd.AddCommand(newProtectCmd(cliCtx))
 
 	// Jamf Platform namespace
-	cmd.AddCommand(newPlatformCmd())
+	cmd.AddCommand(newPlatformCmd(cliCtx))
 
 	// Apply root-level aliases and groups for --help output
 	applyRootAliases(cmd)
@@ -754,6 +755,66 @@ func resolveProduct(cmd *cobra.Command, cfg *config.Config) string {
 	return "pro"
 }
 
+// clearableProtectCache is a jamfprotect.TokenCache that stores tokens on disk
+// (using the same file format as the SDK's built-in FileTokenCache) and
+// supports forced invalidation via Clear(). Clear() marks the cache as bypassed
+// so the next Load call returns nothing, forcing the SDK to exchange fresh
+// credentials. Store resets the bypass flag and persists the new token.
+//
+// The SDK calls Load/Store with a pre-computed key (sha256 of baseURL+clientID),
+// so we use it directly as the filename suffix — no key derivation needed here.
+type clearableProtectCache struct {
+	dir     string
+	mu      sync.Mutex
+	cleared bool
+}
+
+func (c *clearableProtectCache) Load(key string) (string, time.Time, bool) {
+	c.mu.Lock()
+	cleared := c.cleared
+	c.mu.Unlock()
+	if cleared {
+		return "", time.Time{}, false
+	}
+	data, err := os.ReadFile(filepath.Join(c.dir, "jamfprotect-token-"+key))
+	if err != nil {
+		return "", time.Time{}, false
+	}
+	var entry struct {
+		AccessToken string    `json:"access_token"`
+		ExpiresAt   time.Time `json:"expires_at"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil || entry.AccessToken == "" {
+		return "", time.Time{}, false
+	}
+	return entry.AccessToken, entry.ExpiresAt, true
+}
+
+func (c *clearableProtectCache) Store(key string, token string, expiresAt time.Time) error {
+	c.mu.Lock()
+	c.cleared = false
+	c.mu.Unlock()
+	if err := os.MkdirAll(c.dir, 0o700); err != nil {
+		return fmt.Errorf("creating protect token cache dir: %w", err)
+	}
+	data, err := json.Marshal(struct {
+		AccessToken string    `json:"access_token"`
+		ExpiresAt   time.Time `json:"expires_at"`
+	}{token, expiresAt})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(c.dir, "jamfprotect-token-"+key), data, 0o600)
+}
+
+// Clear marks the cache as bypassed so the next Load returns nothing, forcing
+// the SDK to exchange fresh credentials. Store resets the bypass automatically.
+func (c *clearableProtectCache) Clear() {
+	c.mu.Lock()
+	c.cleared = true
+	c.mu.Unlock()
+}
+
 // resolveProtectClient constructs a Jamf Protect SDK client from config/flags/env
 // and assigns it to cliCtx.ProtectClient.
 func resolveProtectClient(cfg *config.Config, cliCtx *registry.CLIContext) error {
@@ -841,7 +902,9 @@ func resolveProtectClient(cfg *config.Config, cliCtx *registry.CLIContext) error
 		jamfprotect.WithHTTPClient(stdClient),
 	}
 	if cacheDir, err := os.UserCacheDir(); err == nil {
-		protectOpts = append(protectOpts, jamfprotect.WithFileTokenCache(filepath.Join(cacheDir, "jamf-cli")))
+		cache := &clearableProtectCache{dir: filepath.Join(cacheDir, "jamf-cli")}
+		protectOpts = append(protectOpts, jamfprotect.WithTokenCache(cache))
+		cliCtx.ClearProtectToken = cache.Clear
 	}
 	sdkClient := jamfprotect.NewClient(url, cid, csecret, protectOpts...)
 	cliCtx.ProtectClient = sdkClient

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Jamf-Concepts/jamf-cli/internal/auth"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
 	"github.com/Jamf-Concepts/jamfprotect-go-sdk/jamfprotect"
 )
@@ -276,9 +277,14 @@ type PlatformClient interface {
 type CLIContext struct {
 	Client              HTTPClient
 	Output              OutputFormatter
+	AuthProvider        auth.Provider // resolved Pro auth provider (nil for Protect commands)
 	ProtectClient       ProtectClient
 	PlatformClient      PlatformClient
 	Uploader            FileUploader   // non-nil for Pro commands; supports streaming uploads
 	ProfileName         string         // resolved profile name; empty when using env-var auth
 	DestructiveCooldown *time.Duration // nil = use default (10s); 0 = disabled
+	// ClearProtectToken, when non-nil, clears the Jamf Protect disk token cache
+	// so the next AccessToken call exchanges fresh credentials. Used by
+	// "protect auth token --refresh". Nil when no disk cache is configured.
+	ClearProtectToken func()
 }


### PR DESCRIPTION
## Summary

- Adds `auth token` subcommand to `pro`, `protect`, and `platform` namespaces for printing valid access tokens (JSON output with `token` and `expires_at` fields, compatible with `--field token` extraction)
- Adds `--refresh` flag to force a fresh credential exchange, bypassing in-memory and disk caches
- Introduces `auth.Refresher` and `auth.Expirer` interfaces on `OAuth2Provider` and `PlatformOAuth2Provider`
- Refactors `protect auth token` output from bare string to structured JSON (matches pro/platform format)
- Adds `clearableProtectCache` wrapping the Protect SDK's token cache with `Clear()` support for `--refresh`
- Exposes `AuthProvider` and `ClearProtectToken` on `CLIContext` for command-level access
- 18 new tests covering structure, output format, expiry handling, refresh behaviour, and error paths

## ⚠️ Breaking change

`protect auth token` previously printed a bare token string. It now outputs structured JSON matching the `pro` and `platform` format:

```json
{
  "token": "...",
  "expires_at": "2026-04-14T12:30:00Z"
}
```

Scripts piping the old bare output should switch to `protect auth token --field token` for the raw string.

## Test plan

- [x] `go test -run "TestPro.*Auth|TestPlatform.*Auth|TestProtect.*Auth" ./internal/commands/...` — all 18 pass
- [x] Manual: `jamf-cli pro auth token` with oauth2 profile → JSON with token + expires_at
- [x] Manual: `jamf-cli pro auth token --field token` → bare token string
- [x] Manual: `jamf-cli pro auth token --refresh` → new token (different from cached)
- [x] Manual: `jamf-cli protect auth token` → JSON output
- [x] Manual: `jamf-cli platform auth token` with platform profile → JSON output

Closes: #132 

🤖 Generated with [Claude Code](https://claude.com/claude-code)