### PR TITLE
chore: upgrade jamfplatform-go-sdk to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Jamf-Concepts/jamf-cli
 go 1.26.2
 
 require (
-	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.3.0
+	github.com/Jamf-Concepts/jamfplatform-go-sdk v0.4.0
 	github.com/Jamf-Concepts/jamfprotect-go-sdk v0.3.0
 	github.com/Jamf-Concepts/jamfschool-go-sdk v0.1.2-0.20260414190035-1648ab3aa213
 	github.com/getkin/kin-openapi v0.135.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.3.0 h1:W5sL0Fl8RDwRuwTgHRuWoScUrAi6XHeYJWMydjagHh8=
-github.com/Jamf-Concepts/jamfplatform-go-sdk v0.3.0/go.mod h1:aNjapJAdC8d/9KsGnMK8ouZU7KBl9sS1RF/yLQkHgO8=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.4.0 h1:CFZvi3lM5xG25RY2LDX7qSw0hnUDGT5RmCofTX98+vY=
+github.com/Jamf-Concepts/jamfplatform-go-sdk v0.4.0/go.mod h1:aNjapJAdC8d/9KsGnMK8ouZU7KBl9sS1RF/yLQkHgO8=
 github.com/Jamf-Concepts/jamfprotect-go-sdk v0.3.0 h1:MKgLA8y5+Q0JwqhoRebmtaZpd5yWZu56fynKqzH8YOI=
 github.com/Jamf-Concepts/jamfprotect-go-sdk v0.3.0/go.mod h1:B7fH/nVg1fq44E1Q/hzhnJ+H9VjBslt9Wj39gRWR8Bc=
 github.com/Jamf-Concepts/jamfschool-go-sdk v0.1.2-0.20260414190035-1648ab3aa213 h1:lxRZxFlopNKuY6OJF9e8FJo4V0Z5FyyZcMi8Q5CqDAw=

--- a/internal/commands/pro_blueprints.go
+++ b/internal/commands/pro_blueprints.go
@@ -327,9 +327,9 @@ func blueprintCreateToUpdate(c *jamfplatform.CreateBlueprintRequest) *jamfplatfo
 	update := &jamfplatform.UpdateBlueprintRequest{
 		Name:        &c.Name,
 		Description: c.Description,
-		Steps:       c.Steps,
+		Steps:       &c.Steps,
 	}
-	if c.Scope != nil {
+	if len(c.Scope.DeviceGroups) > 0 {
 		update.Scope = &jamfplatform.BlueprintScope{
 			DeviceGroups: c.Scope.DeviceGroups,
 		}
@@ -341,7 +341,7 @@ func blueprintScaffold() *jamfplatform.CreateBlueprintRequest {
 	stepName := "Step 1"
 	return &jamfplatform.CreateBlueprintRequest{
 		Name: "My Blueprint",
-		Scope: &jamfplatform.CreateScope{
+		Scope: jamfplatform.CreateScope{
 			DeviceGroups: []string{"<device-group-id>"},
 		},
 		Steps: []jamfplatform.BlueprintStep{
@@ -735,7 +735,6 @@ Examples:
 				Scope: &jamfplatform.BlueprintScope{
 					DeviceGroups: newScope,
 				},
-				Steps: bp.Steps,
 			}
 			if err := cliCtx.PlatformClient.UpdateBlueprint(ctx, id, updateReq); err != nil {
 				return err
@@ -823,7 +822,6 @@ Examples:
 				Scope: &jamfplatform.BlueprintScope{
 					DeviceGroups: newScope,
 				},
-				Steps: bp.Steps,
 			}
 			if err := cliCtx.PlatformClient.UpdateBlueprint(ctx, id, updateReq); err != nil {
 				return err
@@ -953,7 +951,7 @@ The source scope is copied by default. Use --scope to override device group targ
 			createReq := &jamfplatform.CreateBlueprintRequest{
 				Name:        args[1],
 				Description: source.Description,
-				Scope: &jamfplatform.CreateScope{
+				Scope: jamfplatform.CreateScope{
 					DeviceGroups: groups,
 				},
 				Steps: steps,
@@ -1463,7 +1461,7 @@ Examples:
 			importStepName := "Step 1"
 			createReq := &jamfplatform.CreateBlueprintRequest{
 				Name: name,
-				Scope: &jamfplatform.CreateScope{
+				Scope: jamfplatform.CreateScope{
 					DeviceGroups: scopeGroups,
 				},
 				Steps: []jamfplatform.BlueprintStep{
@@ -1833,9 +1831,6 @@ func parseBlueprintApplyInput(ctx context.Context, data []byte, client registry.
 			return nil, fmt.Errorf("input must include a 'name' field")
 		}
 		if len(scopeOverrideIDs) > 0 {
-			if req.Scope == nil {
-				req.Scope = &jamfplatform.CreateScope{}
-			}
 			req.Scope.DeviceGroups = scopeOverrideIDs
 		}
 		return &req, nil
@@ -1863,7 +1858,7 @@ func parseBlueprintApplyInput(ctx context.Context, data []byte, client registry.
 
 	req := &jamfplatform.CreateBlueprintRequest{
 		Name: exp.Name,
-		Scope: &jamfplatform.CreateScope{
+		Scope: jamfplatform.CreateScope{
 			DeviceGroups: groupIDs,
 		},
 		Steps: exp.Steps,

--- a/internal/commands/pro_compliance_benchmarks.go
+++ b/internal/commands/pro_compliance_benchmarks.go
@@ -202,7 +202,7 @@ func newCBApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			var legacyGroupIDs []string
 			if !portableGroupsValid {
 				var legacy jamfplatform.BenchmarkRequestV2
-				if err := unmarshalInput(data, &legacy); err == nil && legacy.Target != nil && len(legacy.Target.DeviceGroups) > 0 {
+				if err := unmarshalInput(data, &legacy); err == nil && len(legacy.Target.DeviceGroups) > 0 {
 					desc := ""
 					if legacy.Description != nil {
 						desc = *legacy.Description
@@ -240,7 +240,7 @@ func newCBApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 				SourceBaselineID: input.SourceBaselineID,
 				Sources:          input.Sources,
 				Rules:            input.Rules,
-				Target:           &jamfplatform.TargetV2{DeviceGroups: groupIDs},
+				Target:           jamfplatform.TargetV2{DeviceGroups: groupIDs},
 				EnforcementMode:  input.EnforcementMode,
 			}
 			result, err := cliCtx.PlatformClient.CreateBenchmark(ctx, req)
@@ -327,7 +327,7 @@ func newCBCloneCmd(cliCtx *registry.CLIContext) *cobra.Command {
 				SourceBaselineID: src.BaselineID,
 				Sources:          src.Sources,
 				Rules:            cbRuleInfosToRequests(src.Rules),
-				Target:           &jamfplatform.TargetV2{DeviceGroups: targetGroupIDs},
+				Target:           jamfplatform.TargetV2{DeviceGroups: targetGroupIDs},
 				EnforcementMode:  src.EnforcementMode,
 			}
 			result, err := cliCtx.PlatformClient.CreateBenchmark(ctx, req)

--- a/internal/commands/pro_platform_device_groups.go
+++ b/internal/commands/pro_platform_device_groups.go
@@ -184,7 +184,7 @@ func deviceGroupScaffold() *jamfplatform.DeviceGroupCreateRepresentationV1 {
 		Description: &desc,
 		DeviceType:  "COMPUTER",
 		GroupType:   "STATIC",
-		Members:     []string{"<device-id>"},
+		Members:     &[]string{"<device-id>"},
 	}
 }
 
@@ -274,7 +274,7 @@ func newPDGAddMembersCmd(cliCtx *registry.CLIContext) *cobra.Command {
 				return err
 			}
 			patch := &jamfplatform.DeviceGroupMemberPatchRepresentationV1{
-				Added: ids,
+				Added: &ids,
 			}
 			if err := cliCtx.PlatformClient.UpdateDeviceGroupMembers(ctx, groupID, patch); err != nil {
 				return err
@@ -307,7 +307,7 @@ func newPDGRemoveMembersCmd(cliCtx *registry.CLIContext) *cobra.Command {
 				return err
 			}
 			patch := &jamfplatform.DeviceGroupMemberPatchRepresentationV1{
-				Removed: ids,
+				Removed: &ids,
 			}
 			if err := cliCtx.PlatformClient.UpdateDeviceGroupMembers(ctx, groupID, patch); err != nil {
 				return err

--- a/internal/commands/pro_platform_test.go
+++ b/internal/commands/pro_platform_test.go
@@ -110,7 +110,7 @@ func (m *platformMockClient) CreateBenchmark(_ context.Context, req *jamfplatfor
 		Description:     desc,
 		BaselineID:      req.SourceBaselineID,
 		Sources:         req.Sources,
-		Target:          req.Target,
+		Target:          &req.Target,
 		EnforcementMode: req.EnforcementMode,
 	}, nil
 }
@@ -1135,7 +1135,7 @@ func TestCBApply_LegacyFormat(t *testing.T) {
 		EnforcementMode:  "AUDIT",
 		Sources:          []jamfplatform.Source{{Branch: "main"}},
 		Rules:            []jamfplatform.RuleRequest{{ID: "r1", Enabled: true}},
-		Target:           &jamfplatform.TargetV2{DeviceGroups: []string{"raw-group-id-1"}},
+		Target:           jamfplatform.TargetV2{DeviceGroups: []string{"raw-group-id-1"}},
 	}
 	path := writeTempJSON(t, legacy)
 
@@ -1171,7 +1171,7 @@ func TestCBApply_LegacyFormatWithGroupOverride(t *testing.T) {
 		Title:            "Legacy With Override",
 		SourceBaselineID: "bl-1",
 		EnforcementMode:  "AUDIT",
-		Target:           &jamfplatform.TargetV2{DeviceGroups: []string{"old-id"}},
+		Target:           jamfplatform.TargetV2{DeviceGroups: []string{"old-id"}},
 	}
 	path := writeTempJSON(t, legacy)
 
@@ -1740,7 +1740,7 @@ func TestBlueprintExportRoundTrip(t *testing.T) {
 	if req.Name != "Round Trip BP" {
 		t.Errorf("name: got %q", req.Name)
 	}
-	if req.Scope == nil || len(req.Scope.DeviceGroups) != 1 || req.Scope.DeviceGroups[0] != "target-uuid" {
+	if len(req.Scope.DeviceGroups) != 1 || req.Scope.DeviceGroups[0] != "target-uuid" {
 		t.Errorf("target scope: got %v, want [target-uuid]", req.Scope)
 	}
 	if len(req.Steps) != 1 || req.Steps[0].Name == nil || *req.Steps[0].Name != "Step 1" {


### PR DESCRIPTION
## Summary
- Upgrades `jamfplatform-go-sdk` from v0.3.0 to v0.4.0 (pointer types for optional slices/maps in request types)
- Blueprint scope add/remove no longer redundantly include steps in the merge-patch body — the API preserves them when omitted
- Device group member patch requests now only include `added` or `removed` field, not both

## Changes
| Type | Field | Change |
|------|-------|--------|
| `CreateBlueprintRequest` | `Scope` | `*CreateScope` → `CreateScope` |
| `UpdateBlueprintRequest` | `Steps` | `[]BlueprintStep` → `*[]BlueprintStep` |
| `BenchmarkRequestV2` | `Target` | `*TargetV2` → `TargetV2` |
| `DeviceGroupCreateRepresentationV1` | `Criteria`, `Members` | `[]T` → `*[]T` |
| `DeviceGroupUpdateRepresentationV1` | `Criteria` | `[]T` → `*[]T` |
| `DeviceGroupMemberPatchRepresentationV1` | `Added`, `Removed` | `[]string` → `*[]string` |

## Test plan
- [x] `make test` — all unit tests pass
- [x] `make lint` — 0 issues
- [x] Integration tested against `platform-nmartin`:
  - [x] Blueprint create, update (apply upsert), scope add, scope remove, get, delete
  - [x] Device group create (smart, no members), update, delete
  - [x] Benchmark list, export
  - [x] Scaffold output for blueprints and device groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)