### PR TITLE
fix: correct APAC gateway URL in platformGatewayRegions

### DIFF
--- a/internal/commands/platform.go
+++ b/internal/commands/platform.go
@@ -38,7 +38,7 @@ var platformGatewayRegions = []struct {
 }{
 	{"US", "https://us.apigw.jamf.com"},
 	{"EU", "https://eu.apigw.jamf.com"},
-	{"APAC", "https://ap.apigw.jamf.com"},
+	{"APAC", "https://apac.apigw.jamf.com"},
 }
 
 func newPlatformSetupCmd() *cobra.Command {


### PR DESCRIPTION
Fix APAC platform gateway URL from ap.apigw.jamf.com to apac.apigw.jamf.com.