### PR TITLE
fix(generator): honor file-field flags on patch commands

### DIFF
--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -1681,24 +1681,47 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 {{- if isPatchOp . }}
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+{{- if opHasFileFields . $ }}
+			// File-sourced fields (--{{ (index $.FileFields 0).Flag }}, etc.) overwrite
+			// any value the caller supplied in the body. When no other body input is
+			// given, injectFileFields constructs a minimal merge-patch from the file
+			// alone.
+			var fileFieldErr error
+			normalized, fileFieldErr = injectFileFields(normalized, []fileFieldSpec{
+{{- range $.FileFields }}
+				{FilePath: flag{{ toCamel .Flag }}, Field: "{{ .Field }}", Encoding: "{{ .Encoding }}", CompanionField: "{{ .CompanionField }}", NameFallback: "{{ .NameFallback }}", NameField: "{{ resourceNameField $ }}"},
+{{- end }}
+			})
+			if fileFieldErr != nil {
+				return fileFieldErr
+			}
+{{- end }}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 {{- else if eq .Name "delete-multiple" }}
 			// Handle --ids flag for bulk operations

--- a/internal/commands/pro/generated/account_preferences.go
+++ b/internal/commands/pro/generated/account_preferences.go
@@ -130,24 +130,32 @@ func newAccountPreferencesPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/activation_codes.go
+++ b/internal/commands/pro/generated/activation_codes.go
@@ -449,24 +449,32 @@ func newActivationCodesPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/adcs_settings.go
+++ b/internal/commands/pro/generated/adcs_settings.go
@@ -711,24 +711,32 @@ func newAdcsSettingsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/cloud_distribution_points.go
+++ b/internal/commands/pro/generated/cloud_distribution_points.go
@@ -473,24 +473,32 @@ func newCloudDistributionPointsPatchCmd(ctx *registry.CLIContext) *cobra.Command
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/computer_inventory_collection_settings.go
+++ b/internal/commands/pro/generated/computer_inventory_collection_settings.go
@@ -293,24 +293,32 @@ func newComputerInventoryCollectionSettingsPatchCmd(ctx *registry.CLIContext) *c
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/computers_inventory.go
+++ b/internal/commands/pro/generated/computers_inventory.go
@@ -593,24 +593,32 @@ func newComputersInventoryPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/digi_cert_settings.go
+++ b/internal/commands/pro/generated/digi_cert_settings.go
@@ -408,24 +408,32 @@ func newDigiCertSettingsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/distribution_points.go
+++ b/internal/commands/pro/generated/distribution_points.go
@@ -949,24 +949,32 @@ func newDistributionPointsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/groups.go
+++ b/internal/commands/pro/generated/groups.go
@@ -404,24 +404,32 @@ func newGroupsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/gsx_connection.go
+++ b/internal/commands/pro/generated/gsx_connection.go
@@ -374,24 +374,32 @@ func newGsxConnectionPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/mdm_renewals.go
+++ b/internal/commands/pro/generated/mdm_renewals.go
@@ -250,24 +250,32 @@ func newMdmRenewalsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/mobile_device_groups_static_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_static_groups.go
@@ -481,24 +481,32 @@ func newMobileDeviceGroupsStaticGroupsPatchCmd(ctx *registry.CLIContext) *cobra.
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/mobile_devices.go
+++ b/internal/commands/pro/generated/mobile_devices.go
@@ -345,24 +345,32 @@ func newMobileDevicesPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/patch_software_title_configurations.go
+++ b/internal/commands/pro/generated/patch_software_title_configurations.go
@@ -629,24 +629,32 @@ func newPatchSoftwareTitleConfigurationsPatchCmd(ctx *registry.CLIContext) *cobr
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/team_viewer_remote_administrations.go
+++ b/internal/commands/pro/generated/team_viewer_remote_administrations.go
@@ -610,24 +610,32 @@ func newTeamViewerRemoteAdministrationsPatchCmd(ctx *registry.CLIContext) *cobra
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/venafis.go
+++ b/internal/commands/pro/generated/venafis.go
@@ -580,24 +580,32 @@ func newVenafisPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {

--- a/internal/commands/pro/generated/vpp_locations.go
+++ b/internal/commands/pro/generated/vpp_locations.go
@@ -735,24 +735,43 @@ func newVppLocationsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var body io.Reader
 			// PATCH: --set flags take priority; fall back to --from-file or stdin
 			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			var normalized []byte
 			switch {
 			case len(flagSet) > 0:
 				data, err := buildMergePatchFromSet(flagSet)
 				if err != nil {
 					return err
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			case fromFile != "":
 				data, err := os.ReadFile(fromFile)
 				if err != nil {
 					return fmt.Errorf("reading input file: %w", err)
 				}
-				body = bytes.NewReader(data)
+				normalized = data
 			default:
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
-					body = os.Stdin
+					raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+					if err != nil {
+						return fmt.Errorf("reading stdin: %w", err)
+					}
+					normalized = raw
 				}
+			}
+			// File-sourced fields (--token-file, etc.) overwrite
+			// any value the caller supplied in the body. When no other body input is
+			// given, injectFileFields constructs a minimal merge-patch from the file
+			// alone.
+			var fileFieldErr error
+			normalized, fileFieldErr = injectFileFields(normalized, []fileFieldSpec{
+				{FilePath: flagTokenFile, Field: "serviceToken", Encoding: "raw", CompanionField: "", NameFallback: "none", NameField: "name"},
+			})
+			if fileFieldErr != nil {
+				return fileFieldErr
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PATCH", path, body)
 			if err != nil {


### PR DESCRIPTION
## Summary

- The generated `patch` command declared and registered file-field flags (e.g. `--token-file`, `--script-file`) but never consumed them when assembling the request body.
- `vpp-locations patch --token-file ...` therefore sent a nil body; since `client.go` only sets `Content-Type` when body is non-nil, the gateway rejected with `415 Unsupported Media Type`.
- Wire the patch branch through the same `injectFileFields` pipeline already used by `create`/`update`/`apply`. Switch now builds a `normalized []byte`, runs file-field injection when applicable, then wraps as the request body.

## Behaviour change for non-FileField patch commands

stdin input is now buffered via `io.ReadAll(io.LimitReader(os.Stdin, 10<<20))` instead of streamed as `os.Stdin`, matching the existing create/update/apply pattern. Merge-patch bodies are tiny JSON — the 10MB cap is not a practical limit. Wire output is identical for the `--set` / `--from-file` paths.

## Scope

Only `vpp-locations patch` was actually broken (the only resource combining `FileFields` with a PATCH endpoint). `scripts`, `computer-extension-attributes`, and `device-enrollment-instances` have `FileFields` but no `PATCH` endpoint. Fix lives in the template so future resources are covered.

## Test plan

- [x] `make generate && make lint && make test` all green
- [x] Live test on `platform-nmartin`:
  - [x] `vpp-locations patch --token-file` → 200 (was 415)
  - [x] `vpp-locations patch --token-file --set ...` combined → 200
  - [x] `vpp-locations patch --set` only → 200
  - [x] `account-preferences patch --set` → 204
  - [x] `account-preferences patch --from-file` → 204
  - [x] `account-preferences patch` via stdin → 204
  - [x] `computers-inventory patch <id> --set ...` → 204
  - [x] `vpp-locations patch --scaffold` prints template
  - [x] `computers-inventory patch` without id/lookup → clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)