### PR TITLE
feat: handle optimistic locking for prestage commands

### DIFF
--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -271,7 +271,14 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 			}
 			return "{id}"
 		},
-		"hasSuffix":       strings.HasSuffix,
+		"hasSuffix": strings.HasSuffix,
+		"opHasVersionLock": func(op *Operation) bool {
+			if op.RequestBody == nil || op.RequestBody.Schema == nil {
+				return false
+			}
+			_, ok := op.RequestBody.Schema.Properties["versionLock"]
+			return ok
+		},
 		"isPatchOp":       isPatchOp,
 		"hasPatchOp":      hasPatchOp,
 		"patchHasLookup":  func(r *Resource) bool { return patchHasLookup(r) },
@@ -1516,7 +1523,7 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 			} else {
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-{{- if $.HasVersionLock }}
+{{- if opHasVersionLock . }}
 					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
 					if err != nil {
 						return fmt.Errorf("reading stdin: %w", err)
@@ -1550,11 +1557,11 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 				if err != nil {
 					return err
 				}
-{{- if and $.HasVersionLock (eq .Name "create") }}
+{{- if and (opHasVersionLock .) (eq .Name "create") }}
 
 				// Optimistic locking: new resources require versionLock 0
 				normalized = setVersionLockZero(normalized)
-{{- else if and $.HasVersionLock (ne .Name "create") }}
+{{- else if and (opHasVersionLock .) (ne .Name "create") }}
 
 				// Optimistic locking: fetch current versionLock and inject into request
 {{- if hasSuffix .Path "/delete-multiple" }}
@@ -1866,13 +1873,8 @@ func resolveNameToID(ctx context.Context, client registry.HTTPClient, listPath, 
 	}
 
 	// Client-side filter: some endpoints ignore RSQL filter params (e.g. prestages).
-	// When we asked for page-size=1 but got more, the server ignored our filter.
-	// Fall back to exact client-side name matching.
-	results := data.Results
-	if len(results) > 1 {
-		results = filterResultsByName(results, nameField, name)
-	}
-
+	// Always verify the returned result actually matches the requested name.
+	results := filterResultsByName(data.Results, nameField, name)
 	if len(results) == 0 {
 		return "", fmt.Errorf("no resource found with name %q", name)
 	}

--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -271,6 +271,7 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 			}
 			return "{id}"
 		},
+		"hasSuffix":       strings.HasSuffix,
 		"isPatchOp":       isPatchOp,
 		"hasPatchOp":      hasPatchOp,
 		"patchHasLookup":  func(r *Resource) bool { return patchHasLookup(r) },
@@ -1515,7 +1516,27 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 			} else {
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
+{{- if $.HasVersionLock }}
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized, err := normalizeInputToJSON(raw)
+					if err != nil {
+						return err
+					}
+					vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, strings.TrimSuffix(path, "/delete-multiple"))
+					if vlErr != nil {
+						return vlErr
+					}
+					normalized, vlErr = injectVersionLocks(normalized, vlResp)
+					if vlErr != nil {
+						return vlErr
+					}
+					body = bytes.NewReader(normalized)
+{{- else }}
 					body = os.Stdin
+{{- end }}
 				}
 			}
 {{- else }}
@@ -1529,6 +1550,26 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 				if err != nil {
 					return err
 				}
+{{- if and $.HasVersionLock (eq .Name "create") }}
+
+				// Optimistic locking: new resources require versionLock 0
+				normalized = setVersionLockZero(normalized)
+{{- else if and $.HasVersionLock (ne .Name "create") }}
+
+				// Optimistic locking: fetch current versionLock and inject into request
+{{- if hasSuffix .Path "/delete-multiple" }}
+				vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, strings.TrimSuffix(path, "/delete-multiple"))
+{{- else }}
+				vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, path)
+{{- end }}
+				if vlErr != nil {
+					return vlErr
+				}
+				normalized, vlErr = injectVersionLocks(normalized, vlResp)
+				if vlErr != nil {
+					return vlErr
+				}
+{{- end }}
 				body = bytes.NewReader(normalized)
 			}
 {{- end }}
@@ -1695,6 +1736,9 @@ If not, a new resource is created.` + "`" + `,
 					fmt.Fprintf(os.Stderr, "[dry-run] Would create {{ .NameSingular }} %q\n", name)
 					return nil
 				}
+{{- if .HasVersionLock }}
+				data = setVersionLockZero(data)
+{{- end }}
 				resp, err := ctx.Client.Do(reqCtx, "POST", "{{ createPath .Operations }}", bytes.NewReader(data))
 				if err != nil {
 					return err
@@ -1722,6 +1766,16 @@ If not, a new resource is created.` + "`" + `,
 			}
 
 			updatePath := strings.Replace("{{ updatePath .Operations }}", "{{ updatePathParam .Operations }}", url.PathEscape(id), 1)
+{{- if .HasVersionLock }}
+			vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, updatePath)
+			if vlErr != nil {
+				return vlErr
+			}
+			data, vlErr = injectVersionLocks(data, vlResp)
+			if vlErr != nil {
+				return vlErr
+			}
+{{- end }}
 			resp, err := ctx.Client.Do(reqCtx, "PUT", updatePath, bytes.NewReader(data))
 			if err != nil {
 				return err
@@ -1811,8 +1865,20 @@ func resolveNameToID(ctx context.Context, client registry.HTTPClient, listPath, 
 		return "", fmt.Errorf("no resource found with name %q", name)
 	}
 
+	// Client-side filter: some endpoints ignore RSQL filter params (e.g. prestages).
+	// When we asked for page-size=1 but got more, the server ignored our filter.
+	// Fall back to exact client-side name matching.
+	results := data.Results
+	if len(results) > 1 {
+		results = filterResultsByName(results, nameField, name)
+	}
+
+	if len(results) == 0 {
+		return "", fmt.Errorf("no resource found with name %q", name)
+	}
+
 	var first map[string]any
-	if err := json.Unmarshal(data.Results[0], &first); err != nil {
+	if err := json.Unmarshal(results[0], &first); err != nil {
 		return "", fmt.Errorf("parsing lookup result: %w", err)
 	}
 
@@ -1833,6 +1899,25 @@ func extractIDString(obj map[string]any, field string) string {
 	default:
 		return ""
 	}
+}
+
+// filterResultsByName filters JSON results to those with an exact name match.
+// Some API endpoints ignore RSQL filter params (e.g. prestages) and return all
+// results. This provides a client-side fallback for accurate name resolution.
+func filterResultsByName(results []json.RawMessage, nameField, name string) []json.RawMessage {
+	var filtered []json.RawMessage
+	for _, raw := range results {
+		var obj map[string]any
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			continue
+		}
+		if v, ok := obj[nameField]; ok {
+			if s, ok := v.(string); ok && s == name {
+				filtered = append(filtered, raw)
+			}
+		}
+	}
+	return filtered
 }
 
 // readApplyInput reads input from --from-file or stdin for apply commands.
@@ -1952,12 +2037,19 @@ func resolveNameToIDForApply(ctx context.Context, client registry.HTTPClient, li
 		return "", nil // Not found — caller should create
 	}
 
+	// Client-side filter: some endpoints ignore RSQL filter params (e.g. prestages).
+	// Always apply exact name matching to guard against false positives.
+	results := filterResultsByName(data.Results, nameField, name)
+	if len(results) == 0 {
+		return "", nil // Not found — caller should create
+	}
+
 	// Parse results to extract IDs
 	type applyMatch struct {
 		id string
 	}
 	var matches []applyMatch
-	for _, raw := range data.Results {
+	for _, raw := range results {
 		var obj map[string]any
 		if err := json.Unmarshal(raw, &obj); err != nil {
 			continue
@@ -2051,5 +2143,88 @@ func parsePatchValue(s string) any {
 		return i
 	}
 	return s
+}
+
+// fetchVersionLock GETs a resource and returns the raw response body.
+// The caller uses this to extract versionLock values for optimistic locking.
+func fetchVersionLock(ctx context.Context, client registry.HTTPClient, getPath string) ([]byte, error) {
+	resp, err := client.Do(ctx, "GET", getPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetching resource for version lock: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading version lock response: %w", err)
+	}
+	return body, nil
+}
+
+// injectVersionLocks deep-merges all versionLock fields from a GET response
+// into the user-provided request body. This ensures optimistic locking fields
+// are current without requiring users to manually fetch and set them.
+func injectVersionLocks(data, serverResponse []byte) ([]byte, error) {
+	var dst, src map[string]any
+	if err := json.Unmarshal(data, &dst); err != nil {
+		return data, nil // unparseable input — pass through unchanged
+	}
+	if err := json.Unmarshal(serverResponse, &src); err != nil {
+		return data, fmt.Errorf("parsing server response for version lock: %w", err)
+	}
+	mergeVersionLocks(dst, src)
+	out, err := json.Marshal(dst)
+	if err != nil {
+		return data, nil
+	}
+	return out, nil
+}
+
+// mergeVersionLocks recursively copies versionLock fields from src into dst.
+func mergeVersionLocks(dst, src map[string]any) {
+	if vl, ok := src["versionLock"]; ok {
+		dst["versionLock"] = vl
+	}
+	for key, srcVal := range src {
+		srcObj, ok := srcVal.(map[string]any)
+		if !ok {
+			continue
+		}
+		dstVal, ok := dst[key]
+		if !ok {
+			continue
+		}
+		dstObj, ok := dstVal.(map[string]any)
+		if !ok {
+			continue
+		}
+		mergeVersionLocks(dstObj, srcObj)
+	}
+}
+
+// setVersionLockZero recursively sets all versionLock fields to 0 in the JSON document.
+// Used when creating new resources that require optimistic locking.
+func setVersionLockZero(data []byte) []byte {
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	zeroVersionLocks(obj)
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return data
+	}
+	return out
+}
+
+// zeroVersionLocks recursively sets all versionLock fields to 0.
+func zeroVersionLocks(obj map[string]any) {
+	if _, ok := obj["versionLock"]; ok {
+		obj["versionLock"] = 0
+	}
+	for _, v := range obj {
+		if nested, ok := v.(map[string]any); ok {
+			zeroVersionLocks(nested)
+		}
+	}
 }
 `

--- a/generator/parser/parser.go
+++ b/generator/parser/parser.go
@@ -278,6 +278,9 @@ func ParseSpec(specPath string) ([]*Resource, error) {
 		resource.GoName = strcase.ToCamel(resourceName)
 	}
 
+	// Detect optimistic locking (prestages use versionLock in PUT/POST request bodies).
+	resource.HasVersionLock = detectVersionLock(allOps)
+
 	return []*Resource{resource}, nil
 }
 
@@ -374,6 +377,7 @@ func splitByPathFamilies(description string, ops []*Operation, schemas map[strin
 					}
 				}
 			}
+			r.HasVersionLock = detectVersionLock(familyOps)
 
 			resources = append(resources, r)
 		}
@@ -461,6 +465,7 @@ func splitByPathFamilies(description string, ops []*Operation, schemas map[strin
 				}
 			}
 		}
+		r.HasVersionLock = detectVersionLock(parentOps)
 		resources = append(resources, r)
 
 		for _, op := range parentOps {
@@ -581,6 +586,24 @@ func pathToResourceName(path string) string {
 		}
 	}
 	return strings.ReplaceAll(path, "/", "-")
+}
+
+// detectVersionLock returns true if any PUT or POST request body in the resource
+// includes a versionLock property. This indicates the resource uses optimistic
+// locking (prestages and prestage scopes).
+func detectVersionLock(ops []*Operation) bool {
+	for _, op := range ops {
+		if op.Method != "PUT" && op.Method != "POST" {
+			continue
+		}
+		if op.RequestBody == nil || op.RequestBody.Schema == nil {
+			continue
+		}
+		if _, ok := op.RequestBody.Schema.Properties["versionLock"]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // detectSingleton returns true if the operations describe a singleton resource:

--- a/generator/parser/parser_test.go
+++ b/generator/parser/parser_test.go
@@ -712,6 +712,92 @@ func TestDetectSingleton(t *testing.T) {
 	}
 }
 
+func TestDetectVersionLock(t *testing.T) {
+	versionLockSchema := &Schema{
+		Properties: map[string]*Property{
+			"displayName": {Name: "displayName", Type: "string"},
+			"versionLock": {Name: "versionLock", Type: "integer"},
+		},
+	}
+	noVersionLockSchema := &Schema{
+		Properties: map[string]*Property{
+			"name": {Name: "name", Type: "string"},
+		},
+	}
+
+	tests := []struct {
+		name string
+		ops  []*Operation
+		want bool
+	}{
+		{
+			name: "PUT with versionLock in request body",
+			ops: []*Operation{
+				{Name: "list", Method: "GET", Path: "/v3/computer-prestages"},
+				{
+					Name: "update", Method: "PUT", Path: "/v3/computer-prestages/{id}",
+					RequestBody: &RequestBody{Schema: versionLockSchema},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "POST with versionLock in request body",
+			ops: []*Operation{
+				{
+					Name: "create-scope", Method: "POST", Path: "/v2/computer-prestages/{id}/scope",
+					RequestBody: &RequestBody{Schema: versionLockSchema},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no versionLock in any request body",
+			ops: []*Operation{
+				{Name: "list", Method: "GET", Path: "/v1/buildings"},
+				{
+					Name: "create", Method: "POST", Path: "/v1/buildings",
+					RequestBody: &RequestBody{Schema: noVersionLockSchema},
+				},
+				{
+					Name: "update", Method: "PUT", Path: "/v1/buildings/{id}",
+					RequestBody: &RequestBody{Schema: noVersionLockSchema},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "GET-only operations (no request body)",
+			ops: []*Operation{
+				{Name: "list", Method: "GET", Path: "/v1/things"},
+				{Name: "get", Method: "GET", Path: "/v1/things/{id}"},
+			},
+			want: false,
+		},
+		{
+			name: "nil request body on PUT",
+			ops: []*Operation{
+				{Name: "update", Method: "PUT", Path: "/v1/things/{id}"},
+			},
+			want: false,
+		},
+		{
+			name: "empty operations",
+			ops:  []*Operation{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectVersionLock(tt.ops)
+			if got != tt.want {
+				t.Errorf("detectVersionLock() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseSpec_SingletonSpec(t *testing.T) {
 	dir := t.TempDir()
 	specPath := filepath.Join(dir, "CacheSettings.yaml")

--- a/generator/parser/types.go
+++ b/generator/parser/types.go
@@ -24,6 +24,7 @@ type Resource struct {
 	LookupFields      []LookupField // Alternate identifier fields for patch-by-name / delete-by-name (e.g. serial number)
 	NameLookupPath    string        // Override list path for name resolution (when the standard list endpoint ignores RSQL)
 	NameLookupIDField string        // Override ID field extracted from NameLookupPath response (when it differs from IDField)
+	HasVersionLock    bool          // True when PUT/POST request body includes versionLock (optimistic locking for prestages)
 }
 
 // Operation represents an API operation (endpoint)

--- a/internal/commands/pro/generated/computer_prestage_scopes.go
+++ b/internal/commands/pro/generated/computer_prestage_scopes.go
@@ -150,7 +150,23 @@ func newComputerPrestageScopesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra
 			} else {
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized, err := normalizeInputToJSON(raw)
+					if err != nil {
+						return err
+					}
+					vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, strings.TrimSuffix(path, "/delete-multiple"))
+					if vlErr != nil {
+						return vlErr
+					}
+					normalized, vlErr = injectVersionLocks(normalized, vlResp)
+					if vlErr != nil {
+						return vlErr
+					}
+					body = bytes.NewReader(normalized)
 				}
 			}
 			resp, err := ctx.Client.Do(reqCtx, "POST", path, body)
@@ -256,6 +272,16 @@ func newComputerPrestageScopesCreateScopeCmd(ctx *registry.CLIContext) *cobra.Co
 				if err != nil {
 					return err
 				}
+
+				// Optimistic locking: fetch current versionLock and inject into request
+				vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, path)
+				if vlErr != nil {
+					return vlErr
+				}
+				normalized, vlErr = injectVersionLocks(normalized, vlResp)
+				if vlErr != nil {
+					return vlErr
+				}
 				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "POST", path, body)
@@ -318,6 +344,16 @@ func newComputerPrestageScopesUpdateScopeCmd(ctx *registry.CLIContext) *cobra.Co
 				normalized, err := normalizeInputToJSON(raw)
 				if err != nil {
 					return err
+				}
+
+				// Optimistic locking: fetch current versionLock and inject into request
+				vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, path)
+				if vlErr != nil {
+					return vlErr
+				}
+				normalized, vlErr = injectVersionLocks(normalized, vlResp)
+				if vlErr != nil {
+					return vlErr
 				}
 				body = bytes.NewReader(normalized)
 			}

--- a/internal/commands/pro/generated/computer_prestages.go
+++ b/internal/commands/pro/generated/computer_prestages.go
@@ -313,9 +313,6 @@ func newComputerPrestagesCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 				if err != nil {
 					return err
 				}
-
-				// Optimistic locking: new resources require versionLock 0
-				normalized = setVersionLockZero(normalized)
 				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "POST", path, body)

--- a/internal/commands/pro/generated/computer_prestages.go
+++ b/internal/commands/pro/generated/computer_prestages.go
@@ -313,6 +313,9 @@ func newComputerPrestagesCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 				if err != nil {
 					return err
 				}
+
+				// Optimistic locking: new resources require versionLock 0
+				normalized = setVersionLockZero(normalized)
 				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "POST", path, body)
@@ -437,6 +440,16 @@ func newComputerPrestagesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 				normalized, err := normalizeInputToJSON(raw)
 				if err != nil {
 					return err
+				}
+
+				// Optimistic locking: fetch current versionLock and inject into request
+				vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, path)
+				if vlErr != nil {
+					return vlErr
+				}
+				normalized, vlErr = injectVersionLocks(normalized, vlResp)
+				if vlErr != nil {
+					return vlErr
 				}
 				body = bytes.NewReader(normalized)
 			}
@@ -678,6 +691,7 @@ If not, a new resource is created.`,
 					fmt.Fprintf(os.Stderr, "[dry-run] Would create computer-prestage %q\n", name)
 					return nil
 				}
+				data = setVersionLockZero(data)
 				resp, err := ctx.Client.Do(reqCtx, "POST", "/v3/computer-prestages", bytes.NewReader(data))
 				if err != nil {
 					return err
@@ -705,6 +719,14 @@ If not, a new resource is created.`,
 			}
 
 			updatePath := strings.Replace("/v3/computer-prestages/{id}", "{id}", url.PathEscape(id), 1)
+			vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, updatePath)
+			if vlErr != nil {
+				return vlErr
+			}
+			data, vlErr = injectVersionLocks(data, vlResp)
+			if vlErr != nil {
+				return vlErr
+			}
 			resp, err := ctx.Client.Do(reqCtx, "PUT", updatePath, bytes.NewReader(data))
 			if err != nil {
 				return err

--- a/internal/commands/pro/generated/mobile_device_prestage_scopes.go
+++ b/internal/commands/pro/generated/mobile_device_prestage_scopes.go
@@ -150,7 +150,23 @@ func newMobileDevicePrestageScopesDeleteMultipleCmd(ctx *registry.CLIContext) *c
 			} else {
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized, err := normalizeInputToJSON(raw)
+					if err != nil {
+						return err
+					}
+					vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, strings.TrimSuffix(path, "/delete-multiple"))
+					if vlErr != nil {
+						return vlErr
+					}
+					normalized, vlErr = injectVersionLocks(normalized, vlResp)
+					if vlErr != nil {
+						return vlErr
+					}
+					body = bytes.NewReader(normalized)
 				}
 			}
 			resp, err := ctx.Client.Do(reqCtx, "POST", path, body)
@@ -256,6 +272,16 @@ func newMobileDevicePrestageScopesCreateScopeCmd(ctx *registry.CLIContext) *cobr
 				if err != nil {
 					return err
 				}
+
+				// Optimistic locking: fetch current versionLock and inject into request
+				vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, path)
+				if vlErr != nil {
+					return vlErr
+				}
+				normalized, vlErr = injectVersionLocks(normalized, vlResp)
+				if vlErr != nil {
+					return vlErr
+				}
 				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "POST", path, body)
@@ -318,6 +344,16 @@ func newMobileDevicePrestageScopesUpdateScopeCmd(ctx *registry.CLIContext) *cobr
 				normalized, err := normalizeInputToJSON(raw)
 				if err != nil {
 					return err
+				}
+
+				// Optimistic locking: fetch current versionLock and inject into request
+				vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, path)
+				if vlErr != nil {
+					return vlErr
+				}
+				normalized, vlErr = injectVersionLocks(normalized, vlResp)
+				if vlErr != nil {
+					return vlErr
 				}
 				body = bytes.NewReader(normalized)
 			}

--- a/internal/commands/pro/generated/mobile_device_prestages.go
+++ b/internal/commands/pro/generated/mobile_device_prestages.go
@@ -327,9 +327,6 @@ func newMobileDevicePrestagesCreateCmd(ctx *registry.CLIContext) *cobra.Command 
 				if err != nil {
 					return err
 				}
-
-				// Optimistic locking: new resources require versionLock 0
-				normalized = setVersionLockZero(normalized)
 				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "POST", path, body)
@@ -706,23 +703,7 @@ func newMobileDevicePrestagesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.
 			} else {
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
-					if err != nil {
-						return fmt.Errorf("reading stdin: %w", err)
-					}
-					normalized, err := normalizeInputToJSON(raw)
-					if err != nil {
-						return err
-					}
-					vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, strings.TrimSuffix(path, "/delete-multiple"))
-					if vlErr != nil {
-						return vlErr
-					}
-					normalized, vlErr = injectVersionLocks(normalized, vlResp)
-					if vlErr != nil {
-						return vlErr
-					}
-					body = bytes.NewReader(normalized)
+					body = os.Stdin
 				}
 			}
 			resp, err := ctx.Client.Do(reqCtx, "POST", path, body)
@@ -949,16 +930,6 @@ func newMobileDevicePrestagesAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.
 				normalized, err := normalizeInputToJSON(raw)
 				if err != nil {
 					return err
-				}
-
-				// Optimistic locking: fetch current versionLock and inject into request
-				vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, path)
-				if vlErr != nil {
-					return vlErr
-				}
-				normalized, vlErr = injectVersionLocks(normalized, vlResp)
-				if vlErr != nil {
-					return vlErr
 				}
 				body = bytes.NewReader(normalized)
 			}

--- a/internal/commands/pro/generated/mobile_device_prestages.go
+++ b/internal/commands/pro/generated/mobile_device_prestages.go
@@ -327,6 +327,9 @@ func newMobileDevicePrestagesCreateCmd(ctx *registry.CLIContext) *cobra.Command 
 				if err != nil {
 					return err
 				}
+
+				// Optimistic locking: new resources require versionLock 0
+				normalized = setVersionLockZero(normalized)
 				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "POST", path, body)
@@ -458,6 +461,16 @@ func newMobileDevicePrestagesUpdateCmd(ctx *registry.CLIContext) *cobra.Command 
 				normalized, err := normalizeInputToJSON(raw)
 				if err != nil {
 					return err
+				}
+
+				// Optimistic locking: fetch current versionLock and inject into request
+				vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, path)
+				if vlErr != nil {
+					return vlErr
+				}
+				normalized, vlErr = injectVersionLocks(normalized, vlResp)
+				if vlErr != nil {
+					return vlErr
 				}
 				body = bytes.NewReader(normalized)
 			}
@@ -693,7 +706,23 @@ func newMobileDevicePrestagesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.
 			} else {
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized, err := normalizeInputToJSON(raw)
+					if err != nil {
+						return err
+					}
+					vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, strings.TrimSuffix(path, "/delete-multiple"))
+					if vlErr != nil {
+						return vlErr
+					}
+					normalized, vlErr = injectVersionLocks(normalized, vlResp)
+					if vlErr != nil {
+						return vlErr
+					}
+					body = bytes.NewReader(normalized)
 				}
 			}
 			resp, err := ctx.Client.Do(reqCtx, "POST", path, body)
@@ -920,6 +949,16 @@ func newMobileDevicePrestagesAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.
 				normalized, err := normalizeInputToJSON(raw)
 				if err != nil {
 					return err
+				}
+
+				// Optimistic locking: fetch current versionLock and inject into request
+				vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, path)
+				if vlErr != nil {
+					return vlErr
+				}
+				normalized, vlErr = injectVersionLocks(normalized, vlResp)
+				if vlErr != nil {
+					return vlErr
 				}
 				body = bytes.NewReader(normalized)
 			}
@@ -1182,6 +1221,7 @@ If not, a new resource is created.`,
 					fmt.Fprintf(os.Stderr, "[dry-run] Would create mobile-device-prestage %q\n", name)
 					return nil
 				}
+				data = setVersionLockZero(data)
 				resp, err := ctx.Client.Do(reqCtx, "POST", "/v3/mobile-device-prestages", bytes.NewReader(data))
 				if err != nil {
 					return err
@@ -1209,6 +1249,14 @@ If not, a new resource is created.`,
 			}
 
 			updatePath := strings.Replace("/v3/mobile-device-prestages/{id}", "{id}", url.PathEscape(id), 1)
+			vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, updatePath)
+			if vlErr != nil {
+				return vlErr
+			}
+			data, vlErr = injectVersionLocks(data, vlResp)
+			if vlErr != nil {
+				return vlErr
+			}
 			resp, err := ctx.Client.Do(reqCtx, "PUT", updatePath, bytes.NewReader(data))
 			if err != nil {
 				return err

--- a/internal/commands/pro/generated/registry.go
+++ b/internal/commands/pro/generated/registry.go
@@ -220,13 +220,8 @@ func resolveNameToID(ctx context.Context, client registry.HTTPClient, listPath, 
 	}
 
 	// Client-side filter: some endpoints ignore RSQL filter params (e.g. prestages).
-	// When we asked for page-size=1 but got more, the server ignored our filter.
-	// Fall back to exact client-side name matching.
-	results := data.Results
-	if len(results) > 1 {
-		results = filterResultsByName(results, nameField, name)
-	}
-
+	// Always verify the returned result actually matches the requested name.
+	results := filterResultsByName(data.Results, nameField, name)
 	if len(results) == 0 {
 		return "", fmt.Errorf("no resource found with name %q", name)
 	}

--- a/internal/commands/pro/generated/registry.go
+++ b/internal/commands/pro/generated/registry.go
@@ -219,8 +219,20 @@ func resolveNameToID(ctx context.Context, client registry.HTTPClient, listPath, 
 		return "", fmt.Errorf("no resource found with name %q", name)
 	}
 
+	// Client-side filter: some endpoints ignore RSQL filter params (e.g. prestages).
+	// When we asked for page-size=1 but got more, the server ignored our filter.
+	// Fall back to exact client-side name matching.
+	results := data.Results
+	if len(results) > 1 {
+		results = filterResultsByName(results, nameField, name)
+	}
+
+	if len(results) == 0 {
+		return "", fmt.Errorf("no resource found with name %q", name)
+	}
+
 	var first map[string]any
-	if err := json.Unmarshal(data.Results[0], &first); err != nil {
+	if err := json.Unmarshal(results[0], &first); err != nil {
 		return "", fmt.Errorf("parsing lookup result: %w", err)
 	}
 
@@ -241,6 +253,25 @@ func extractIDString(obj map[string]any, field string) string {
 	default:
 		return ""
 	}
+}
+
+// filterResultsByName filters JSON results to those with an exact name match.
+// Some API endpoints ignore RSQL filter params (e.g. prestages) and return all
+// results. This provides a client-side fallback for accurate name resolution.
+func filterResultsByName(results []json.RawMessage, nameField, name string) []json.RawMessage {
+	var filtered []json.RawMessage
+	for _, raw := range results {
+		var obj map[string]any
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			continue
+		}
+		if v, ok := obj[nameField]; ok {
+			if s, ok := v.(string); ok && s == name {
+				filtered = append(filtered, raw)
+			}
+		}
+	}
+	return filtered
 }
 
 // readApplyInput reads input from --from-file or stdin for apply commands.
@@ -360,12 +391,19 @@ func resolveNameToIDForApply(ctx context.Context, client registry.HTTPClient, li
 		return "", nil // Not found — caller should create
 	}
 
+	// Client-side filter: some endpoints ignore RSQL filter params (e.g. prestages).
+	// Always apply exact name matching to guard against false positives.
+	results := filterResultsByName(data.Results, nameField, name)
+	if len(results) == 0 {
+		return "", nil // Not found — caller should create
+	}
+
 	// Parse results to extract IDs
 	type applyMatch struct {
 		id string
 	}
 	var matches []applyMatch
-	for _, raw := range data.Results {
+	for _, raw := range results {
 		var obj map[string]any
 		if err := json.Unmarshal(raw, &obj); err != nil {
 			continue
@@ -457,4 +495,87 @@ func parsePatchValue(s string) any {
 		return i
 	}
 	return s
+}
+
+// fetchVersionLock GETs a resource and returns the raw response body.
+// The caller uses this to extract versionLock values for optimistic locking.
+func fetchVersionLock(ctx context.Context, client registry.HTTPClient, getPath string) ([]byte, error) {
+	resp, err := client.Do(ctx, "GET", getPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetching resource for version lock: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading version lock response: %w", err)
+	}
+	return body, nil
+}
+
+// injectVersionLocks deep-merges all versionLock fields from a GET response
+// into the user-provided request body. This ensures optimistic locking fields
+// are current without requiring users to manually fetch and set them.
+func injectVersionLocks(data, serverResponse []byte) ([]byte, error) {
+	var dst, src map[string]any
+	if err := json.Unmarshal(data, &dst); err != nil {
+		return data, nil // unparseable input — pass through unchanged
+	}
+	if err := json.Unmarshal(serverResponse, &src); err != nil {
+		return data, fmt.Errorf("parsing server response for version lock: %w", err)
+	}
+	mergeVersionLocks(dst, src)
+	out, err := json.Marshal(dst)
+	if err != nil {
+		return data, nil
+	}
+	return out, nil
+}
+
+// mergeVersionLocks recursively copies versionLock fields from src into dst.
+func mergeVersionLocks(dst, src map[string]any) {
+	if vl, ok := src["versionLock"]; ok {
+		dst["versionLock"] = vl
+	}
+	for key, srcVal := range src {
+		srcObj, ok := srcVal.(map[string]any)
+		if !ok {
+			continue
+		}
+		dstVal, ok := dst[key]
+		if !ok {
+			continue
+		}
+		dstObj, ok := dstVal.(map[string]any)
+		if !ok {
+			continue
+		}
+		mergeVersionLocks(dstObj, srcObj)
+	}
+}
+
+// setVersionLockZero recursively sets all versionLock fields to 0 in the JSON document.
+// Used when creating new resources that require optimistic locking.
+func setVersionLockZero(data []byte) []byte {
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	zeroVersionLocks(obj)
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return data
+	}
+	return out
+}
+
+// zeroVersionLocks recursively sets all versionLock fields to 0.
+func zeroVersionLocks(obj map[string]any) {
+	if _, ok := obj["versionLock"]; ok {
+		obj["versionLock"] = 0
+	}
+	for _, v := range obj {
+		if nested, ok := v.(map[string]any); ok {
+			zeroVersionLocks(nested)
+		}
+	}
 }

--- a/internal/commands/pro/generated/version_lock_test.go
+++ b/internal/commands/pro/generated/version_lock_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026, Jamf Software LLC
+
+package generated
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSetVersionLockZero(t *testing.T) {
+	t.Run("sets top-level versionLock to 0", func(t *testing.T) {
+		input := []byte(`{"displayName":"Test","versionLock":42}`)
+		got := parseJSON(t, setVersionLockZero(input))
+		if vl := got["versionLock"]; vl != float64(0) {
+			t.Errorf("versionLock = %v, want 0", vl)
+		}
+	})
+
+	t.Run("adds versionLock when missing", func(t *testing.T) {
+		input := []byte(`{"displayName":"Test"}`)
+		got := parseJSON(t, setVersionLockZero(input))
+		// versionLock was not present, so it should NOT be added
+		// (zeroVersionLocks only modifies existing fields)
+		if _, ok := got["versionLock"]; ok {
+			t.Error("expected versionLock to not be added when absent")
+		}
+	})
+
+	t.Run("zeros nested versionLock fields", func(t *testing.T) {
+		input := []byte(`{
+			"displayName": "Test",
+			"versionLock": 5,
+			"locationInformation": {"versionLock": 10, "room": "A1"},
+			"purchasingInformation": {"versionLock": 20, "vendor": "Apple"}
+		}`)
+		got := parseJSON(t, setVersionLockZero(input))
+		if vl := got["versionLock"]; vl != float64(0) {
+			t.Errorf("top-level versionLock = %v, want 0", vl)
+		}
+		loc := got["locationInformation"].(map[string]any)
+		if vl := loc["versionLock"]; vl != float64(0) {
+			t.Errorf("locationInformation.versionLock = %v, want 0", vl)
+		}
+		purch := got["purchasingInformation"].(map[string]any)
+		if vl := purch["versionLock"]; vl != float64(0) {
+			t.Errorf("purchasingInformation.versionLock = %v, want 0", vl)
+		}
+	})
+
+	t.Run("invalid JSON returns input unchanged", func(t *testing.T) {
+		input := []byte(`not json`)
+		out := setVersionLockZero(input)
+		if string(out) != string(input) {
+			t.Errorf("expected unchanged input, got %s", out)
+		}
+	})
+}
+
+func TestInjectVersionLocks(t *testing.T) {
+	t.Run("injects top-level versionLock from server response", func(t *testing.T) {
+		userData := []byte(`{"displayName":"Test","versionLock":0}`)
+		serverResp := []byte(`{"displayName":"Test","versionLock":42,"id":"1"}`)
+		out, err := injectVersionLocks(userData, serverResp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := parseJSON(t, out)
+		if vl := got["versionLock"]; vl != float64(42) {
+			t.Errorf("versionLock = %v, want 42", vl)
+		}
+	})
+
+	t.Run("injects nested versionLock fields", func(t *testing.T) {
+		userData := []byte(`{
+			"displayName": "Test",
+			"versionLock": 0,
+			"locationInformation": {"versionLock": 0, "room": "A1"},
+			"purchasingInformation": {"versionLock": 0, "vendor": "Apple"}
+		}`)
+		serverResp := []byte(`{
+			"displayName": "Test",
+			"versionLock": 10,
+			"locationInformation": {"versionLock": 5, "room": "B2", "id": "49"},
+			"purchasingInformation": {"versionLock": 3, "id": "1"}
+		}`)
+		out, err := injectVersionLocks(userData, serverResp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := parseJSON(t, out)
+		if vl := got["versionLock"]; vl != float64(10) {
+			t.Errorf("top-level versionLock = %v, want 10", vl)
+		}
+		loc := got["locationInformation"].(map[string]any)
+		if vl := loc["versionLock"]; vl != float64(5) {
+			t.Errorf("locationInformation.versionLock = %v, want 5", vl)
+		}
+		// User field preserved
+		if room := loc["room"]; room != "A1" {
+			t.Errorf("locationInformation.room = %v, want A1", room)
+		}
+		purch := got["purchasingInformation"].(map[string]any)
+		if vl := purch["versionLock"]; vl != float64(3) {
+			t.Errorf("purchasingInformation.versionLock = %v, want 3", vl)
+		}
+		// User field preserved
+		if vendor := purch["vendor"]; vendor != "Apple" {
+			t.Errorf("purchasingInformation.vendor = %v, want Apple", vendor)
+		}
+	})
+
+	t.Run("does not add versionLock to objects absent in user data", func(t *testing.T) {
+		userData := []byte(`{"displayName":"Test","versionLock":0}`)
+		serverResp := []byte(`{
+			"displayName": "Test",
+			"versionLock": 5,
+			"locationInformation": {"versionLock": 3}
+		}`)
+		out, err := injectVersionLocks(userData, serverResp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := parseJSON(t, out)
+		if vl := got["versionLock"]; vl != float64(5) {
+			t.Errorf("versionLock = %v, want 5", vl)
+		}
+		// locationInformation not in user data — should not appear
+		if _, ok := got["locationInformation"]; ok {
+			t.Error("expected locationInformation to not be added")
+		}
+	})
+
+	t.Run("preserves non-versionLock user fields", func(t *testing.T) {
+		userData := []byte(`{"displayName":"MyName","versionLock":0,"mandatory":true}`)
+		serverResp := []byte(`{"displayName":"OldName","versionLock":7,"mandatory":false}`)
+		out, err := injectVersionLocks(userData, serverResp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := parseJSON(t, out)
+		if name := got["displayName"]; name != "MyName" {
+			t.Errorf("displayName = %v, want MyName (should preserve user value)", name)
+		}
+		if m := got["mandatory"]; m != true {
+			t.Errorf("mandatory = %v, want true (should preserve user value)", m)
+		}
+		if vl := got["versionLock"]; vl != float64(7) {
+			t.Errorf("versionLock = %v, want 7 (should take server value)", vl)
+		}
+	})
+
+	t.Run("invalid user JSON passes through", func(t *testing.T) {
+		userData := []byte(`not json`)
+		serverResp := []byte(`{"versionLock":5}`)
+		out, err := injectVersionLocks(userData, serverResp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(out) != "not json" {
+			t.Errorf("expected unchanged input, got %s", out)
+		}
+	})
+
+	t.Run("invalid server JSON returns error", func(t *testing.T) {
+		userData := []byte(`{"versionLock":0}`)
+		serverResp := []byte(`not json`)
+		_, err := injectVersionLocks(userData, serverResp)
+		if err == nil {
+			t.Error("expected error for invalid server response")
+		}
+	})
+}
+
+func TestMergeVersionLocks(t *testing.T) {
+	t.Run("deeply nested merge", func(t *testing.T) {
+		dst := map[string]any{
+			"versionLock": float64(0),
+			"outer": map[string]any{
+				"versionLock": float64(0),
+				"inner": map[string]any{
+					"versionLock": float64(0),
+					"data":        "keep",
+				},
+			},
+		}
+		src := map[string]any{
+			"versionLock": float64(10),
+			"outer": map[string]any{
+				"versionLock": float64(20),
+				"inner": map[string]any{
+					"versionLock": float64(30),
+					"data":        "ignore",
+				},
+			},
+		}
+		mergeVersionLocks(dst, src)
+		if dst["versionLock"] != float64(10) {
+			t.Errorf("top versionLock = %v, want 10", dst["versionLock"])
+		}
+		outer := dst["outer"].(map[string]any)
+		if outer["versionLock"] != float64(20) {
+			t.Errorf("outer.versionLock = %v, want 20", outer["versionLock"])
+		}
+		inner := outer["inner"].(map[string]any)
+		if inner["versionLock"] != float64(30) {
+			t.Errorf("outer.inner.versionLock = %v, want 30", inner["versionLock"])
+		}
+		// Non-versionLock fields untouched
+		if inner["data"] != "keep" {
+			t.Errorf("outer.inner.data = %v, want keep", inner["data"])
+		}
+	})
+
+	t.Run("skips non-object values", func(t *testing.T) {
+		dst := map[string]any{
+			"versionLock": float64(0),
+			"name":        "keep",
+		}
+		src := map[string]any{
+			"versionLock": float64(5),
+			"name":        "ignore",
+		}
+		mergeVersionLocks(dst, src)
+		if dst["versionLock"] != float64(5) {
+			t.Errorf("versionLock = %v, want 5", dst["versionLock"])
+		}
+		if dst["name"] != "keep" {
+			t.Errorf("name = %v, want keep", dst["name"])
+		}
+	})
+}
+
+func TestFilterResultsByName(t *testing.T) {
+	results := []json.RawMessage{
+		json.RawMessage(`{"id":"1","displayName":"1:1"}`),
+		json.RawMessage(`{"id":"3","displayName":"Shared"}`),
+		json.RawMessage(`{"id":"4","displayName":"All - Customer - 1:1"}`),
+		json.RawMessage(`{"id":"80","displayName":"Test"}`),
+		json.RawMessage(`{"id":"94","displayName":"test"}`),
+	}
+
+	t.Run("exact match returns single result", func(t *testing.T) {
+		got := filterResultsByName(results, "displayName", "Shared")
+		if len(got) != 1 {
+			t.Fatalf("got %d results, want 1", len(got))
+		}
+		m := parseJSON(t, got[0])
+		if m["id"] != "3" {
+			t.Errorf("id = %v, want 3", m["id"])
+		}
+	})
+
+	t.Run("case sensitive", func(t *testing.T) {
+		got := filterResultsByName(results, "displayName", "Test")
+		if len(got) != 1 {
+			t.Fatalf("got %d results, want 1", len(got))
+		}
+		m := parseJSON(t, got[0])
+		if m["id"] != "80" {
+			t.Errorf("id = %v, want 80", m["id"])
+		}
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		got := filterResultsByName(results, "displayName", "Nonexistent")
+		if len(got) != 0 {
+			t.Errorf("got %d results, want 0", len(got))
+		}
+	})
+
+	t.Run("multiple exact matches", func(t *testing.T) {
+		dupes := []json.RawMessage{
+			json.RawMessage(`{"id":"1","name":"Foo"}`),
+			json.RawMessage(`{"id":"2","name":"Bar"}`),
+			json.RawMessage(`{"id":"3","name":"Foo"}`),
+		}
+		got := filterResultsByName(dupes, "name", "Foo")
+		if len(got) != 2 {
+			t.Fatalf("got %d results, want 2", len(got))
+		}
+	})
+
+	t.Run("partial match not included", func(t *testing.T) {
+		got := filterResultsByName(results, "displayName", "1:1")
+		if len(got) != 1 {
+			t.Fatalf("got %d results, want 1 (not partial matches)", len(got))
+		}
+		m := parseJSON(t, got[0])
+		if m["id"] != "1" {
+			t.Errorf("id = %v, want 1", m["id"])
+		}
+	})
+}
+
+// parseJSON is a test helper that unmarshals JSON and fails the test on error.
+func parseJSON(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("failed to parse JSON %q: %v", data, err)
+	}
+	return m
+}


### PR DESCRIPTION
## Summary

- Auto-inject `versionLock` for prestage and prestage-scope commands that require optimistic locking
- On **update/replace**: GET current resource, deep-merge all `versionLock` fields (including nested `locationInformation`, `purchasingInformation`, `accountSettings`) into the request body
- On **create**: recursively zero all `versionLock` fields
- On **scope operations** (create-scope, update-scope, delete-multiple): fetch current scope's `versionLock` before mutating
- Fix name resolution for prestages — list endpoints ignore RSQL `filter` param, added client-side exact name matching fallback in both `resolveNameToID` and `resolveNameToIDForApply`

Affected resources: `computer-prestages`, `mobile-device-prestages`, `computer-prestage-scopes`, `mobile-device-prestage-scopes`

Fixes #134

## Test plan

- [x] Unit tests: `detectVersionLock`, `setVersionLockZero`, `injectVersionLocks`, `mergeVersionLocks`, `filterResultsByName` (19 cases)
- [x] `make generate && make build && make test && make lint` — all clean
- [x] Live tested on nmartin.jamfcloud.com:
  - `computer-prestages create` with wrong versionLock → zeroed, 201 Created
  - `computer-prestages update 1` with versionLock=0 → auto-injected 78, accepted (78→79)
  - `computer-prestages update --name "Test"` with versionLock=999 → auto-injected, accepted
  - `computer-prestages apply --yes` create path → zeroed, 201 Created
  - `computer-prestages apply --yes` update path on "Shared" → fetched+injected, replaced
  - `mobile-device-prestages update 32` with versionLock=999 → auto-injected, 0→1
  - `computer-prestage-scopes update-scope 1` with versionLock=0 → auto-injected 80, accepted (80→81)
  - `computer-prestages apply` on "Shared" — previously returned 5 false collisions, now correctly resolves to single match

🤖 Generated with [Claude Code](https://claude.com/claude-code)