### PR TITLE
feat: apply for PATCH-only resources, device-enrollment composite flows, structured config output

### DIFF
--- a/generator/main.go
+++ b/generator/main.go
@@ -122,6 +122,14 @@ func main() {
 	// Attach file-sourced request-body fields (e.g. --script-file → scriptContents).
 	parser.ApplyFileFields(resources)
 
+	// Rename sub-path action POSTs to "create" for resources that lack a bare
+	// collection POST (e.g. device-enrollment-instances creates via /upload-token).
+	parser.ApplyCreateOpOverrides(resources)
+
+	// Detach auxiliary PUT /{id}/<action> endpoints so update/apply can compose
+	// them alongside the main update body instead of emitting a parallel subcommand.
+	parser.ApplyUpdateTokenOpOverrides(resources)
+
 	// Swap list operation paths to richer detail endpoints where available.
 	parser.ApplyListDetailPaths(resources)
 

--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -248,12 +248,7 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 			if op == nil {
 				return "{id}"
 			}
-			start := strings.LastIndex(op.Path, "{")
-			end := strings.LastIndex(op.Path, "}")
-			if start >= 0 && end > start {
-				return op.Path[start : end+1]
-			}
-			return "{id}"
+			return pathParam(op.Path)
 		},
 		"applyUpdateContentType": func(ops []*Operation) string {
 			op := applyUpdateOp(ops)
@@ -275,12 +270,7 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 			if r.UpdateTokenOp == nil {
 				return "{id}"
 			}
-			start := strings.LastIndex(r.UpdateTokenOp.Path, "{")
-			end := strings.LastIndex(r.UpdateTokenOp.Path, "}")
-			if start >= 0 && end > start {
-				return r.UpdateTokenOp.Path[start : end+1]
-			}
-			return "{id}"
+			return pathParam(r.UpdateTokenOp.Path)
 		},
 		"deletePath": func(ops []*Operation) string {
 			for _, op := range ops {
@@ -293,11 +283,7 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 		"deletePathParam": func(ops []*Operation) string {
 			for _, op := range ops {
 				if op.Name == "delete" && op.Method == "DELETE" {
-					start := strings.LastIndex(op.Path, "{")
-					end := strings.LastIndex(op.Path, "}")
-					if start != -1 && end > start {
-						return op.Path[start : end+1]
-					}
+					return pathParam(op.Path)
 				}
 			}
 			return "{id}"
@@ -324,11 +310,7 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 		"updatePathParam": func(ops []*Operation) string {
 			for _, op := range ops {
 				if op.Name == "update" && op.Method == "PUT" {
-					start := strings.LastIndex(op.Path, "{")
-					end := strings.LastIndex(op.Path, "}")
-					if start != -1 && end > start {
-						return op.Path[start : end+1]
-					}
+					return pathParam(op.Path)
 				}
 			}
 			return "{id}"
@@ -511,11 +493,7 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 		"resourceUpdatePathParam": func(r *Resource) string {
 			for _, op := range r.Operations {
 				if op.Name == "update" && op.Method == "PUT" {
-					start := strings.LastIndex(op.Path, "{")
-					end := strings.LastIndex(op.Path, "}")
-					if start >= 0 && end > start {
-						return op.Path[start : end+1]
-					}
+					return pathParam(op.Path)
 				}
 			}
 			return "{id}"
@@ -603,12 +581,7 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 			// Extract the path parameter name from the URL path itself,
 			// so it works even when the param is defined at the path level
 			// in the OpenAPI spec rather than on the individual operation.
-			start := strings.LastIndex(op.Path, "{")
-			end := strings.LastIndex(op.Path, "}")
-			if start != -1 && end > start {
-				return op.Path[start : end+1]
-			}
-			return "{id}"
+			return pathParam(op.Path)
 		},
 	}).Parse(resourceTemplate)
 	if err != nil {
@@ -665,6 +638,17 @@ func (g *Generator) GenerateRegistry(resources []*Resource) (string, error) {
 // Template helper functions
 func hasPathParam(path string) bool {
 	return strings.Contains(path, "{")
+}
+
+// pathParam returns the last {name} token in a URL path (e.g. "{id}"). Falls
+// back to "{id}" when the path has no brace-delimited segment.
+func pathParam(path string) string {
+	start := strings.LastIndex(path, "{")
+	end := strings.LastIndex(path, "}")
+	if start >= 0 && end > start {
+		return path[start : end+1]
+	}
+	return "{id}"
 }
 
 func pathParams(params []*Parameter) []*Parameter {
@@ -1105,11 +1089,7 @@ func patchPath(ops []*Operation) string {
 func patchPathParam(ops []*Operation) string {
 	for _, op := range ops {
 		if isPatchOp(op) {
-			start := strings.LastIndex(op.Path, "{")
-			end := strings.LastIndex(op.Path, "}")
-			if start != -1 && end > start {
-				return op.Path[start : end+1]
-			}
+			return pathParam(op.Path)
 		}
 	}
 	return "{id}"
@@ -1868,7 +1848,15 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 {{- if opHasFileFields . $ }}
 {{- if opHasUpdateTokenOp . $ }}
 			// File fields for this resource route to {{ updateTokenPath $ }} via a
-			// separate PUT below, not this endpoint's body.
+			// separate PUT below, not this endpoint's body. Strip them from stdin
+			// input so the main PUT never carries token payload keys.
+			if len(normalized) > 0 {
+				var stripErr error
+				normalized, stripErr = removeJSONFields(normalized{{ range $.FileFields }}, "{{ .Field }}"{{ if .CompanionField }}, "{{ .CompanionField }}"{{ end }}{{ end }})
+				if stripErr != nil {
+					return stripErr
+				}
+			}
 {{- else }}
 			// File-sourced fields (--{{ (index $.FileFields 0).Flag }}, etc.) overwrite
 			// any value the caller supplied in the body; companion fields and name
@@ -2166,6 +2154,14 @@ If not, a new resource is created.` + "`" + `,
 			if err != nil {
 				return fmt.Errorf("input must include a %q field: %w", "{{ .NameField }}", err)
 			}
+{{- if .UpdateTokenOp }}
+			// Strip file-field keys from the main body so the follow-up PUT never
+			// re-sends token payload (which belongs to {{ .UpdateTokenOp.Path }}).
+			data, err = removeJSONFields(data{{ range .FileFields }}, "{{ .Field }}"{{ if .CompanionField }}, "{{ .CompanionField }}"{{ end }}{{ end }})
+			if err != nil {
+				return err
+			}
+{{- end }}
 
 			// Check if resource exists by name (read-only, runs even in dry-run)
 			noInput, _ := cmd.Flags().GetBool("no-input")
@@ -2209,7 +2205,7 @@ If not, a new resource is created.` + "`" + `,
 				bodyPath := strings.Replace("{{ applyUpdatePath .Operations }}", "{{ applyUpdatePathParam .Operations }}", url.PathEscape(newID), 1)
 				bodyResp, err := ctx.Client.Do(reqCtx, "{{ applyUpdateMethod .Operations }}", bodyPath, bytes.NewReader(data))
 				if err != nil {
-					return fmt.Errorf("create succeeded (id %s) but applying body fields failed: %w", newID, err)
+					return fmt.Errorf("create succeeded (id %s) but applying body fields failed: %w\nthe {{ .NameSingular }} exists but is unnamed; to recover run: jamf-cli {{ .Name }} update %s --from-file <body.json>", newID, err, newID)
 				}
 				defer bodyResp.Body.Close()
 				fmt.Fprintf(os.Stderr, "Created {{ .NameSingular }} %q (id: %s)\n", name, newID)
@@ -2266,7 +2262,7 @@ If not, a new resource is created.` + "`" + `,
 				}
 				tokenResp = tr
 			}
-			if len(data) == 0 {
+			if len(data) == 0 && tokenResp != nil {
 				// Only the token was replaced — return its response.
 				defer tokenResp.Body.Close()
 				fmt.Fprintf(os.Stderr, "Replaced {{ .NameSingular }} token %q (id: %s)\n", name, id)

--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -262,6 +262,26 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 			}
 			return ""
 		},
+		"opHasUpdateTokenOp": func(op *Operation, r *Resource) bool {
+			return op.Name == "update" && op.Method == "PUT" && r.UpdateTokenOp != nil
+		},
+		"updateTokenPath": func(r *Resource) string {
+			if r.UpdateTokenOp == nil {
+				return ""
+			}
+			return r.UpdateTokenOp.Path
+		},
+		"updateTokenPathParam": func(r *Resource) string {
+			if r.UpdateTokenOp == nil {
+				return "{id}"
+			}
+			start := strings.LastIndex(r.UpdateTokenOp.Path, "{")
+			end := strings.LastIndex(r.UpdateTokenOp.Path, "}")
+			if start >= 0 && end > start {
+				return r.UpdateTokenOp.Path[start : end+1]
+			}
+			return "{id}"
+		},
 		"deletePath": func(ops []*Operation) string {
 			for _, op := range ops {
 				if op.Name == "delete" && op.Method == "DELETE" {
@@ -1300,7 +1320,7 @@ import (
 {{- if needsMultipart . }}
 	"mime/multipart"
 {{- end }}
-{{- if hasDelete .Operations }}
+{{- if or (hasDelete .Operations) .UpdateTokenOp }}
 	"net/http"
 {{- end }}
 {{- if needsURL . }}
@@ -1846,6 +1866,10 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 {{- end }}
 			}
 {{- if opHasFileFields . $ }}
+{{- if opHasUpdateTokenOp . $ }}
+			// File fields for this resource route to {{ updateTokenPath $ }} via a
+			// separate PUT below, not this endpoint's body.
+{{- else }}
 			// File-sourced fields (--{{ (index $.FileFields 0).Flag }}, etc.) overwrite
 			// any value the caller supplied in the body; companion fields and name
 			// fallbacks only fill when absent.
@@ -1865,9 +1889,37 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 				return fileFieldErr
 			}
 {{- end }}
+{{- end }}
 			if len(normalized) > 0 {
 				body = bytes.NewReader(normalized)
 			}
+{{- end }}
+{{- if opHasUpdateTokenOp . $ }}
+			// Composite update: --{{ (index $.FileFields 0).Flag }} routes to {{ updateTokenPath $ }};
+			// body fields go to {{ .Path }}. At least one input is required.
+			if len(normalized) == 0{{ range $.FileFields }} && flag{{ toCamel .Flag }} == ""{{ end }} {
+				return fmt.Errorf("nothing to update: provide --from-file, stdin body, or --{{ (index $.FileFields 0).Flag }}")
+			}
+{{- range $.FileFields }}
+			if flag{{ toCamel .Flag }} != "" {
+				tokenBody, tbErr := injectFileFields(nil, []fileFieldSpec{
+					{FilePath: flag{{ toCamel .Flag }}, Field: "{{ .Field }}", Encoding: "{{ .Encoding }}", CompanionField: "{{ .CompanionField }}", NameFallback: "{{ .NameFallback }}", NameField: "{{ resourceNameField $ }}"},
+				})
+				if tbErr != nil {
+					return tbErr
+				}
+				tokenPath := strings.Replace("{{ updateTokenPath $ }}", "{{ updateTokenPathParam $ }}", url.PathEscape(resolvedID), 1)
+				tokenResp, tokenErr := ctx.Client.Do(reqCtx, "PUT", tokenPath, bytes.NewReader(tokenBody))
+				if tokenErr != nil {
+					return tokenErr
+				}
+				if len(normalized) == 0 {
+					defer tokenResp.Body.Close()
+					return ctx.Output.PrintResponse(tokenResp)
+				}
+				_ = tokenResp.Body.Close()
+			}
+{{- end }}
 {{- end }}
 			resp, err := ctx.Client.Do(reqCtx, "{{ .Method }}", path, body)
 {{- end }}
@@ -1904,7 +1956,7 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 					}
 				}
 				if renameID == "" {
-					return fmt.Errorf("upload succeeded but response did not include id; cannot apply --rename")
+					return fmt.Errorf("upload succeeded but response did not include id; cannot apply --name")
 				}
 {{- end }}
 				renameURL := strings.Replace("{{ resourceUpdatePath $ }}", "{{ resourceUpdatePathParam $ }}", url.PathEscape(renameID), 1)
@@ -2000,7 +2052,7 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 	cmd.Flags().StringVar(&flagBodyName, "name", "", "Name for the {{ $.NameSingular }} (sets the body's {{ resourceNameField $ }} field)")
 {{- end }}
 {{- if opEmitsRenameFlag . $ }}
-	cmd.Flags().StringVar(&flagRename, "rename", "", "After the upload succeeds, apply this name via a follow-up PUT to {{ resourceUpdatePath $ }} (this endpoint's body rejects a name field)")
+	cmd.Flags().StringVar(&flagRename, "name", "", "Canonical name to apply to the {{ $.NameSingular }} via a follow-up PUT to {{ resourceUpdatePath $ }} (this endpoint's body has no name field)")
 {{- end }}
 
 	return cmd
@@ -2080,7 +2132,7 @@ If not, a new resource is created.` + "`" + `,
 				return err
 			}
 {{- end }}
-{{- if .FileFields }}
+{{- if and .FileFields (not .UpdateTokenOp) }}
 			data, err = injectFileFields(data, []fileFieldSpec{
 {{- range .FileFields }}
 				{FilePath: flag{{ toCamel .Flag }}, Field: "{{ .Field }}", Encoding: "{{ .Encoding }}", CompanionField: "{{ .CompanionField }}", NameFallback: "{{ .NameFallback }}", NameField: "{{ resourceNameField $ }}"},
@@ -2089,6 +2141,24 @@ If not, a new resource is created.` + "`" + `,
 			if err != nil {
 				return err
 			}
+{{- end }}
+{{- if .UpdateTokenOp }}
+			// Composite flow: file fields route to {{ .UpdateTokenOp.Path }} (on update)
+			// or are combined with the create body (on create). Build a separate token
+			// body so the main PUT to {{ applyUpdatePath .Operations }} only carries
+			// DeviceEnrollmentInstance-schema fields.
+			var tokenBody []byte
+{{- range .FileFields }}
+			if flag{{ toCamel .Flag }} != "" {
+				tb, tbErr := injectFileFields(nil, []fileFieldSpec{
+					{FilePath: flag{{ toCamel .Flag }}, Field: "{{ .Field }}", Encoding: "{{ .Encoding }}", CompanionField: "{{ .CompanionField }}", NameFallback: "{{ .NameFallback }}", NameField: "{{ resourceNameField $ }}"},
+				})
+				if tbErr != nil {
+					return tbErr
+				}
+				tokenBody = tb
+			}
+{{- end }}
 {{- end }}
 
 			// Extract name from JSON input
@@ -2110,6 +2180,41 @@ If not, a new resource is created.` + "`" + `,
 					fmt.Fprintf(os.Stderr, "[dry-run] Would create {{ .NameSingular }} %q\n", name)
 					return nil
 				}
+{{- if .UpdateTokenOp }}
+				if len(tokenBody) == 0 {
+					return fmt.Errorf("cannot create {{ .NameSingular }} %q: --{{ (index .FileFields 0).Flag }} is required", name)
+				}
+				postResp, err := ctx.Client.Do(reqCtx, "POST", "{{ createPath .Operations }}", bytes.NewReader(tokenBody))
+				if err != nil {
+					return err
+				}
+				postBytes, readErr := io.ReadAll(io.LimitReader(postResp.Body, 10<<20))
+				_ = postResp.Body.Close()
+				if readErr != nil {
+					return fmt.Errorf("reading create response: %w", readErr)
+				}
+				var postDecoded map[string]any
+				var newID string
+				if jerr := json.Unmarshal(postBytes, &postDecoded); jerr == nil {
+					if v, ok := postDecoded["id"].(string); ok {
+						newID = v
+					} else if v, ok := postDecoded["id"].(float64); ok {
+						newID = strconv.FormatFloat(v, 'f', -1, 64)
+					}
+				}
+				if newID == "" {
+					return fmt.Errorf("create succeeded but response did not include id")
+				}
+				// Follow-up: PUT main body to apply name/other DeviceEnrollmentInstance fields.
+				bodyPath := strings.Replace("{{ applyUpdatePath .Operations }}", "{{ applyUpdatePathParam .Operations }}", url.PathEscape(newID), 1)
+				bodyResp, err := ctx.Client.Do(reqCtx, "{{ applyUpdateMethod .Operations }}", bodyPath, bytes.NewReader(data))
+				if err != nil {
+					return fmt.Errorf("create succeeded (id %s) but applying body fields failed: %w", newID, err)
+				}
+				defer bodyResp.Body.Close()
+				fmt.Fprintf(os.Stderr, "Created {{ .NameSingular }} %q (id: %s)\n", name, newID)
+				return ctx.Output.PrintResponse(bodyResp)
+{{- else }}
 {{- if .HasVersionLock }}
 				data = setVersionLockZero(data)
 {{- end }}
@@ -2120,6 +2225,7 @@ If not, a new resource is created.` + "`" + `,
 				defer resp.Body.Close()
 				fmt.Fprintf(os.Stderr, "Created {{ .NameSingular }} %q\n", name)
 				return ctx.Output.PrintResponse(resp)
+{{- end }}
 			}
 
 			// Found — replace
@@ -2148,6 +2254,26 @@ If not, a new resource is created.` + "`" + `,
 			data, vlErr = injectVersionLocks(data, vlResp)
 			if vlErr != nil {
 				return vlErr
+			}
+{{- end }}
+{{- if .UpdateTokenOp }}
+			var tokenResp *http.Response
+			if len(tokenBody) > 0 {
+				tokenPath := strings.Replace("{{ .UpdateTokenOp.Path }}", "{{ updateTokenPathParam . }}", url.PathEscape(id), 1)
+				tr, tokenErr := ctx.Client.Do(reqCtx, "PUT", tokenPath, bytes.NewReader(tokenBody))
+				if tokenErr != nil {
+					return tokenErr
+				}
+				tokenResp = tr
+			}
+			if len(data) == 0 {
+				// Only the token was replaced — return its response.
+				defer tokenResp.Body.Close()
+				fmt.Fprintf(os.Stderr, "Replaced {{ .NameSingular }} token %q (id: %s)\n", name, id)
+				return ctx.Output.PrintResponse(tokenResp)
+			}
+			if tokenResp != nil {
+				_ = tokenResp.Body.Close()
 			}
 {{- end }}
 {{- if eq (applyUpdateMethod .Operations) "PATCH" }}
@@ -2487,6 +2613,35 @@ func injectFileFields(body []byte, specs []fileFieldSpec) ([]byte, error) {
 		return nil, fmt.Errorf("re-marshaling body after file-field injection: %w", err)
 	}
 	return out, nil
+}
+
+// removeJSONFields strips the named top-level keys from a JSON object body and
+// returns the re-marshaled result. When body is empty or not a JSON object, it is
+// returned unchanged. Used by composite apply/update flows that route some fields
+// (e.g. encodedToken, tokenFileName) to an auxiliary endpoint and must not
+// re-send them to the main body endpoint.
+func removeJSONFields(body []byte, fields ...string) ([]byte, error) {
+	if len(body) == 0 || len(fields) == 0 {
+		return body, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		return body, nil // not a JSON object — pass through
+	}
+	changed := false
+	for _, f := range fields {
+		if _, ok := m[f]; ok {
+			delete(m, f)
+			changed = true
+		}
+	}
+	if !changed {
+		return body, nil
+	}
+	if len(m) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(m)
 }
 
 // readApplyInput reads input from --from-file or stdin for apply commands.

--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -229,6 +229,39 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 		"hasDelete":      hasDelete,
 		"hasDestructive": hasDestructive,
 		"hasApply":       func(ops []*Operation) bool { return hasApply(ops) },
+		"applyUpdateMethod": func(ops []*Operation) string {
+			op := applyUpdateOp(ops)
+			if op == nil {
+				return ""
+			}
+			return op.Method
+		},
+		"applyUpdatePath": func(ops []*Operation) string {
+			op := applyUpdateOp(ops)
+			if op == nil {
+				return ""
+			}
+			return op.Path
+		},
+		"applyUpdatePathParam": func(ops []*Operation) string {
+			op := applyUpdateOp(ops)
+			if op == nil {
+				return "{id}"
+			}
+			start := strings.LastIndex(op.Path, "{")
+			end := strings.LastIndex(op.Path, "}")
+			if start >= 0 && end > start {
+				return op.Path[start : end+1]
+			}
+			return "{id}"
+		},
+		"applyUpdateContentType": func(ops []*Operation) string {
+			op := applyUpdateOp(ops)
+			if op != nil && op.Method == "PATCH" {
+				return "application/merge-patch+json"
+			}
+			return ""
+		},
 		"deletePath": func(ops []*Operation) string {
 			for _, op := range ops {
 				if op.Name == "delete" && op.Method == "DELETE" {
@@ -1168,19 +1201,38 @@ func scaffoldJSON(s *Schema) string {
 	return string(data)
 }
 
-// hasApply returns true if the resource has both create and update operations.
+// hasApply returns true if the resource has a create and a mutating update-style
+// operation suitable for upsert. The update can be PUT (full replace) or PATCH
+// (JSON merge-patch) — when both exist, PUT is preferred; when only PATCH exists,
+// apply uses PATCH with application/merge-patch+json semantics.
 func hasApply(ops []*Operation) bool {
-	hasCreate := false
-	hasUpdate := false
+	return hasApplyCreate(ops) && applyUpdateOp(ops) != nil
+}
+
+// hasApplyCreate reports whether the resource has a conventional POST create.
+func hasApplyCreate(ops []*Operation) bool {
 	for _, op := range ops {
 		if op.Name == "create" && op.Method == "POST" {
-			hasCreate = true
-		}
-		if op.Name == "update" && op.Method == "PUT" {
-			hasUpdate = true
+			return true
 		}
 	}
-	return hasCreate && hasUpdate
+	return false
+}
+
+// applyUpdateOp returns the operation that apply should use for the replace branch.
+// Prefers a PUT update; falls back to a PATCH with path param and a JSON body.
+func applyUpdateOp(ops []*Operation) *Operation {
+	for _, op := range ops {
+		if op.Name == "update" && op.Method == "PUT" {
+			return op
+		}
+	}
+	for _, op := range ops {
+		if isPatchOp(op) && hasPathParam(op.Path) {
+			return op
+		}
+	}
+	return nil
 }
 
 // hasScaffold returns true if any operation has a request body with a schema.
@@ -2087,7 +2139,7 @@ If not, a new resource is created.` + "`" + `,
 				}
 			}
 
-			updatePath := strings.Replace("{{ updatePath .Operations }}", "{{ updatePathParam .Operations }}", url.PathEscape(id), 1)
+			updatePath := strings.Replace("{{ applyUpdatePath .Operations }}", "{{ applyUpdatePathParam .Operations }}", url.PathEscape(id), 1)
 {{- if .HasVersionLock }}
 			vlResp, vlErr := fetchVersionLock(reqCtx, ctx.Client, updatePath)
 			if vlErr != nil {
@@ -2098,7 +2150,10 @@ If not, a new resource is created.` + "`" + `,
 				return vlErr
 			}
 {{- end }}
-			resp, err := ctx.Client.Do(reqCtx, "PUT", updatePath, bytes.NewReader(data))
+{{- if eq (applyUpdateMethod .Operations) "PATCH" }}
+			reqCtx = registry.WithContentType(reqCtx, "{{ applyUpdateContentType .Operations }}")
+{{- end }}
+			resp, err := ctx.Client.Do(reqCtx, "{{ applyUpdateMethod .Operations }}", updatePath, bytes.NewReader(data))
 			if err != nil {
 				return err
 			}

--- a/generator/parser/generator_test.go
+++ b/generator/parser/generator_test.go
@@ -1278,6 +1278,28 @@ func TestHasApply(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"create POST + patch op with path param (PATCH-only resource)",
+			[]*Operation{
+				{Name: "create", Method: "POST"},
+				{
+					Name: "patch", Method: "PATCH", Path: "/v1/things/{id}",
+					RequestBody: &RequestBody{Schema: &Schema{Properties: map[string]*Property{"name": {Type: "string"}}}},
+				},
+			},
+			true,
+		},
+		{
+			"PATCH op without path param does not qualify",
+			[]*Operation{
+				{Name: "create", Method: "POST"},
+				{
+					Name: "patch", Method: "PATCH", Path: "/v1/things",
+					RequestBody: &RequestBody{Schema: &Schema{Properties: map[string]*Property{"name": {Type: "string"}}}},
+				},
+			},
+			false,
+		},
 		{"empty", []*Operation{}, false},
 	}
 	for _, tt := range tests {
@@ -1287,6 +1309,36 @@ func TestHasApply(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApplyUpdateOp(t *testing.T) {
+	post := &Operation{Name: "create", Method: "POST", Path: "/v1/things"}
+	put := &Operation{Name: "update", Method: "PUT", Path: "/v1/things/{id}"}
+	patch := &Operation{
+		Name: "patch", Method: "PATCH", Path: "/v1/things/{id}",
+		RequestBody: &RequestBody{Schema: &Schema{Properties: map[string]*Property{"name": {Type: "string"}}}},
+	}
+
+	t.Run("prefers PUT when both PUT and PATCH exist", func(t *testing.T) {
+		got := applyUpdateOp([]*Operation{post, put, patch})
+		if got != put {
+			t.Errorf("got %+v, want PUT op", got)
+		}
+	})
+
+	t.Run("falls back to PATCH when no PUT exists", func(t *testing.T) {
+		got := applyUpdateOp([]*Operation{post, patch})
+		if got != patch {
+			t.Errorf("got %+v, want PATCH op", got)
+		}
+	})
+
+	t.Run("returns nil when neither exists", func(t *testing.T) {
+		got := applyUpdateOp([]*Operation{post})
+		if got != nil {
+			t.Errorf("got %+v, want nil", got)
+		}
+	})
 }
 
 func TestGenerate_ApplyCommand(t *testing.T) {

--- a/generator/parser/parser.go
+++ b/generator/parser/parser.go
@@ -121,6 +121,72 @@ func ApplyFileFields(resources []*Resource) {
 	}
 }
 
+// resourceCreateOpOverrides maps resources whose creation happens via a sub-path
+// action (e.g. POST /collection/<action>) rather than a bare POST on the collection
+// path. When set, the matching operation is renamed to "create" so the standard
+// create subcommand is generated (with its --scaffold / file-field / apply wiring),
+// and no parallel action subcommand is emitted.
+var resourceCreateOpOverrides = map[string]OpPathMethod{
+	// Jamf Pro has no POST /v1/device-enrollments; creation goes through the
+	// token-upload action endpoint.
+	"device-enrollment-instances": {Path: "/v1/device-enrollments/upload-token", Method: "POST"},
+}
+
+// OpPathMethod is a (path, method) pair used to identify an operation for overrides.
+type OpPathMethod struct {
+	Path   string
+	Method string
+}
+
+// ApplyCreateOpOverrides renames operations listed in resourceCreateOpOverrides to
+// "create" so the generator emits them as the resource's canonical create command.
+// Must be called after DeduplicateVersioned/ApplyNameOverrides so resource names
+// are canonical.
+func ApplyCreateOpOverrides(resources []*Resource) {
+	for _, r := range resources {
+		target, ok := resourceCreateOpOverrides[r.Name]
+		if !ok {
+			continue
+		}
+		for _, op := range r.Operations {
+			if op.Path == target.Path && op.Method == target.Method {
+				op.Name = "create"
+				break
+			}
+		}
+	}
+}
+
+// resourceUpdateTokenOpOverrides maps resources that have an auxiliary PUT endpoint
+// for file-field payloads (e.g. PUT /v1/device-enrollments/{id}/upload-token). When
+// matched, the operation is lifted off the resource's Operations slice (so it does
+// not produce its own subcommand) and attached to r.UpdateTokenOp, and the update/
+// apply templates route the resource's file-field flag to it.
+var resourceUpdateTokenOpOverrides = map[string]OpPathMethod{
+	"device-enrollment-instances": {Path: "/v1/device-enrollments/{id}/upload-token", Method: "PUT"},
+}
+
+// ApplyUpdateTokenOpOverrides detaches the configured auxiliary token-update op from
+// the resource's Operations slice and records it on r.UpdateTokenOp. The main update
+// command then composes a token PUT + a body PUT based on which flags are supplied.
+func ApplyUpdateTokenOpOverrides(resources []*Resource) {
+	for _, r := range resources {
+		target, ok := resourceUpdateTokenOpOverrides[r.Name]
+		if !ok {
+			continue
+		}
+		filtered := r.Operations[:0]
+		for _, op := range r.Operations {
+			if op.Path == target.Path && op.Method == target.Method {
+				r.UpdateTokenOp = op
+				continue
+			}
+			filtered = append(filtered, op)
+		}
+		r.Operations = filtered
+	}
+}
+
 // resourceNameFieldOverrides maps canonical resource names to the correct RSQL
 // filter field for name-based lookups. Used when detectNameField() returns the
 // wrong value — typically because the name lives in a nested object (e.g.

--- a/generator/parser/parser_test.go
+++ b/generator/parser/parser_test.go
@@ -2127,6 +2127,110 @@ func TestApplyNameFieldOverrides(t *testing.T) {
 	}
 }
 
+func TestApplyCreateOpOverrides(t *testing.T) {
+	// Resource matching the override map: sub-path POST should be renamed to "create".
+	target := resourceCreateOpOverrides["device-enrollment-instances"]
+	if target.Path == "" {
+		t.Fatal("resourceCreateOpOverrides missing device-enrollment-instances entry")
+	}
+
+	r := &Resource{
+		Name: "device-enrollment-instances",
+		Operations: []*Operation{
+			{Name: "list", Method: "GET", Path: "/v1/device-enrollments"},
+			{Name: "upload-token", Method: target.Method, Path: target.Path},
+			{Name: "update", Method: "PUT", Path: "/v1/device-enrollments/{id}"},
+		},
+	}
+	// Unaffected resource: keeps its op names unchanged.
+	other := &Resource{
+		Name: "buildings",
+		Operations: []*Operation{
+			{Name: "list", Method: "GET", Path: "/v1/buildings"},
+			{Name: "create", Method: "POST", Path: "/v1/buildings"},
+		},
+	}
+	ApplyCreateOpOverrides([]*Resource{r, other})
+
+	// Target op should now be named "create".
+	var got *Operation
+	for _, op := range r.Operations {
+		if op.Path == target.Path && op.Method == target.Method {
+			got = op
+			break
+		}
+	}
+	if got == nil {
+		t.Fatal("target op not found after ApplyCreateOpOverrides")
+	}
+	if got.Name != "create" {
+		t.Errorf("op name = %q, want %q", got.Name, "create")
+	}
+	// Untouched ops keep their names.
+	for _, op := range other.Operations {
+		if op.Name != "list" && op.Name != "create" {
+			t.Errorf("buildings op renamed unexpectedly to %q", op.Name)
+		}
+	}
+}
+
+func TestApplyUpdateTokenOpOverrides(t *testing.T) {
+	target := resourceUpdateTokenOpOverrides["device-enrollment-instances"]
+	if target.Path == "" {
+		t.Fatal("resourceUpdateTokenOpOverrides missing device-enrollment-instances entry")
+	}
+
+	tokenOp := &Operation{Name: "upload-token-by-id", Method: target.Method, Path: target.Path}
+	updateOp := &Operation{Name: "update", Method: "PUT", Path: "/v1/device-enrollments/{id}"}
+	r := &Resource{
+		Name: "device-enrollment-instances",
+		Operations: []*Operation{
+			{Name: "list", Method: "GET", Path: "/v1/device-enrollments"},
+			updateOp,
+			tokenOp,
+		},
+	}
+	ApplyUpdateTokenOpOverrides([]*Resource{r})
+
+	if r.UpdateTokenOp == nil {
+		t.Fatal("UpdateTokenOp not set")
+	}
+	if r.UpdateTokenOp != tokenOp {
+		t.Errorf("UpdateTokenOp = %+v, want the token op", r.UpdateTokenOp)
+	}
+	// Token op must be removed from Operations so no standalone subcommand is emitted.
+	for _, op := range r.Operations {
+		if op.Path == target.Path && op.Method == target.Method {
+			t.Errorf("token op still present in Operations: %+v", op)
+		}
+	}
+	// Other ops remain.
+	names := map[string]bool{}
+	for _, op := range r.Operations {
+		names[op.Name] = true
+	}
+	if !names["list"] || !names["update"] {
+		t.Errorf("unexpected Operations after detach: %v", names)
+	}
+}
+
+func TestApplyUpdateTokenOpOverrides_NoMatch(t *testing.T) {
+	// Resources not in the override map are untouched.
+	r := &Resource{
+		Name: "buildings",
+		Operations: []*Operation{
+			{Name: "update", Method: "PUT", Path: "/v1/buildings/{id}"},
+		},
+	}
+	ApplyUpdateTokenOpOverrides([]*Resource{r})
+	if r.UpdateTokenOp != nil {
+		t.Errorf("UpdateTokenOp set on unrelated resource: %+v", r.UpdateTokenOp)
+	}
+	if len(r.Operations) != 1 {
+		t.Errorf("unrelated resource Operations mutated: %d ops", len(r.Operations))
+	}
+}
+
 func TestParseSchema_AllOfFlattening(t *testing.T) {
 	t.Run("merges properties from allOf items", func(t *testing.T) {
 		schema := &openapi3.Schema{

--- a/generator/parser/types.go
+++ b/generator/parser/types.go
@@ -51,6 +51,7 @@ type Resource struct {
 	TableColumns      []TableColumn // Preferred columns for list table output (when set, overrides generic column selection)
 	DefaultSections   []string      // Default --section values for list (when set, fetches these sections for table output)
 	GetDetailPath     string        // When set, "get" uses this path by default (returns all sections). If the get op has a section param, --section overrides back to the original path.
+	UpdateTokenOp     *Operation    // Optional: auxiliary PUT endpoint for file-field payloads (e.g. PUT /{id}/upload-token). When set, update/apply route the file-field flag to this endpoint instead of the main update body, and no standalone subcommand is emitted for it.
 }
 
 // Operation represents an API operation (endpoint)

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -20,26 +19,55 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/config"
 	"github.com/Jamf-Concepts/jamf-cli/internal/keychain"
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 )
 
-func newConfigCmd() *cobra.Command {
+func newConfigCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage CLI configuration and profiles",
 	}
 
-	cmd.AddCommand(newConfigShowCmd())
+	cmd.AddCommand(newConfigShowCmd(cliCtx))
 	cmd.AddCommand(newConfigPathCmd())
-	cmd.AddCommand(newConfigListCmd())
+	cmd.AddCommand(newConfigListCmd(cliCtx))
 	cmd.AddCommand(newConfigAddProfileCmd())
 	cmd.AddCommand(newConfigRemoveProfileCmd())
 	cmd.AddCommand(newConfigSetDefaultCmd())
-	cmd.AddCommand(newConfigValidateCmd())
+	cmd.AddCommand(newConfigValidateCmd(cliCtx))
 
 	return cmd
 }
 
-func newConfigShowCmd() *cobra.Command {
+// configProfileRow is the per-profile row shape emitted by `show` and `list`.
+// Fields use JSON tags so the output formatter renders stable column names
+// across table/json/yaml/csv.
+type configProfileRow struct {
+	Name         string `json:"name"`
+	URL          string `json:"url"`
+	AuthMethod   string `json:"auth-method"`
+	TenantID     string `json:"tenant-id,omitempty"`
+	Default      bool   `json:"default,omitempty"`
+	Token        string `json:"token,omitempty"`
+	ClientID     string `json:"client-id,omitempty"`
+	ClientSecret string `json:"client-secret,omitempty"`
+	Status       string `json:"status,omitempty"`
+	Healthy      *bool  `json:"healthy,omitempty"`
+}
+
+// activeProfileName returns the profile currently in effect: flag > env > default.
+func activeProfileName(cfg *config.Config) string {
+	active := profile
+	if active == "" {
+		active = os.Getenv("JAMF_PROFILE")
+	}
+	if active == "" {
+		active = cfg.DefaultProfile
+	}
+	return active
+}
+
+func newConfigShowCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	return &cobra.Command{
 		Use:   "show",
 		Short: "Show resolved configuration with sources",
@@ -49,15 +77,35 @@ func newConfigShowCmd() *cobra.Command {
 				return err
 			}
 
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "# Config file: %s\n", config.ConfigPath())
+			active := activeProfileName(cfg)
+			names := sortedProfileNames(cfg)
+			profiles := make([]configProfileRow, 0, len(names))
+			for _, name := range names {
+				p := cfg.Profiles[name]
+				profiles = append(profiles, configProfileRow{
+					Name:         name,
+					URL:          p.URL,
+					AuthMethod:   p.AuthMethod,
+					TenantID:     p.TenantID,
+					Default:      name == active,
+					Token:        p.Token,
+					ClientID:     p.ClientID,
+					ClientSecret: p.ClientSecret,
+				})
+			}
 
-			data, err := yaml.Marshal(cfg)
+			out := map[string]any{
+				"config-file":     config.ConfigPath(),
+				"default-profile": cfg.DefaultProfile,
+				"default-output":  cfg.DefaultOutput,
+				"profiles":        profiles,
+			}
+
+			data, err := json.Marshal(out)
 			if err != nil {
 				return fmt.Errorf("marshalling config for display: %w", err)
 			}
-
-			_, _ = fmt.Fprint(cmd.OutOrStdout(), string(data))
-			return nil
+			return cliCtx.Output.PrintRaw(data)
 		},
 	}
 }
@@ -103,7 +151,7 @@ func checkHealth(baseURL string) healthResult {
 	return healthResult{checks[0], false}
 }
 
-func newConfigListCmd() *cobra.Command {
+func newConfigListCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var status bool
 
 	cmd := &cobra.Command{
@@ -117,24 +165,14 @@ func newConfigListCmd() *cobra.Command {
 			}
 
 			if len(cfg.Profiles) == 0 {
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No profiles configured. Run: jamf-cli config add-profile <name> --url <url>")
-				return nil
+				// No rows to format — emit a structured empty list and a
+				// helper hint to stderr for interactive users.
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "No profiles configured. Run: jamf-cli config add-profile <name> --url <url>")
+				return cliCtx.Output.PrintRaw([]byte("[]"))
 			}
 
-			// Determine active profile: flag > env > default
-			active := profile
-			if active == "" {
-				active = os.Getenv("JAMF_PROFILE")
-			}
-			if active == "" {
-				active = cfg.DefaultProfile
-			}
-
-			names := make([]string, 0, len(cfg.Profiles))
-			for name := range cfg.Profiles {
-				names = append(names, name)
-			}
-			sort.Strings(names)
+			active := activeProfileName(cfg)
+			names := sortedProfileNames(cfg)
 
 			// Run health checks in parallel when --status is set
 			var results map[string]healthResult
@@ -155,34 +193,30 @@ func newConfigListCmd() *cobra.Command {
 				wg.Wait()
 			}
 
-			w := cmd.OutOrStdout()
+			rows := make([]configProfileRow, 0, len(names))
 			for _, name := range names {
 				p := cfg.Profiles[name]
-				marker := " "
-				if name == active {
-					marker = "*"
+				row := configProfileRow{
+					Name:       name,
+					URL:        p.URL,
+					AuthMethod: p.AuthMethod,
+					TenantID:   p.TenantID,
+					Default:    name == active,
 				}
-
-				if !status {
-					_, _ = fmt.Fprintf(w, "  %s %-20s %-40s %s\n", marker, name, p.URL, p.AuthMethod)
-					continue
+				if status {
+					r := results[name]
+					row.Status = r.Status
+					healthy := r.Healthy
+					row.Healthy = &healthy
 				}
-
-				r := results[name]
-				var statusCol string
-				if noColor {
-					statusCol = r.Status
-				} else if r.Healthy {
-					statusCol = "\033[32m●\033[0m " + r.Status
-				} else if r.Status == "offline" || strings.HasPrefix(r.Status, "HTTP") {
-					statusCol = "\033[31m●\033[0m " + r.Status
-				} else {
-					statusCol = "\033[33m●\033[0m " + r.Status
-				}
-				_, _ = fmt.Fprintf(w, "  %s %-20s %-40s %-8s %s\n", marker, name, p.URL, p.AuthMethod, statusCol)
+				rows = append(rows, row)
 			}
 
-			return nil
+			data, err := json.Marshal(rows)
+			if err != nil {
+				return fmt.Errorf("marshalling profiles: %w", err)
+			}
+			return cliCtx.Output.PrintRaw(data)
 		},
 	}
 
@@ -436,41 +470,49 @@ func newConfigSetDefaultCmd() *cobra.Command {
 	}
 }
 
-func newConfigValidateCmd() *cobra.Command {
+// validateCheck is one line of validation output.
+type validateCheck struct {
+	Scope   string `json:"scope"` // "config" or profile name
+	Name    string `json:"name"`
+	Status  string `json:"status"` // "pass" or "fail"
+	Message string `json:"message,omitempty"`
+}
+
+func newConfigValidateCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var connectivity bool
 
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate config file and profile settings",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			w := cmd.OutOrStdout()
 			path := config.ConfigPath()
-			hasErrors := false
-
-			pass := func(msg string) { _, _ = fmt.Fprintf(w, "  \u2713 %s\n", msg) }
-			fail := func(msg string) { _, _ = fmt.Fprintf(w, "  \u2717 %s\n", msg); hasErrors = true }
-
-			_, _ = fmt.Fprintf(w, "Config file: %s\n", path)
+			var checks []validateCheck
+			pass := func(scope, name string) {
+				checks = append(checks, validateCheck{Scope: scope, Name: name, Status: "pass"})
+			}
+			fail := func(scope, name, msg string) {
+				checks = append(checks, validateCheck{Scope: scope, Name: name, Status: "fail", Message: msg})
+			}
 
 			// 1. File exists
 			data, err := os.ReadFile(path)
 			if err != nil {
 				if os.IsNotExist(err) {
-					fail("File does not exist")
-					return fmt.Errorf("config file not found at %s", path)
+					fail("config", "file-exists", fmt.Sprintf("no file at %s", path))
+					return emitValidateAndFail(cliCtx, checks, fmt.Errorf("config file not found at %s", path))
 				}
-				fail(fmt.Sprintf("Cannot read file: %v", err))
-				return err
+				fail("config", "file-readable", err.Error())
+				return emitValidateAndFail(cliCtx, checks, err)
 			}
-			pass("File exists")
+			pass("config", "file-exists")
 
 			// 2. Valid YAML
 			var cfg config.Config
 			if err := yaml.Unmarshal(data, &cfg); err != nil {
-				fail(fmt.Sprintf("Invalid YAML: %v", err))
-				return fmt.Errorf("config file is not valid YAML")
+				fail("config", "valid-yaml", err.Error())
+				return emitValidateAndFail(cliCtx, checks, fmt.Errorf("config file is not valid YAML"))
 			}
-			pass("Valid YAML")
+			pass("config", "valid-yaml")
 
 			if cfg.Profiles == nil {
 				cfg.Profiles = make(map[string]config.Profile)
@@ -482,39 +524,32 @@ func newConfigValidateCmd() *cobra.Command {
 					"table": true, "json": true, "csv": true, "yaml": true, "plain": true,
 				}
 				if validFormats[cfg.DefaultOutput] {
-					pass(fmt.Sprintf("Default output format: %s", cfg.DefaultOutput))
+					pass("config", "default-output")
 				} else {
-					fail(fmt.Sprintf("Invalid default-output %q (must be table, json, csv, yaml, or plain)", cfg.DefaultOutput))
+					fail("config", "default-output", fmt.Sprintf("invalid %q (must be table, json, csv, yaml, or plain)", cfg.DefaultOutput))
 				}
 			}
 
 			// 4. default-profile references existing profile
 			if cfg.DefaultProfile != "" {
 				if _, ok := cfg.Profiles[cfg.DefaultProfile]; ok {
-					pass(fmt.Sprintf("Default profile: %s", cfg.DefaultProfile))
+					pass("config", "default-profile")
 				} else {
-					fail(fmt.Sprintf("Default profile %q not found in profiles", cfg.DefaultProfile))
+					fail("config", "default-profile", fmt.Sprintf("%q not found in profiles", cfg.DefaultProfile))
 				}
 			}
 
 			// 5-7. Validate each profile
-			names := make([]string, 0, len(cfg.Profiles))
-			for name := range cfg.Profiles {
-				names = append(names, name)
-			}
-			sort.Strings(names)
-
 			validAuthMethods := map[string]bool{"token": true, "oauth2": true, "platform": true}
 
-			for _, name := range names {
+			for _, name := range sortedProfileNames(&cfg) {
 				p := cfg.Profiles[name]
-				_, _ = fmt.Fprintf(w, "\nProfile %q:\n", name)
 
 				// URL
 				if p.URL != "" {
-					pass(fmt.Sprintf("URL: %s", p.URL))
+					pass(name, "url")
 				} else {
-					fail("Missing url")
+					fail(name, "url", "missing")
 				}
 
 				// Auth method
@@ -522,68 +557,27 @@ func newConfigValidateCmd() *cobra.Command {
 				if authMethod == "" {
 					authMethod = "token"
 				}
-				if validAuthMethods[authMethod] {
-					pass(fmt.Sprintf("Auth method: %s", authMethod))
-				} else {
-					fail(fmt.Sprintf("Invalid auth-method %q", authMethod))
+				if !validAuthMethods[authMethod] {
+					fail(name, "auth-method", fmt.Sprintf("invalid %q", authMethod))
 					continue
 				}
+				pass(name, "auth-method")
 
 				// Auth-method-specific fields
 				switch authMethod {
 				case "platform":
-					if p.ClientID == "" {
-						fail("Missing client-id")
-					} else {
-						if _, err := config.ResolveSecret(p.ClientID); err != nil {
-							fail(fmt.Sprintf("client-id not resolvable: %v", err))
-						} else {
-							pass("client-id resolvable")
-						}
-					}
-					if p.ClientSecret == "" {
-						fail("Missing client-secret")
-					} else {
-						if _, err := config.ResolveSecret(p.ClientSecret); err != nil {
-							fail(fmt.Sprintf("client-secret not resolvable: %v", err))
-						} else {
-							pass("client-secret resolvable")
-						}
-					}
+					checkSecretField(&checks, name, "client-id", p.ClientID)
+					checkSecretField(&checks, name, "client-secret", p.ClientSecret)
 					if p.TenantID == "" {
-						fail("Missing tenant-id")
+						fail(name, "tenant-id", "missing")
 					} else {
-						pass(fmt.Sprintf("Tenant ID: %s", p.TenantID))
+						pass(name, "tenant-id")
 					}
 				case "oauth2":
-					if p.ClientID == "" {
-						fail("Missing client-id")
-					} else {
-						if _, err := config.ResolveSecret(p.ClientID); err != nil {
-							fail(fmt.Sprintf("client-id not resolvable: %v", err))
-						} else {
-							pass("client-id resolvable")
-						}
-					}
-					if p.ClientSecret == "" {
-						fail("Missing client-secret")
-					} else {
-						if _, err := config.ResolveSecret(p.ClientSecret); err != nil {
-							fail(fmt.Sprintf("client-secret not resolvable: %v", err))
-						} else {
-							pass("client-secret resolvable")
-						}
-					}
+					checkSecretField(&checks, name, "client-id", p.ClientID)
+					checkSecretField(&checks, name, "client-secret", p.ClientSecret)
 				case "token":
-					if p.Token == "" {
-						fail("Missing token")
-					} else {
-						if _, err := config.ResolveSecret(p.Token); err != nil {
-							fail(fmt.Sprintf("token not resolvable: %v", err))
-						} else {
-							pass("token resolvable")
-						}
-					}
+					checkSecretField(&checks, name, "token", p.Token)
 				}
 
 				// Optional connectivity check
@@ -591,25 +585,32 @@ func newConfigValidateCmd() *cobra.Command {
 					httpClient := &http.Client{Timeout: 10 * time.Second}
 					req, err := http.NewRequestWithContext(cmd.Context(), "HEAD", p.URL, nil)
 					if err != nil {
-						fail(fmt.Sprintf("Connectivity: invalid URL: %v", err))
+						fail(name, "connectivity", fmt.Sprintf("invalid URL: %v", err))
 					} else {
 						resp, err := httpClient.Do(req)
 						if err != nil {
-							fail(fmt.Sprintf("Connectivity: %v", err))
+							fail(name, "connectivity", err.Error())
 						} else {
 							_ = resp.Body.Close()
-							pass(fmt.Sprintf("Connectivity: reachable (HTTP %d)", resp.StatusCode))
+							checks = append(checks, validateCheck{
+								Scope:   name,
+								Name:    "connectivity",
+								Status:  "pass",
+								Message: fmt.Sprintf("HTTP %d", resp.StatusCode),
+							})
 						}
 					}
 				}
 			}
 
-			_, _ = fmt.Fprintln(w)
-			if hasErrors {
-				_, _ = fmt.Fprintln(w, "\u2717 Validation completed with errors.")
-				return fmt.Errorf("config validation failed")
+			if err := emitValidate(cliCtx, checks); err != nil {
+				return err
 			}
-			_, _ = fmt.Fprintln(w, "\u2713 All checks passed.")
+			for _, c := range checks {
+				if c.Status == "fail" {
+					return fmt.Errorf("config validation failed")
+				}
+			}
 			return nil
 		},
 	}
@@ -617,4 +618,32 @@ func newConfigValidateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&connectivity, "connectivity", false, "test server reachability for each profile")
 
 	return cmd
+}
+
+// checkSecretField fails when the value is empty or not resolvable, otherwise passes.
+func checkSecretField(checks *[]validateCheck, profileName, field, value string) {
+	if value == "" {
+		*checks = append(*checks, validateCheck{Scope: profileName, Name: field, Status: "fail", Message: "missing"})
+		return
+	}
+	if _, err := config.ResolveSecret(value); err != nil {
+		*checks = append(*checks, validateCheck{Scope: profileName, Name: field, Status: "fail", Message: fmt.Sprintf("not resolvable: %v", err)})
+		return
+	}
+	*checks = append(*checks, validateCheck{Scope: profileName, Name: field, Status: "pass"})
+}
+
+func emitValidate(cliCtx *registry.CLIContext, checks []validateCheck) error {
+	data, err := json.Marshal(checks)
+	if err != nil {
+		return fmt.Errorf("marshalling validation results: %w", err)
+	}
+	return cliCtx.Output.PrintRaw(data)
+}
+
+func emitValidateAndFail(cliCtx *registry.CLIContext, checks []validateCheck, cause error) error {
+	if err := emitValidate(cliCtx, checks); err != nil {
+		return err
+	}
+	return cause
 }

--- a/internal/commands/config_subcommands_test.go
+++ b/internal/commands/config_subcommands_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,7 +15,17 @@ import (
 	"testing"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/config"
+	"github.com/Jamf-Concepts/jamf-cli/internal/output"
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 )
+
+// newTestCtx builds a CLIContext whose Output writes to w in the given format.
+// Used to capture structured output from config commands in tests.
+func newTestCtx(w io.Writer, format string) *registry.CLIContext {
+	formatter := output.New(format, true, false)
+	formatter.SetWriter(w)
+	return &registry.CLIContext{Output: &cliOutput{formatter}}
+}
 
 // --- config show tests ---
 
@@ -29,8 +40,8 @@ profiles:
 `
 	_ = os.WriteFile(filepath.Join(jDir, "config.yaml"), []byte(yaml), 0o600)
 
-	cmd := newConfigShowCmd()
 	buf := &bytes.Buffer{}
+	cmd := newConfigShowCmd(newTestCtx(buf, "json"))
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
 
@@ -39,19 +50,22 @@ profiles:
 	}
 
 	out := buf.String()
-	if !strings.Contains(out, "# Config file:") {
-		t.Error("expected config file header")
+	if !strings.Contains(out, `"config-file"`) {
+		t.Errorf("expected config-file key in output:\n%s", out)
 	}
 	if !strings.Contains(out, "prod.jamfcloud.com") {
-		t.Error("expected URL in output")
+		t.Errorf("expected URL in output:\n%s", out)
+	}
+	if !strings.Contains(out, `"default-profile": "prod"`) {
+		t.Errorf("expected default-profile in output:\n%s", out)
 	}
 }
 
 func TestConfigShow_MissingFile(t *testing.T) {
 	setupTempConfig(t)
 
-	cmd := newConfigShowCmd()
 	buf := &bytes.Buffer{}
+	cmd := newConfigShowCmd(newTestCtx(buf, "json"))
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
 
@@ -85,8 +99,8 @@ func TestConfigPath_PrintsPath(t *testing.T) {
 func TestConfigList_Empty(t *testing.T) {
 	setupTempConfig(t)
 
-	cmd := newConfigListCmd()
 	buf := &bytes.Buffer{}
+	cmd := newConfigListCmd(newTestCtx(buf, "json"))
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
 
@@ -94,8 +108,12 @@ func TestConfigList_Empty(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !strings.Contains(buf.String(), "No profiles configured") {
-		t.Errorf("expected 'No profiles configured' message, got:\n%s", buf.String())
+	out := buf.String()
+	if !strings.Contains(out, "No profiles configured") {
+		t.Errorf("expected 'No profiles configured' hint on stderr, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[]") {
+		t.Errorf("expected empty JSON array when no profiles, got:\n%s", out)
 	}
 }
 
@@ -112,8 +130,8 @@ profiles:
 `
 	_ = os.WriteFile(filepath.Join(jDir, "config.yaml"), []byte(yaml), 0o600)
 
-	cmd := newConfigListCmd()
 	buf := &bytes.Buffer{}
+	cmd := newConfigListCmd(newTestCtx(buf, "json"))
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
 
@@ -121,16 +139,21 @@ profiles:
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	out := buf.String()
-	// Alpha should be marked as active (default)
-	if !strings.Contains(out, "* alpha") {
-		t.Error("expected alpha to be marked as default with *")
+	var rows []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rows); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
 	}
-	if !strings.Contains(out, "beta") {
-		t.Error("expected beta in output")
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d: %v", len(rows), rows)
 	}
-	if !strings.Contains(out, "alpha.jamfcloud.com") {
-		t.Error("expected alpha URL in output")
+	if rows[0]["name"] != "alpha" || rows[0]["default"] != true {
+		t.Errorf("expected alpha as default, got: %v", rows[0])
+	}
+	if rows[1]["name"] != "beta" {
+		t.Errorf("expected beta second, got: %v", rows[1])
+	}
+	if rows[0]["url"] != "https://alpha.jamfcloud.com" {
+		t.Errorf("expected alpha URL, got: %v", rows[0]["url"])
 	}
 }
 
@@ -383,8 +406,8 @@ func TestConfigList_WithStatus(t *testing.T) {
 			yaml := fmt.Sprintf("default-profile: test\nprofiles:\n  test:\n    url: %s\n    auth-method: token\n", srv.URL)
 			_ = os.WriteFile(filepath.Join(jDir, "config.yaml"), []byte(yaml), 0o600)
 
-			cmd := newConfigListCmd()
 			buf := &bytes.Buffer{}
+			cmd := newConfigListCmd(newTestCtx(buf, "json"))
 			cmd.SetOut(buf)
 			cmd.SetErr(buf)
 			cmd.SetArgs([]string{"--status"})

--- a/internal/commands/config_validate_test.go
+++ b/internal/commands/config_validate_test.go
@@ -40,8 +40,8 @@ func runValidateCmd(t *testing.T, yamlContent string) (string, error) {
 		}
 	}
 
-	cmd := newConfigValidateCmd()
 	buf := &bytes.Buffer{}
+	cmd := newConfigValidateCmd(newTestCtx(buf, "json"))
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
 
@@ -66,8 +66,8 @@ profiles:
 	if err != nil {
 		t.Fatalf("expected no error, got: %v\nOutput:\n%s", err, out)
 	}
-	if !strings.Contains(out, "All checks passed") {
-		t.Errorf("expected 'All checks passed' in output:\n%s", out)
+	if strings.Contains(out, `"fail"`) {
+		t.Errorf("expected no failures, got:\n%s", out)
 	}
 }
 
@@ -80,8 +80,8 @@ func TestConfigValidate_MissingFile(t *testing.T) {
 	}
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	cmd := newConfigValidateCmd()
 	buf := &bytes.Buffer{}
+	cmd := newConfigValidateCmd(newTestCtx(buf, "json"))
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
 
@@ -90,8 +90,8 @@ func TestConfigValidate_MissingFile(t *testing.T) {
 		t.Fatal("expected error for missing config file")
 		return
 	}
-	if !strings.Contains(buf.String(), "does not exist") {
-		t.Errorf("expected 'does not exist' in output:\n%s", buf.String())
+	if !strings.Contains(buf.String(), "no file at") {
+		t.Errorf("expected 'no file at' message in output:\n%s", buf.String())
 	}
 }
 
@@ -101,8 +101,8 @@ func TestConfigValidate_InvalidYAML(t *testing.T) {
 		t.Fatal("expected error for invalid YAML")
 		return
 	}
-	if !strings.Contains(out, "Invalid YAML") {
-		t.Errorf("expected 'Invalid YAML' in output:\n%s", out)
+	if !strings.Contains(out, `"valid-yaml"`) || !strings.Contains(out, `"fail"`) {
+		t.Errorf("expected valid-yaml failure in output:\n%s", out)
 	}
 }
 
@@ -116,8 +116,8 @@ profiles: {}
 		t.Fatal("expected error for invalid output format")
 		return
 	}
-	if !strings.Contains(out, "Invalid default-output") {
-		t.Errorf("expected 'Invalid default-output' in output:\n%s", out)
+	if !strings.Contains(out, `"default-output"`) || !strings.Contains(out, `"fail"`) {
+		t.Errorf("expected default-output failure in output:\n%s", out)
 	}
 }
 
@@ -139,6 +139,9 @@ profiles:
 	if !strings.Contains(out, "not found in profiles") {
 		t.Errorf("expected 'not found in profiles' in output:\n%s", out)
 	}
+	if !strings.Contains(out, `"default-profile"`) {
+		t.Errorf("expected default-profile key in output:\n%s", out)
+	}
 }
 
 func TestConfigValidate_MissingURL(t *testing.T) {
@@ -154,8 +157,8 @@ profiles:
 		t.Fatal("expected error for missing URL")
 		return
 	}
-	if !strings.Contains(out, "Missing url") {
-		t.Errorf("expected 'Missing url' in output:\n%s", out)
+	if !strings.Contains(out, `"url"`) || !strings.Contains(out, `"missing"`) {
+		t.Errorf("expected missing url failure in output:\n%s", out)
 	}
 }
 
@@ -171,8 +174,8 @@ profiles:
 		t.Fatal("expected error for invalid auth method")
 		return
 	}
-	if !strings.Contains(out, "Invalid auth-method") {
-		t.Errorf("expected 'Invalid auth-method' in output:\n%s", out)
+	if !strings.Contains(out, `"auth-method"`) || !strings.Contains(out, `"invalid \"magic\""`) {
+		t.Errorf("expected invalid auth-method failure in output:\n%s", out)
 	}
 }
 
@@ -188,11 +191,14 @@ profiles:
 		t.Fatal("expected error for missing oauth2 credentials")
 		return
 	}
-	if !strings.Contains(out, "Missing client-id") {
-		t.Errorf("expected 'Missing client-id' in output:\n%s", out)
+	if !strings.Contains(out, `"client-id"`) {
+		t.Errorf("expected client-id check in output:\n%s", out)
 	}
-	if !strings.Contains(out, "Missing client-secret") {
-		t.Errorf("expected 'Missing client-secret' in output:\n%s", out)
+	if !strings.Contains(out, `"client-secret"`) {
+		t.Errorf("expected client-secret check in output:\n%s", out)
+	}
+	if strings.Count(out, `"missing"`) < 2 {
+		t.Errorf("expected both client-id and client-secret to be missing:\n%s", out)
 	}
 }
 
@@ -227,8 +233,8 @@ profiles:
 	if err != nil {
 		t.Fatalf("expected no error, got: %v\nOutput:\n%s", err, out)
 	}
-	if !strings.Contains(out, "token resolvable") {
-		t.Errorf("expected 'token resolvable' in output:\n%s", out)
+	if !strings.Contains(out, `"name": "token"`) || !strings.Contains(out, `"pass"`) {
+		t.Errorf("expected token pass in output:\n%s", out)
 	}
 }
 
@@ -300,11 +306,11 @@ profiles:
 	if err != nil {
 		t.Fatalf("expected no error, got: %v\nOutput:\n%s", err, out)
 	}
-	if !strings.Contains(out, "client-id resolvable") {
-		t.Errorf("expected 'client-id resolvable' in output:\n%s", out)
+	if !strings.Contains(out, `"client-id"`) || !strings.Contains(out, `"client-secret"`) {
+		t.Errorf("expected client-id and client-secret checks in output:\n%s", out)
 	}
-	if !strings.Contains(out, "client-secret resolvable") {
-		t.Errorf("expected 'client-secret resolvable' in output:\n%s", out)
+	if strings.Contains(out, `"fail"`) {
+		t.Errorf("expected no failures with keychain-backed secrets:\n%s", out)
 	}
 }
 

--- a/internal/commands/pro/generated/adcs_settings.go
+++ b/internal/commands/pro/generated/adcs_settings.go
@@ -35,6 +35,7 @@ func NewAdcsSettingsCmd(ctx *registry.CLIContext) *cobra.Command {
 	cmd.AddCommand(newAdcsSettingsValidateClientCertificateCmd(ctx))
 	cmd.AddCommand(newAdcsSettingsPatchCmd(ctx))
 	cmd.AddCommand(newAdcsSettingsDependenciesCmd(ctx))
+	cmd.AddCommand(newAdcsSettingsApplyCmd(ctx))
 
 	return cmd
 }
@@ -810,6 +811,130 @@ func newAdcsSettingsDependenciesCmd(ctx *registry.CLIContext) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flagName, "name", "", "Look up adcs-setting by name")
+
+	return cmd
+}
+
+func newAdcsSettingsApplyCmd(ctx *registry.CLIContext) *cobra.Command {
+	var (
+		fromFile     string
+		flagYes      bool
+		flagDryRun   bool
+		flagScaffold bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Create or replace a adcs-setting by name",
+		Long: `Create or replace a adcs-setting. Reads JSON or YAML from --from-file or stdin.
+
+The displayName field in the input is used to check if the resource
+already exists. If it does, the resource is replaced (with confirmation).
+If not, a new resource is created.`,
+		Example: `  # Apply a adcs-setting from a JSON file
+  jamf-cli adcs-settings apply --from-file adcs-setting.json
+
+  # Apply a adcs-setting from a YAML file
+  jamf-cli adcs-settings apply --from-file adcs-setting.yaml
+
+  # Apply from stdin
+  cat adcs-setting.json | jamf-cli adcs-settings apply
+
+  # Apply without replacement confirmation
+  jamf-cli adcs-settings apply --from-file adcs-setting.json --yes
+
+  # Preview what would happen
+  jamf-cli adcs-settings apply --from-file adcs-setting.json --dry-run`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reqCtx := cmd.Context()
+			if flagScaffold {
+				return printScaffoldOutput(`{
+  "adcsUrl": "https://\u003chost-name\u003e.example.com",
+  "apiClientId": "A11B43D6-9ED4-4B29-B726-E2DE747D2410",
+  "caName": "EXAMPLE-SUBCA02-CA",
+  "clientCert": {},
+  "displayName": "Example Display Name",
+  "fqdn": "example-subca02.example.com",
+  "outbound": true,
+  "revocationEnabled": true,
+  "serverCert": {}
+}`, ctx.Output.Format())
+			}
+
+			// Read input (JSON or YAML). When file flags are present, empty input
+			// is OK — the file-field injector constructs a minimal body.
+			data, err := readApplyInput(fromFile)
+			if err != nil {
+				return err
+			}
+			if len(data) > 0 {
+				data, err = normalizeInputToJSON(data)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Extract name from JSON input
+			name, err := extractJSONField(data, "displayName")
+			if err != nil {
+				return fmt.Errorf("input must include a %q field: %w", "displayName", err)
+			}
+
+			// Check if resource exists by name (read-only, runs even in dry-run)
+			noInput, _ := cmd.Flags().GetBool("no-input")
+			id, err := resolveNameToIDForApply(reqCtx, ctx.Client, "/v1/pki/adcs-settings", "displayName", "id", name, noInput)
+			if err != nil {
+				return err
+			}
+
+			if id == "" {
+				// Not found — create
+				if flagDryRun {
+					fmt.Fprintf(os.Stderr, "[dry-run] Would create adcs-setting %q\n", name)
+					return nil
+				}
+				resp, err := ctx.Client.Do(reqCtx, "POST", "/v1/pki/adcs-settings", bytes.NewReader(data))
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				fmt.Fprintf(os.Stderr, "Created adcs-setting %q\n", name)
+				return ctx.Output.PrintResponse(resp)
+			}
+
+			// Found — replace
+			if flagDryRun {
+				fmt.Fprintf(os.Stderr, "[dry-run] Would replace adcs-setting %q (id: %s)\n", name, id)
+				return nil
+			}
+			if !flagYes {
+				if noInput {
+					return fmt.Errorf("adcs-setting %q already exists (id: %s); use --yes to replace when --no-input is set", name, id)
+				}
+				fmt.Fprintf(os.Stderr, "adcs-setting %q already exists (id: %s) and will be replaced. Type 'yes' to confirm: ", name, id)
+				var confirm string
+				fmt.Scanln(&confirm)
+				if confirm != "yes" {
+					return fmt.Errorf("aborted")
+				}
+			}
+
+			updatePath := strings.Replace("/v1/pki/adcs-settings/{id}", "{id}", url.PathEscape(id), 1)
+			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			resp, err := ctx.Client.Do(reqCtx, "PATCH", updatePath, bytes.NewReader(data))
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			fmt.Fprintf(os.Stderr, "Replaced adcs-setting %q (id: %s)\n", name, id)
+			return ctx.Output.PrintResponse(resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to JSON or YAML input file (or pipe to stdin)")
+	cmd.Flags().BoolVar(&flagYes, "yes", false, "Skip confirmation prompt when replacing")
+	cmd.Flags().BoolVarP(&flagDryRun, "dry-run", "n", false, "Preview without executing")
+	cmd.Flags().BoolVar(&flagScaffold, "scaffold", false, "Print a JSON template for the request body and exit")
 
 	return cmd
 }

--- a/internal/commands/pro/generated/computers_inventory.go
+++ b/internal/commands/pro/generated/computers_inventory.go
@@ -39,6 +39,7 @@ func NewComputersInventoryCmd(ctx *registry.CLIContext) *cobra.Command {
 	cmd.AddCommand(newComputersInventoryFilevaultByIdCmd(ctx))
 	cmd.AddCommand(newComputersInventoryViewDeviceLockPinCmd(ctx))
 	cmd.AddCommand(newComputersInventoryViewRecoveryLockPasswordCmd(ctx))
+	cmd.AddCommand(newComputersInventoryApplyCmd(ctx))
 
 	return cmd
 }
@@ -1156,6 +1157,137 @@ func newComputersInventoryViewRecoveryLockPasswordCmd(ctx *registry.CLIContext) 
 	cmd.Flags().StringVar(&flagName, "name", "", "Look up computers-inventory by name")
 	cmd.Flags().StringVar(&flagSerial, "serial", "", "Look up computer by serial number")
 	cmd.Flags().StringVar(&flagUdid, "udid", "", "Look up computer by UDID")
+
+	return cmd
+}
+
+func newComputersInventoryApplyCmd(ctx *registry.CLIContext) *cobra.Command {
+	var (
+		fromFile     string
+		flagYes      bool
+		flagDryRun   bool
+		flagScaffold bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Create or replace a computers-inventory by name",
+		Long: `Create or replace a computers-inventory. Reads JSON or YAML from --from-file or stdin.
+
+The general.name field in the input is used to check if the resource
+already exists. If it does, the resource is replaced (with confirmation).
+If not, a new resource is created.`,
+		Example: `  # Apply a computers-inventory from a JSON file
+  jamf-cli computers-inventory apply --from-file computers-inventory.json
+
+  # Apply a computers-inventory from a YAML file
+  jamf-cli computers-inventory apply --from-file computers-inventory.yaml
+
+  # Apply from stdin
+  cat computers-inventory.json | jamf-cli computers-inventory apply
+
+  # Apply without replacement confirmation
+  jamf-cli computers-inventory apply --from-file computers-inventory.json --yes
+
+  # Preview what would happen
+  jamf-cli computers-inventory apply --from-file computers-inventory.json --dry-run`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reqCtx := cmd.Context()
+			if flagScaffold {
+				return printScaffoldOutput(`{
+  "applications": [],
+  "certificates": [],
+  "configurationProfiles": [],
+  "general": {},
+  "hardware": {},
+  "localUserAccounts": [],
+  "operatingSystem": {},
+  "packageReceipts": {},
+  "printers": [],
+  "purchasing": {},
+  "security": {},
+  "services": [],
+  "softwareUpdates": [],
+  "storage": {},
+  "udid": "45436edf-864e-4364-982a-330b01d39e65",
+  "userAndLocation": {}
+}`, ctx.Output.Format())
+			}
+
+			// Read input (JSON or YAML). When file flags are present, empty input
+			// is OK — the file-field injector constructs a minimal body.
+			data, err := readApplyInput(fromFile)
+			if err != nil {
+				return err
+			}
+			if len(data) > 0 {
+				data, err = normalizeInputToJSON(data)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Extract name from JSON input
+			name, err := extractJSONField(data, "general.name")
+			if err != nil {
+				return fmt.Errorf("input must include a %q field: %w", "general.name", err)
+			}
+
+			// Check if resource exists by name (read-only, runs even in dry-run)
+			noInput, _ := cmd.Flags().GetBool("no-input")
+			id, err := resolveNameToIDForApply(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", name, noInput)
+			if err != nil {
+				return err
+			}
+
+			if id == "" {
+				// Not found — create
+				if flagDryRun {
+					fmt.Fprintf(os.Stderr, "[dry-run] Would create computers-inventory %q\n", name)
+					return nil
+				}
+				resp, err := ctx.Client.Do(reqCtx, "POST", "/v3/computers-inventory", bytes.NewReader(data))
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				fmt.Fprintf(os.Stderr, "Created computers-inventory %q\n", name)
+				return ctx.Output.PrintResponse(resp)
+			}
+
+			// Found — replace
+			if flagDryRun {
+				fmt.Fprintf(os.Stderr, "[dry-run] Would replace computers-inventory %q (id: %s)\n", name, id)
+				return nil
+			}
+			if !flagYes {
+				if noInput {
+					return fmt.Errorf("computers-inventory %q already exists (id: %s); use --yes to replace when --no-input is set", name, id)
+				}
+				fmt.Fprintf(os.Stderr, "computers-inventory %q already exists (id: %s) and will be replaced. Type 'yes' to confirm: ", name, id)
+				var confirm string
+				fmt.Scanln(&confirm)
+				if confirm != "yes" {
+					return fmt.Errorf("aborted")
+				}
+			}
+
+			updatePath := strings.Replace("/v3/computers-inventory-detail/{id}", "{id}", url.PathEscape(id), 1)
+			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			resp, err := ctx.Client.Do(reqCtx, "PATCH", updatePath, bytes.NewReader(data))
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			fmt.Fprintf(os.Stderr, "Replaced computers-inventory %q (id: %s)\n", name, id)
+			return ctx.Output.PrintResponse(resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to JSON or YAML input file (or pipe to stdin)")
+	cmd.Flags().BoolVar(&flagYes, "yes", false, "Skip confirmation prompt when replacing")
+	cmd.Flags().BoolVarP(&flagDryRun, "dry-run", "n", false, "Preview without executing")
+	cmd.Flags().BoolVar(&flagScaffold, "scaffold", false, "Print a JSON template for the request body and exit")
 
 	return cmd
 }

--- a/internal/commands/pro/generated/device_enrollment_instances.go
+++ b/internal/commands/pro/generated/device_enrollment_instances.go
@@ -415,7 +415,15 @@ func newDeviceEnrollmentInstancesUpdateCmd(ctx *registry.CLIContext) *cobra.Comm
 				}
 			}
 			// File fields for this resource route to /v1/device-enrollments/{id}/upload-token via a
-			// separate PUT below, not this endpoint's body.
+			// separate PUT below, not this endpoint's body. Strip them from stdin
+			// input so the main PUT never carries token payload keys.
+			if len(normalized) > 0 {
+				var stripErr error
+				normalized, stripErr = removeJSONFields(normalized, "encodedToken", "tokenFileName")
+				if stripErr != nil {
+					return stripErr
+				}
+			}
 			if len(normalized) > 0 {
 				body = bytes.NewReader(normalized)
 			}
@@ -1072,6 +1080,12 @@ If not, a new resource is created.`,
 			if err != nil {
 				return fmt.Errorf("input must include a %q field: %w", "name", err)
 			}
+			// Strip file-field keys from the main body so the follow-up PUT never
+			// re-sends token payload (which belongs to /v1/device-enrollments/{id}/upload-token).
+			data, err = removeJSONFields(data, "encodedToken", "tokenFileName")
+			if err != nil {
+				return err
+			}
 
 			// Check if resource exists by name (read-only, runs even in dry-run)
 			noInput, _ := cmd.Flags().GetBool("no-input")
@@ -1114,7 +1128,7 @@ If not, a new resource is created.`,
 				bodyPath := strings.Replace("/v1/device-enrollments/{id}", "{id}", url.PathEscape(newID), 1)
 				bodyResp, err := ctx.Client.Do(reqCtx, "PUT", bodyPath, bytes.NewReader(data))
 				if err != nil {
-					return fmt.Errorf("create succeeded (id %s) but applying body fields failed: %w", newID, err)
+					return fmt.Errorf("create succeeded (id %s) but applying body fields failed: %w\nthe device-enrollment-instance exists but is unnamed; to recover run: jamf-cli device-enrollment-instances update %s --from-file <body.json>", newID, err, newID)
 				}
 				defer bodyResp.Body.Close()
 				fmt.Fprintf(os.Stderr, "Created device-enrollment-instance %q (id: %s)\n", name, newID)
@@ -1148,7 +1162,7 @@ If not, a new resource is created.`,
 				}
 				tokenResp = tr
 			}
-			if len(data) == 0 {
+			if len(data) == 0 && tokenResp != nil {
 				// Only the token was replaced — return its response.
 				defer tokenResp.Body.Close()
 				fmt.Fprintf(os.Stderr, "Replaced device-enrollment-instance token %q (id: %s)\n", name, id)

--- a/internal/commands/pro/generated/device_enrollment_instances.go
+++ b/internal/commands/pro/generated/device_enrollment_instances.go
@@ -29,15 +29,15 @@ func NewDeviceEnrollmentInstancesCmd(ctx *registry.CLIContext) *cobra.Command {
 
 	cmd.AddCommand(newDeviceEnrollmentInstancesListCmd(ctx))
 	cmd.AddCommand(newDeviceEnrollmentInstancesGetCmd(ctx))
+	cmd.AddCommand(newDeviceEnrollmentInstancesCreateCmd(ctx))
 	cmd.AddCommand(newDeviceEnrollmentInstancesUpdateCmd(ctx))
 	cmd.AddCommand(newDeviceEnrollmentInstancesDeleteCmd(ctx))
 	cmd.AddCommand(newDeviceEnrollmentInstancesHistoryCmd(ctx))
 	cmd.AddCommand(newDeviceEnrollmentInstancesAddHistoryNoteCmd(ctx))
 	cmd.AddCommand(newDeviceEnrollmentInstancesPublicKeyCmd(ctx))
-	cmd.AddCommand(newDeviceEnrollmentInstancesUploadTokenCmd(ctx))
 	cmd.AddCommand(newDeviceEnrollmentInstancesDevicesCmd(ctx))
 	cmd.AddCommand(newDeviceEnrollmentInstancesDisownCmd(ctx))
-	cmd.AddCommand(newDeviceEnrollmentInstancesUploadTokenByIdCmd(ctx))
+	cmd.AddCommand(newDeviceEnrollmentInstancesApplyCmd(ctx))
 
 	return cmd
 }
@@ -229,6 +229,120 @@ func newDeviceEnrollmentInstancesGetCmd(ctx *registry.CLIContext) *cobra.Command
 	return cmd
 }
 
+func newDeviceEnrollmentInstancesCreateCmd(ctx *registry.CLIContext) *cobra.Command {
+	var (
+		flagScaffold  bool
+		flagTokenFile string
+
+		flagRename string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a Device Enrollment Instance with the supplied Token",
+		Long:  "Creates a device enrollment instance with the supplied token.",
+		Example: `  # Show the JSON template for creating a device-enrollment-instance
+  jamf-cli device-enrollment-instances create --scaffold
+
+  # Create a device-enrollment-instance from JSON
+  echo '{"name":"Example"}' | jamf-cli device-enrollment-instances create
+
+  # Get a device-enrollment-instance, modify it, and create a copy
+  jamf-cli device-enrollment-instances get 1 -o json | jq '.name = "Copy"' | jamf-cli device-enrollment-instances create`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reqCtx := cmd.Context()
+
+			if flagScaffold {
+				return printScaffoldOutput(`{
+  "encodedToken": "U29tZSByYW5kb20gYml0IG9mIHRleHQgdG8gdXNlIGFuZCBzZWUgaWYgYW55b25lIGFjdHVhbGx5IHRyaWVzIHRvIGRlY29kZSBpdA==",
+  "tokenFileName": "Acme MDM Token"
+}`, ctx.Output.Format())
+			}
+
+			// Build request path
+			path := "/v1/device-enrollments/upload-token"
+
+			// Build query string
+			var queryParts []string
+			if len(queryParts) > 0 {
+				path = path + "?" + strings.Join(queryParts, "&")
+			}
+
+			// Make request
+			// Read body from stdin if available
+			var body io.Reader
+			var normalized []byte
+			stat, _ := os.Stdin.Stat()
+			if (stat.Mode() & os.ModeCharDevice) == 0 {
+				raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
+				if err != nil {
+					return fmt.Errorf("reading stdin: %w", err)
+				}
+				normalized, err = normalizeInputToJSON(raw)
+				if err != nil {
+					return err
+				}
+			}
+			// File-sourced fields (--token-file, etc.) overwrite
+			// any value the caller supplied in the body; companion fields and name
+			// fallbacks only fill when absent.
+			var fileFieldErr error
+			normalized, fileFieldErr = injectFileFields(normalized, []fileFieldSpec{
+				{FilePath: flagTokenFile, Field: "encodedToken", Encoding: "base64", CompanionField: "tokenFileName", NameFallback: "none", NameField: "name"},
+			})
+			if fileFieldErr != nil {
+				return fileFieldErr
+			}
+			if len(normalized) > 0 {
+				body = bytes.NewReader(normalized)
+			}
+			resp, err := ctx.Client.Do(reqCtx, "POST", path, body)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			if flagRename != "" && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				var renameID string
+				respBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+				_ = resp.Body.Close()
+				if readErr != nil {
+					return fmt.Errorf("reading upload response: %w", readErr)
+				}
+				var postResp map[string]any
+				if err := json.Unmarshal(respBytes, &postResp); err == nil {
+					if v, ok := postResp["id"].(string); ok {
+						renameID = v
+					} else if v, ok := postResp["id"].(float64); ok {
+						renameID = strconv.FormatFloat(v, 'f', -1, 64)
+					}
+				}
+				if renameID == "" {
+					return fmt.Errorf("upload succeeded but response did not include id; cannot apply --name")
+				}
+				renameURL := strings.Replace("/v1/device-enrollments/{id}", "{id}", url.PathEscape(renameID), 1)
+				if err := renameResourceByID(reqCtx, ctx.Client, renameURL, "name", flagRename); err != nil {
+					return fmt.Errorf("upload succeeded (id %s) but rename failed: %w", renameID, err)
+				}
+				showResp, showErr := ctx.Client.Do(reqCtx, "GET", renameURL, nil)
+				if showErr != nil {
+					return fmt.Errorf("rename succeeded but refetch failed: %w", showErr)
+				}
+				defer showResp.Body.Close()
+				return ctx.Output.PrintResponse(showResp)
+			}
+			return ctx.Output.PrintResponse(resp)
+		},
+	}
+
+	cmd.Flags().BoolVar(&flagScaffold, "scaffold", false, "Print a JSON template for the request body and exit")
+	cmd.Flags().StringVar(&flagTokenFile, "token-file", "", "Path to a DEP server token (.p7m); contents are base64-encoded into encodedToken")
+
+	cmd.Flags().StringVar(&flagRename, "name", "", "Canonical name to apply to the device-enrollment-instance via a follow-up PUT to /v1/device-enrollments/{id} (this endpoint's body has no name field)")
+
+	return cmd
+}
+
 func newDeviceEnrollmentInstancesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 	var (
 		flagScaffold bool
@@ -300,18 +414,33 @@ func newDeviceEnrollmentInstancesUpdateCmd(ctx *registry.CLIContext) *cobra.Comm
 					return err
 				}
 			}
-			// File-sourced fields (--token-file, etc.) overwrite
-			// any value the caller supplied in the body; companion fields and name
-			// fallbacks only fill when absent.
-			var fileFieldErr error
-			normalized, fileFieldErr = injectFileFields(normalized, []fileFieldSpec{
-				{FilePath: flagTokenFile, Field: "encodedToken", Encoding: "base64", CompanionField: "tokenFileName", NameFallback: "none", NameField: "name"},
-			})
-			if fileFieldErr != nil {
-				return fileFieldErr
-			}
+			// File fields for this resource route to /v1/device-enrollments/{id}/upload-token via a
+			// separate PUT below, not this endpoint's body.
 			if len(normalized) > 0 {
 				body = bytes.NewReader(normalized)
+			}
+			// Composite update: --token-file routes to /v1/device-enrollments/{id}/upload-token;
+			// body fields go to /v1/device-enrollments/{id}. At least one input is required.
+			if len(normalized) == 0 && flagTokenFile == "" {
+				return fmt.Errorf("nothing to update: provide --from-file, stdin body, or --token-file")
+			}
+			if flagTokenFile != "" {
+				tokenBody, tbErr := injectFileFields(nil, []fileFieldSpec{
+					{FilePath: flagTokenFile, Field: "encodedToken", Encoding: "base64", CompanionField: "tokenFileName", NameFallback: "none", NameField: "name"},
+				})
+				if tbErr != nil {
+					return tbErr
+				}
+				tokenPath := strings.Replace("/v1/device-enrollments/{id}/upload-token", "{id}", url.PathEscape(resolvedID), 1)
+				tokenResp, tokenErr := ctx.Client.Do(reqCtx, "PUT", tokenPath, bytes.NewReader(tokenBody))
+				if tokenErr != nil {
+					return tokenErr
+				}
+				if len(normalized) == 0 {
+					defer tokenResp.Body.Close()
+					return ctx.Output.PrintResponse(tokenResp)
+				}
+				_ = tokenResp.Body.Close()
 			}
 			resp, err := ctx.Client.Do(reqCtx, "PUT", path, body)
 			if err != nil {
@@ -729,112 +858,6 @@ func newDeviceEnrollmentInstancesPublicKeyCmd(ctx *registry.CLIContext) *cobra.C
 	return cmd
 }
 
-func newDeviceEnrollmentInstancesUploadTokenCmd(ctx *registry.CLIContext) *cobra.Command {
-	var (
-		flagScaffold  bool
-		flagTokenFile string
-
-		flagRename string
-	)
-
-	cmd := &cobra.Command{
-		Use:   "upload-token",
-		Short: "Create a Device Enrollment Instance with the supplied Token",
-		Long:  "Creates a device enrollment instance with the supplied token.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			reqCtx := cmd.Context()
-
-			if flagScaffold {
-				return printScaffoldOutput(`{
-  "encodedToken": "U29tZSByYW5kb20gYml0IG9mIHRleHQgdG8gdXNlIGFuZCBzZWUgaWYgYW55b25lIGFjdHVhbGx5IHRyaWVzIHRvIGRlY29kZSBpdA==",
-  "tokenFileName": "Acme MDM Token"
-}`, ctx.Output.Format())
-			}
-
-			// Build request path
-			path := "/v1/device-enrollments/upload-token"
-
-			// Build query string
-			var queryParts []string
-			if len(queryParts) > 0 {
-				path = path + "?" + strings.Join(queryParts, "&")
-			}
-
-			// Make request
-			// Read body from stdin if available
-			var body io.Reader
-			var normalized []byte
-			stat, _ := os.Stdin.Stat()
-			if (stat.Mode() & os.ModeCharDevice) == 0 {
-				raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
-				if err != nil {
-					return fmt.Errorf("reading stdin: %w", err)
-				}
-				normalized, err = normalizeInputToJSON(raw)
-				if err != nil {
-					return err
-				}
-			}
-			// File-sourced fields (--token-file, etc.) overwrite
-			// any value the caller supplied in the body; companion fields and name
-			// fallbacks only fill when absent.
-			var fileFieldErr error
-			normalized, fileFieldErr = injectFileFields(normalized, []fileFieldSpec{
-				{FilePath: flagTokenFile, Field: "encodedToken", Encoding: "base64", CompanionField: "tokenFileName", NameFallback: "none", NameField: "name"},
-			})
-			if fileFieldErr != nil {
-				return fileFieldErr
-			}
-			if len(normalized) > 0 {
-				body = bytes.NewReader(normalized)
-			}
-			resp, err := ctx.Client.Do(reqCtx, "POST", path, body)
-			if err != nil {
-				return err
-			}
-			defer resp.Body.Close()
-
-			if flagRename != "" && resp.StatusCode >= 200 && resp.StatusCode < 300 {
-				var renameID string
-				respBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
-				_ = resp.Body.Close()
-				if readErr != nil {
-					return fmt.Errorf("reading upload response: %w", readErr)
-				}
-				var postResp map[string]any
-				if err := json.Unmarshal(respBytes, &postResp); err == nil {
-					if v, ok := postResp["id"].(string); ok {
-						renameID = v
-					} else if v, ok := postResp["id"].(float64); ok {
-						renameID = strconv.FormatFloat(v, 'f', -1, 64)
-					}
-				}
-				if renameID == "" {
-					return fmt.Errorf("upload succeeded but response did not include id; cannot apply --rename")
-				}
-				renameURL := strings.Replace("/v1/device-enrollments/{id}", "{id}", url.PathEscape(renameID), 1)
-				if err := renameResourceByID(reqCtx, ctx.Client, renameURL, "name", flagRename); err != nil {
-					return fmt.Errorf("upload succeeded (id %s) but rename failed: %w", renameID, err)
-				}
-				showResp, showErr := ctx.Client.Do(reqCtx, "GET", renameURL, nil)
-				if showErr != nil {
-					return fmt.Errorf("rename succeeded but refetch failed: %w", showErr)
-				}
-				defer showResp.Body.Close()
-				return ctx.Output.PrintResponse(showResp)
-			}
-			return ctx.Output.PrintResponse(resp)
-		},
-	}
-
-	cmd.Flags().BoolVar(&flagScaffold, "scaffold", false, "Print a JSON template for the request body and exit")
-	cmd.Flags().StringVar(&flagTokenFile, "token-file", "", "Path to a DEP server token (.p7m); contents are base64-encoded into encodedToken")
-
-	cmd.Flags().StringVar(&flagRename, "rename", "", "After the upload succeeds, apply this name via a follow-up PUT to /v1/device-enrollments/{id} (this endpoint's body rejects a name field)")
-
-	return cmd
-}
-
 func newDeviceEnrollmentInstancesDevicesCmd(ctx *registry.CLIContext) *cobra.Command {
 	var (
 		flagName string
@@ -969,24 +992,41 @@ func newDeviceEnrollmentInstancesDisownCmd(ctx *registry.CLIContext) *cobra.Comm
 	return cmd
 }
 
-func newDeviceEnrollmentInstancesUploadTokenByIdCmd(ctx *registry.CLIContext) *cobra.Command {
+func newDeviceEnrollmentInstancesApplyCmd(ctx *registry.CLIContext) *cobra.Command {
 	var (
-		flagScaffold bool
-		flagName     string
-
+		fromFile      string
+		flagYes       bool
+		flagDryRun    bool
+		flagScaffold  bool
 		flagTokenFile string
 
-		flagRename string
+		flagBodyName string
 	)
 
 	cmd := &cobra.Command{
-		Use:   "upload-token-by-id [<id>]",
-		Short: "Update a Device Enrollment Instance with the supplied Token",
-		Long:  "Updates a device enrollment instance with the supplied token.",
-		Args:  cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			reqCtx := cmd.Context()
+		Use:   "apply",
+		Short: "Create or replace a device-enrollment-instance by name",
+		Long: `Create or replace a device-enrollment-instance. Reads JSON or YAML from --from-file or stdin.
 
+The name field in the input is used to check if the resource
+already exists. If it does, the resource is replaced (with confirmation).
+If not, a new resource is created.`,
+		Example: `  # Apply a device-enrollment-instance from a JSON file
+  jamf-cli device-enrollment-instances apply --from-file device-enrollment-instance.json
+
+  # Apply a device-enrollment-instance from a YAML file
+  jamf-cli device-enrollment-instances apply --from-file device-enrollment-instance.yaml
+
+  # Apply from stdin
+  cat device-enrollment-instance.json | jamf-cli device-enrollment-instances apply
+
+  # Apply without replacement confirmation
+  jamf-cli device-enrollment-instances apply --from-file device-enrollment-instance.json --yes
+
+  # Preview what would happen
+  jamf-cli device-enrollment-instances apply --from-file device-enrollment-instance.json --dry-run`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reqCtx := cmd.Context()
 			if flagScaffold {
 				return printScaffoldOutput(`{
   "encodedToken": "U29tZSByYW5kb20gYml0IG9mIHRleHQgdG8gdXNlIGFuZCBzZWUgaWYgYW55b25lIGFjdHVhbGx5IHRyaWVzIHRvIGRlY29kZSBpdA==",
@@ -994,89 +1034,146 @@ func newDeviceEnrollmentInstancesUploadTokenByIdCmd(ctx *registry.CLIContext) *c
 }`, ctx.Output.Format())
 			}
 
-			// Resolve resource ID from positional arg, --name, or lookup flags
-			var resolvedID string
-			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName)
-				if err != nil {
-					return err
-				}
-				resolvedID = rid
-			} else if len(args) > 0 {
-				resolvedID = args[0]
-			} else {
-				return fmt.Errorf("provide an <id> argument, --name")
+			// Read input (JSON or YAML). When file flags are present, empty input
+			// is OK — the file-field injector constructs a minimal body.
+			data, err := readApplyInput(fromFile)
+			anyFileFlag := flagTokenFile != ""
+			if err != nil && !anyFileFlag {
+				return err
 			}
-
-			// Build request path
-			path := "/v1/device-enrollments/{id}/upload-token"
-			path = strings.Replace(path, "{id}", url.PathEscape(resolvedID), 1)
-
-			// Build query string
-			var queryParts []string
-			if len(queryParts) > 0 {
-				path = path + "?" + strings.Join(queryParts, "&")
-			}
-
-			// Make request
-			// Read body from stdin if available
-			var body io.Reader
-			var normalized []byte
-			stat, _ := os.Stdin.Stat()
-			if (stat.Mode() & os.ModeCharDevice) == 0 {
-				raw, err := io.ReadAll(io.LimitReader(os.Stdin, 10<<20))
-				if err != nil {
-					return fmt.Errorf("reading stdin: %w", err)
-				}
-				normalized, err = normalizeInputToJSON(raw)
+			err = nil
+			if len(data) > 0 {
+				data, err = normalizeInputToJSON(data)
 				if err != nil {
 					return err
 				}
 			}
-			// File-sourced fields (--token-file, etc.) overwrite
-			// any value the caller supplied in the body; companion fields and name
-			// fallbacks only fill when absent.
-			var fileFieldErr error
-			normalized, fileFieldErr = injectFileFields(normalized, []fileFieldSpec{
-				{FilePath: flagTokenFile, Field: "encodedToken", Encoding: "base64", CompanionField: "tokenFileName", NameFallback: "none", NameField: "name"},
-			})
-			if fileFieldErr != nil {
-				return fileFieldErr
+			data, err = setBodyStringField(data, "name", flagBodyName)
+			if err != nil {
+				return err
 			}
-			if len(normalized) > 0 {
-				body = bytes.NewReader(normalized)
+			// Composite flow: file fields route to /v1/device-enrollments/{id}/upload-token (on update)
+			// or are combined with the create body (on create). Build a separate token
+			// body so the main PUT to /v1/device-enrollments/{id} only carries
+			// DeviceEnrollmentInstance-schema fields.
+			var tokenBody []byte
+			if flagTokenFile != "" {
+				tb, tbErr := injectFileFields(nil, []fileFieldSpec{
+					{FilePath: flagTokenFile, Field: "encodedToken", Encoding: "base64", CompanionField: "tokenFileName", NameFallback: "none", NameField: "name"},
+				})
+				if tbErr != nil {
+					return tbErr
+				}
+				tokenBody = tb
 			}
-			resp, err := ctx.Client.Do(reqCtx, "PUT", path, body)
+
+			// Extract name from JSON input
+			name, err := extractJSONField(data, "name")
+			if err != nil {
+				return fmt.Errorf("input must include a %q field: %w", "name", err)
+			}
+
+			// Check if resource exists by name (read-only, runs even in dry-run)
+			noInput, _ := cmd.Flags().GetBool("no-input")
+			id, err := resolveNameToIDForApply(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", name, noInput)
+			if err != nil {
+				return err
+			}
+
+			if id == "" {
+				// Not found — create
+				if flagDryRun {
+					fmt.Fprintf(os.Stderr, "[dry-run] Would create device-enrollment-instance %q\n", name)
+					return nil
+				}
+				if len(tokenBody) == 0 {
+					return fmt.Errorf("cannot create device-enrollment-instance %q: --token-file is required", name)
+				}
+				postResp, err := ctx.Client.Do(reqCtx, "POST", "/v1/device-enrollments/upload-token", bytes.NewReader(tokenBody))
+				if err != nil {
+					return err
+				}
+				postBytes, readErr := io.ReadAll(io.LimitReader(postResp.Body, 10<<20))
+				_ = postResp.Body.Close()
+				if readErr != nil {
+					return fmt.Errorf("reading create response: %w", readErr)
+				}
+				var postDecoded map[string]any
+				var newID string
+				if jerr := json.Unmarshal(postBytes, &postDecoded); jerr == nil {
+					if v, ok := postDecoded["id"].(string); ok {
+						newID = v
+					} else if v, ok := postDecoded["id"].(float64); ok {
+						newID = strconv.FormatFloat(v, 'f', -1, 64)
+					}
+				}
+				if newID == "" {
+					return fmt.Errorf("create succeeded but response did not include id")
+				}
+				// Follow-up: PUT main body to apply name/other DeviceEnrollmentInstance fields.
+				bodyPath := strings.Replace("/v1/device-enrollments/{id}", "{id}", url.PathEscape(newID), 1)
+				bodyResp, err := ctx.Client.Do(reqCtx, "PUT", bodyPath, bytes.NewReader(data))
+				if err != nil {
+					return fmt.Errorf("create succeeded (id %s) but applying body fields failed: %w", newID, err)
+				}
+				defer bodyResp.Body.Close()
+				fmt.Fprintf(os.Stderr, "Created device-enrollment-instance %q (id: %s)\n", name, newID)
+				return ctx.Output.PrintResponse(bodyResp)
+			}
+
+			// Found — replace
+			if flagDryRun {
+				fmt.Fprintf(os.Stderr, "[dry-run] Would replace device-enrollment-instance %q (id: %s)\n", name, id)
+				return nil
+			}
+			if !flagYes {
+				if noInput {
+					return fmt.Errorf("device-enrollment-instance %q already exists (id: %s); use --yes to replace when --no-input is set", name, id)
+				}
+				fmt.Fprintf(os.Stderr, "device-enrollment-instance %q already exists (id: %s) and will be replaced. Type 'yes' to confirm: ", name, id)
+				var confirm string
+				fmt.Scanln(&confirm)
+				if confirm != "yes" {
+					return fmt.Errorf("aborted")
+				}
+			}
+
+			updatePath := strings.Replace("/v1/device-enrollments/{id}", "{id}", url.PathEscape(id), 1)
+			var tokenResp *http.Response
+			if len(tokenBody) > 0 {
+				tokenPath := strings.Replace("/v1/device-enrollments/{id}/upload-token", "{id}", url.PathEscape(id), 1)
+				tr, tokenErr := ctx.Client.Do(reqCtx, "PUT", tokenPath, bytes.NewReader(tokenBody))
+				if tokenErr != nil {
+					return tokenErr
+				}
+				tokenResp = tr
+			}
+			if len(data) == 0 {
+				// Only the token was replaced — return its response.
+				defer tokenResp.Body.Close()
+				fmt.Fprintf(os.Stderr, "Replaced device-enrollment-instance token %q (id: %s)\n", name, id)
+				return ctx.Output.PrintResponse(tokenResp)
+			}
+			if tokenResp != nil {
+				_ = tokenResp.Body.Close()
+			}
+			resp, err := ctx.Client.Do(reqCtx, "PUT", updatePath, bytes.NewReader(data))
 			if err != nil {
 				return err
 			}
 			defer resp.Body.Close()
-
-			if flagRename != "" && resp.StatusCode >= 200 && resp.StatusCode < 300 {
-				var renameID string
-				_ = resp.Body.Close()
-				renameID = resolvedID
-				renameURL := strings.Replace("/v1/device-enrollments/{id}", "{id}", url.PathEscape(renameID), 1)
-				if err := renameResourceByID(reqCtx, ctx.Client, renameURL, "name", flagRename); err != nil {
-					return fmt.Errorf("upload succeeded (id %s) but rename failed: %w", renameID, err)
-				}
-				showResp, showErr := ctx.Client.Do(reqCtx, "GET", renameURL, nil)
-				if showErr != nil {
-					return fmt.Errorf("rename succeeded but refetch failed: %w", showErr)
-				}
-				defer showResp.Body.Close()
-				return ctx.Output.PrintResponse(showResp)
-			}
+			fmt.Fprintf(os.Stderr, "Replaced device-enrollment-instance %q (id: %s)\n", name, id)
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
 
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to JSON or YAML input file (or pipe to stdin)")
+	cmd.Flags().BoolVar(&flagYes, "yes", false, "Skip confirmation prompt when replacing")
+	cmd.Flags().BoolVarP(&flagDryRun, "dry-run", "n", false, "Preview without executing")
 	cmd.Flags().BoolVar(&flagScaffold, "scaffold", false, "Print a JSON template for the request body and exit")
-	cmd.Flags().StringVar(&flagName, "name", "", "Look up device-enrollment-instance by name")
-
 	cmd.Flags().StringVar(&flagTokenFile, "token-file", "", "Path to a DEP server token (.p7m); contents are base64-encoded into encodedToken")
 
-	cmd.Flags().StringVar(&flagRename, "rename", "", "After the upload succeeds, apply this name via a follow-up PUT to /v1/device-enrollments/{id} (this endpoint's body rejects a name field)")
+	cmd.Flags().StringVar(&flagBodyName, "name", "", "Name for the device-enrollment-instance (sets the body's name field)")
 
 	return cmd
 }

--- a/internal/commands/pro/generated/digi_cert_settings.go
+++ b/internal/commands/pro/generated/digi_cert_settings.go
@@ -32,6 +32,7 @@ func NewDigiCertSettingsCmd(ctx *registry.CLIContext) *cobra.Command {
 	cmd.AddCommand(newDigiCertSettingsPatchCmd(ctx))
 	cmd.AddCommand(newDigiCertSettingsConnectionStatusCmd(ctx))
 	cmd.AddCommand(newDigiCertSettingsDependenciesCmd(ctx))
+	cmd.AddCommand(newDigiCertSettingsApplyCmd(ctx))
 
 	return cmd
 }
@@ -560,6 +561,125 @@ func newDigiCertSettingsDependenciesCmd(ctx *registry.CLIContext) *cobra.Command
 	}
 
 	cmd.Flags().StringVar(&flagName, "name", "", "Look up digi-cert-setting by name")
+
+	return cmd
+}
+
+func newDigiCertSettingsApplyCmd(ctx *registry.CLIContext) *cobra.Command {
+	var (
+		fromFile     string
+		flagYes      bool
+		flagDryRun   bool
+		flagScaffold bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Create or replace a digi-cert-setting by name",
+		Long: `Create or replace a digi-cert-setting. Reads JSON or YAML from --from-file or stdin.
+
+The name field in the input is used to check if the resource
+already exists. If it does, the resource is replaced (with confirmation).
+If not, a new resource is created.`,
+		Example: `  # Apply a digi-cert-setting from a JSON file
+  jamf-cli digi-cert-settings apply --from-file digi-cert-setting.json
+
+  # Apply a digi-cert-setting from a YAML file
+  jamf-cli digi-cert-settings apply --from-file digi-cert-setting.yaml
+
+  # Apply from stdin
+  cat digi-cert-setting.json | jamf-cli digi-cert-settings apply
+
+  # Apply without replacement confirmation
+  jamf-cli digi-cert-settings apply --from-file digi-cert-setting.json --yes
+
+  # Preview what would happen
+  jamf-cli digi-cert-settings apply --from-file digi-cert-setting.json --dry-run`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reqCtx := cmd.Context()
+			if flagScaffold {
+				return printScaffoldOutput(`{
+  "caName": "Example Display Name",
+  "clientCert": {},
+  "fqdn": "digicert.example.com",
+  "revocationEnabled": true
+}`, ctx.Output.Format())
+			}
+
+			// Read input (JSON or YAML). When file flags are present, empty input
+			// is OK — the file-field injector constructs a minimal body.
+			data, err := readApplyInput(fromFile)
+			if err != nil {
+				return err
+			}
+			if len(data) > 0 {
+				data, err = normalizeInputToJSON(data)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Extract name from JSON input
+			name, err := extractJSONField(data, "name")
+			if err != nil {
+				return fmt.Errorf("input must include a %q field: %w", "name", err)
+			}
+
+			// Check if resource exists by name (read-only, runs even in dry-run)
+			noInput, _ := cmd.Flags().GetBool("no-input")
+			id, err := resolveNameToIDForApply(reqCtx, ctx.Client, "/v1/pki/digicert/trust-lifecycle-manager", "name", "id", name, noInput)
+			if err != nil {
+				return err
+			}
+
+			if id == "" {
+				// Not found — create
+				if flagDryRun {
+					fmt.Fprintf(os.Stderr, "[dry-run] Would create digi-cert-setting %q\n", name)
+					return nil
+				}
+				resp, err := ctx.Client.Do(reqCtx, "POST", "/v1/pki/digicert/trust-lifecycle-manager", bytes.NewReader(data))
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				fmt.Fprintf(os.Stderr, "Created digi-cert-setting %q\n", name)
+				return ctx.Output.PrintResponse(resp)
+			}
+
+			// Found — replace
+			if flagDryRun {
+				fmt.Fprintf(os.Stderr, "[dry-run] Would replace digi-cert-setting %q (id: %s)\n", name, id)
+				return nil
+			}
+			if !flagYes {
+				if noInput {
+					return fmt.Errorf("digi-cert-setting %q already exists (id: %s); use --yes to replace when --no-input is set", name, id)
+				}
+				fmt.Fprintf(os.Stderr, "digi-cert-setting %q already exists (id: %s) and will be replaced. Type 'yes' to confirm: ", name, id)
+				var confirm string
+				fmt.Scanln(&confirm)
+				if confirm != "yes" {
+					return fmt.Errorf("aborted")
+				}
+			}
+
+			updatePath := strings.Replace("/v1/pki/digicert/trust-lifecycle-manager/{id}", "{id}", url.PathEscape(id), 1)
+			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			resp, err := ctx.Client.Do(reqCtx, "PATCH", updatePath, bytes.NewReader(data))
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			fmt.Fprintf(os.Stderr, "Replaced digi-cert-setting %q (id: %s)\n", name, id)
+			return ctx.Output.PrintResponse(resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to JSON or YAML input file (or pipe to stdin)")
+	cmd.Flags().BoolVar(&flagYes, "yes", false, "Skip confirmation prompt when replacing")
+	cmd.Flags().BoolVarP(&flagDryRun, "dry-run", "n", false, "Preview without executing")
+	cmd.Flags().BoolVar(&flagScaffold, "scaffold", false, "Print a JSON template for the request body and exit")
 
 	return cmd
 }

--- a/internal/commands/pro/generated/mobile_device_groups_static_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_static_groups.go
@@ -31,6 +31,7 @@ func NewMobileDeviceGroupsStaticGroupsCmd(ctx *registry.CLIContext) *cobra.Comma
 	cmd.AddCommand(newMobileDeviceGroupsStaticGroupsCreateCmd(ctx))
 	cmd.AddCommand(newMobileDeviceGroupsStaticGroupsDeleteCmd(ctx))
 	cmd.AddCommand(newMobileDeviceGroupsStaticGroupsPatchCmd(ctx))
+	cmd.AddCommand(newMobileDeviceGroupsStaticGroupsApplyCmd(ctx))
 
 	return cmd
 }
@@ -527,6 +528,125 @@ func newMobileDeviceGroupsStaticGroupsPatchCmd(ctx *registry.CLIContext) *cobra.
 		}, cobra.ShellCompDirectiveNoSpace
 	})
 	cmd.Flags().StringVar(&flagName, "name", "", "Look up mobile-device-groups-static-groups by name")
+
+	return cmd
+}
+
+func newMobileDeviceGroupsStaticGroupsApplyCmd(ctx *registry.CLIContext) *cobra.Command {
+	var (
+		fromFile     string
+		flagYes      bool
+		flagDryRun   bool
+		flagScaffold bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Create or replace a mobile-device-groups-static-groups by name",
+		Long: `Create or replace a mobile-device-groups-static-groups. Reads JSON or YAML from --from-file or stdin.
+
+The groupName field in the input is used to check if the resource
+already exists. If it does, the resource is replaced (with confirmation).
+If not, a new resource is created.`,
+		Example: `  # Apply a mobile-device-groups-static-groups from a JSON file
+  jamf-cli mobile-device-groups-static-groups apply --from-file mobile-device-groups-static-groups.json
+
+  # Apply a mobile-device-groups-static-groups from a YAML file
+  jamf-cli mobile-device-groups-static-groups apply --from-file mobile-device-groups-static-groups.yaml
+
+  # Apply from stdin
+  cat mobile-device-groups-static-groups.json | jamf-cli mobile-device-groups-static-groups apply
+
+  # Apply without replacement confirmation
+  jamf-cli mobile-device-groups-static-groups apply --from-file mobile-device-groups-static-groups.json --yes
+
+  # Preview what would happen
+  jamf-cli mobile-device-groups-static-groups apply --from-file mobile-device-groups-static-groups.json --dry-run`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reqCtx := cmd.Context()
+			if flagScaffold {
+				return printScaffoldOutput(`{
+  "assignments": [],
+  "groupDescription": "Static iPads",
+  "groupName": "Static iPads",
+  "siteId": 11
+}`, ctx.Output.Format())
+			}
+
+			// Read input (JSON or YAML). When file flags are present, empty input
+			// is OK — the file-field injector constructs a minimal body.
+			data, err := readApplyInput(fromFile)
+			if err != nil {
+				return err
+			}
+			if len(data) > 0 {
+				data, err = normalizeInputToJSON(data)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Extract name from JSON input
+			name, err := extractJSONField(data, "groupName")
+			if err != nil {
+				return fmt.Errorf("input must include a %q field: %w", "groupName", err)
+			}
+
+			// Check if resource exists by name (read-only, runs even in dry-run)
+			noInput, _ := cmd.Flags().GetBool("no-input")
+			id, err := resolveNameToIDForApply(reqCtx, ctx.Client, "/v1/mobile-device-groups/static-groups", "groupName", "groupId", name, noInput)
+			if err != nil {
+				return err
+			}
+
+			if id == "" {
+				// Not found — create
+				if flagDryRun {
+					fmt.Fprintf(os.Stderr, "[dry-run] Would create mobile-device-groups-static-groups %q\n", name)
+					return nil
+				}
+				resp, err := ctx.Client.Do(reqCtx, "POST", "/v1/mobile-device-groups/static-groups", bytes.NewReader(data))
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				fmt.Fprintf(os.Stderr, "Created mobile-device-groups-static-groups %q\n", name)
+				return ctx.Output.PrintResponse(resp)
+			}
+
+			// Found — replace
+			if flagDryRun {
+				fmt.Fprintf(os.Stderr, "[dry-run] Would replace mobile-device-groups-static-groups %q (id: %s)\n", name, id)
+				return nil
+			}
+			if !flagYes {
+				if noInput {
+					return fmt.Errorf("mobile-device-groups-static-groups %q already exists (id: %s); use --yes to replace when --no-input is set", name, id)
+				}
+				fmt.Fprintf(os.Stderr, "mobile-device-groups-static-groups %q already exists (id: %s) and will be replaced. Type 'yes' to confirm: ", name, id)
+				var confirm string
+				fmt.Scanln(&confirm)
+				if confirm != "yes" {
+					return fmt.Errorf("aborted")
+				}
+			}
+
+			updatePath := strings.Replace("/v1/mobile-device-groups/static-groups/{id}", "{id}", url.PathEscape(id), 1)
+			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			resp, err := ctx.Client.Do(reqCtx, "PATCH", updatePath, bytes.NewReader(data))
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			fmt.Fprintf(os.Stderr, "Replaced mobile-device-groups-static-groups %q (id: %s)\n", name, id)
+			return ctx.Output.PrintResponse(resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to JSON or YAML input file (or pipe to stdin)")
+	cmd.Flags().BoolVar(&flagYes, "yes", false, "Skip confirmation prompt when replacing")
+	cmd.Flags().BoolVarP(&flagDryRun, "dry-run", "n", false, "Preview without executing")
+	cmd.Flags().BoolVar(&flagScaffold, "scaffold", false, "Print a JSON template for the request body and exit")
 
 	return cmd
 }

--- a/internal/commands/pro/generated/patch_software_title_configurations.go
+++ b/internal/commands/pro/generated/patch_software_title_configurations.go
@@ -42,6 +42,7 @@ func NewPatchSoftwareTitleConfigurationsCmd(ctx *registry.CLIContext) *cobra.Com
 	cmd.AddCommand(newPatchSoftwareTitleConfigurationsPatchReportCmd(ctx))
 	cmd.AddCommand(newPatchSoftwareTitleConfigurationsPatchSummaryCmd(ctx))
 	cmd.AddCommand(newPatchSoftwareTitleConfigurationsVersionsCmd(ctx))
+	cmd.AddCommand(newPatchSoftwareTitleConfigurationsApplyCmd(ctx))
 
 	return cmd
 }
@@ -1247,6 +1248,128 @@ func newPatchSoftwareTitleConfigurationsVersionsCmd(ctx *registry.CLIContext) *c
 	}
 
 	cmd.Flags().StringVar(&flagName, "name", "", "Look up patch-software-title-configuration by name")
+
+	return cmd
+}
+
+func newPatchSoftwareTitleConfigurationsApplyCmd(ctx *registry.CLIContext) *cobra.Command {
+	var (
+		fromFile     string
+		flagYes      bool
+		flagDryRun   bool
+		flagScaffold bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Create or replace a patch-software-title-configuration by name",
+		Long: `Create or replace a patch-software-title-configuration. Reads JSON or YAML from --from-file or stdin.
+
+The displayName field in the input is used to check if the resource
+already exists. If it does, the resource is replaced (with confirmation).
+If not, a new resource is created.`,
+		Example: `  # Apply a patch-software-title-configuration from a JSON file
+  jamf-cli patch-software-title-configurations apply --from-file patch-software-title-configuration.json
+
+  # Apply a patch-software-title-configuration from a YAML file
+  jamf-cli patch-software-title-configurations apply --from-file patch-software-title-configuration.yaml
+
+  # Apply from stdin
+  cat patch-software-title-configuration.json | jamf-cli patch-software-title-configurations apply
+
+  # Apply without replacement confirmation
+  jamf-cli patch-software-title-configurations apply --from-file patch-software-title-configuration.json --yes
+
+  # Preview what would happen
+  jamf-cli patch-software-title-configurations apply --from-file patch-software-title-configuration.json --dry-run`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reqCtx := cmd.Context()
+			if flagScaffold {
+				return printScaffoldOutput(`{
+  "categoryId": "-1",
+  "displayName": "Google Chrome",
+  "emailNotifications": false,
+  "extensionAttributes": [],
+  "siteId": "-1",
+  "softwareTitleId": "1",
+  "uiNotifications": false
+}`, ctx.Output.Format())
+			}
+
+			// Read input (JSON or YAML). When file flags are present, empty input
+			// is OK — the file-field injector constructs a minimal body.
+			data, err := readApplyInput(fromFile)
+			if err != nil {
+				return err
+			}
+			if len(data) > 0 {
+				data, err = normalizeInputToJSON(data)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Extract name from JSON input
+			name, err := extractJSONField(data, "displayName")
+			if err != nil {
+				return fmt.Errorf("input must include a %q field: %w", "displayName", err)
+			}
+
+			// Check if resource exists by name (read-only, runs even in dry-run)
+			noInput, _ := cmd.Flags().GetBool("no-input")
+			id, err := resolveNameToIDForApply(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", name, noInput)
+			if err != nil {
+				return err
+			}
+
+			if id == "" {
+				// Not found — create
+				if flagDryRun {
+					fmt.Fprintf(os.Stderr, "[dry-run] Would create patch-software-title-configuration %q\n", name)
+					return nil
+				}
+				resp, err := ctx.Client.Do(reqCtx, "POST", "/v2/patch-software-title-configurations", bytes.NewReader(data))
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				fmt.Fprintf(os.Stderr, "Created patch-software-title-configuration %q\n", name)
+				return ctx.Output.PrintResponse(resp)
+			}
+
+			// Found — replace
+			if flagDryRun {
+				fmt.Fprintf(os.Stderr, "[dry-run] Would replace patch-software-title-configuration %q (id: %s)\n", name, id)
+				return nil
+			}
+			if !flagYes {
+				if noInput {
+					return fmt.Errorf("patch-software-title-configuration %q already exists (id: %s); use --yes to replace when --no-input is set", name, id)
+				}
+				fmt.Fprintf(os.Stderr, "patch-software-title-configuration %q already exists (id: %s) and will be replaced. Type 'yes' to confirm: ", name, id)
+				var confirm string
+				fmt.Scanln(&confirm)
+				if confirm != "yes" {
+					return fmt.Errorf("aborted")
+				}
+			}
+
+			updatePath := strings.Replace("/v2/patch-software-title-configurations/{id}", "{id}", url.PathEscape(id), 1)
+			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			resp, err := ctx.Client.Do(reqCtx, "PATCH", updatePath, bytes.NewReader(data))
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			fmt.Fprintf(os.Stderr, "Replaced patch-software-title-configuration %q (id: %s)\n", name, id)
+			return ctx.Output.PrintResponse(resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to JSON or YAML input file (or pipe to stdin)")
+	cmd.Flags().BoolVar(&flagYes, "yes", false, "Skip confirmation prompt when replacing")
+	cmd.Flags().BoolVarP(&flagDryRun, "dry-run", "n", false, "Preview without executing")
+	cmd.Flags().BoolVar(&flagScaffold, "scaffold", false, "Print a JSON template for the request body and exit")
 
 	return cmd
 }

--- a/internal/commands/pro/generated/registry.go
+++ b/internal/commands/pro/generated/registry.go
@@ -459,6 +459,35 @@ func injectFileFields(body []byte, specs []fileFieldSpec) ([]byte, error) {
 	return out, nil
 }
 
+// removeJSONFields strips the named top-level keys from a JSON object body and
+// returns the re-marshaled result. When body is empty or not a JSON object, it is
+// returned unchanged. Used by composite apply/update flows that route some fields
+// (e.g. encodedToken, tokenFileName) to an auxiliary endpoint and must not
+// re-send them to the main body endpoint.
+func removeJSONFields(body []byte, fields ...string) ([]byte, error) {
+	if len(body) == 0 || len(fields) == 0 {
+		return body, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		return body, nil // not a JSON object — pass through
+	}
+	changed := false
+	for _, f := range fields {
+		if _, ok := m[f]; ok {
+			delete(m, f)
+			changed = true
+		}
+	}
+	if !changed {
+		return body, nil
+	}
+	if len(m) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(m)
+}
+
 // readApplyInput reads input from --from-file or stdin for apply commands.
 // NOTE: Also used by classic_registry.go helpers (same generated package).
 func readApplyInput(fromFile string) ([]byte, error) {

--- a/internal/commands/pro/generated/remove_json_fields_test.go
+++ b/internal/commands/pro/generated/remove_json_fields_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026, Jamf Software LLC
+
+package generated
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestRemoveJSONFields_StripsListedKeys(t *testing.T) {
+	in := []byte(`{"name":"foo","encodedToken":"abc","tokenFileName":"foo.p7m","siteId":-1}`)
+	out, err := removeJSONFields(in, "encodedToken", "tokenFileName")
+	if err != nil {
+		t.Fatalf("removeJSONFields: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output not valid JSON: %v (%s)", err, out)
+	}
+	want := map[string]any{"name": "foo", "siteId": float64(-1)}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestRemoveJSONFields_UnchangedWhenKeysAbsent(t *testing.T) {
+	in := []byte(`{"name":"foo","siteId":-1}`)
+	out, err := removeJSONFields(in, "encodedToken", "tokenFileName")
+	if err != nil {
+		t.Fatalf("removeJSONFields: %v", err)
+	}
+	// When nothing changes the helper returns the input unchanged (same slice).
+	if string(out) != string(in) {
+		t.Errorf("out = %q, want %q", out, in)
+	}
+}
+
+func TestRemoveJSONFields_EmptyInputPassesThrough(t *testing.T) {
+	out, err := removeJSONFields(nil, "x")
+	if err != nil {
+		t.Fatalf("removeJSONFields: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("got %q, want empty", out)
+	}
+}
+
+func TestRemoveJSONFields_NoFieldsPassesThrough(t *testing.T) {
+	in := []byte(`{"a":1}`)
+	out, err := removeJSONFields(in)
+	if err != nil {
+		t.Fatalf("removeJSONFields: %v", err)
+	}
+	if string(out) != string(in) {
+		t.Errorf("got %q, want %q", out, in)
+	}
+}
+
+func TestRemoveJSONFields_NonObjectPassesThrough(t *testing.T) {
+	// A JSON array is not an object; the helper returns it unchanged rather
+	// than erroring, so callers can pass arbitrary bodies.
+	in := []byte(`[1,2,3]`)
+	out, err := removeJSONFields(in, "x")
+	if err != nil {
+		t.Fatalf("removeJSONFields: %v", err)
+	}
+	if string(out) != string(in) {
+		t.Errorf("got %q, want %q", out, in)
+	}
+}
+
+func TestRemoveJSONFields_ReturnsNilWhenObjectEmptiedOut(t *testing.T) {
+	in := []byte(`{"encodedToken":"abc","tokenFileName":"foo.p7m"}`)
+	out, err := removeJSONFields(in, "encodedToken", "tokenFileName")
+	if err != nil {
+		t.Fatalf("removeJSONFields: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("got %q, want empty (object fully stripped)", out)
+	}
+}

--- a/internal/commands/pro/generated/team_viewer_remote_administrations.go
+++ b/internal/commands/pro/generated/team_viewer_remote_administrations.go
@@ -34,6 +34,7 @@ func NewTeamViewerRemoteAdministrationsCmd(ctx *registry.CLIContext) *cobra.Comm
 	cmd.AddCommand(newTeamViewerRemoteAdministrationsSessionsStatusCmd(ctx))
 	cmd.AddCommand(newTeamViewerRemoteAdministrationsPatchCmd(ctx))
 	cmd.AddCommand(newTeamViewerRemoteAdministrationsStatusCmd(ctx))
+	cmd.AddCommand(newTeamViewerRemoteAdministrationsApplyCmd(ctx))
 
 	return cmd
 }
@@ -709,6 +710,126 @@ func newTeamViewerRemoteAdministrationsStatusCmd(ctx *registry.CLIContext) *cobr
 	}
 
 	cmd.Flags().StringVar(&flagName, "name", "", "Look up team-viewer-remote-administration by name")
+
+	return cmd
+}
+
+func newTeamViewerRemoteAdministrationsApplyCmd(ctx *registry.CLIContext) *cobra.Command {
+	var (
+		fromFile     string
+		flagYes      bool
+		flagDryRun   bool
+		flagScaffold bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Create or replace a team-viewer-remote-administration by name",
+		Long: `Create or replace a team-viewer-remote-administration. Reads JSON or YAML from --from-file or stdin.
+
+The name field in the input is used to check if the resource
+already exists. If it does, the resource is replaced (with confirmation).
+If not, a new resource is created.`,
+		Example: `  # Apply a team-viewer-remote-administration from a JSON file
+  jamf-cli team-viewer-remote-administrations apply --from-file team-viewer-remote-administration.json
+
+  # Apply a team-viewer-remote-administration from a YAML file
+  jamf-cli team-viewer-remote-administrations apply --from-file team-viewer-remote-administration.yaml
+
+  # Apply from stdin
+  cat team-viewer-remote-administration.json | jamf-cli team-viewer-remote-administrations apply
+
+  # Apply without replacement confirmation
+  jamf-cli team-viewer-remote-administrations apply --from-file team-viewer-remote-administration.json --yes
+
+  # Preview what would happen
+  jamf-cli team-viewer-remote-administrations apply --from-file team-viewer-remote-administration.json --dry-run`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reqCtx := cmd.Context()
+			if flagScaffold {
+				return printScaffoldOutput(`{
+  "displayName": "teamViewerConfiguration",
+  "enabled": true,
+  "scriptToken": "12847340-nPAX96bsaADH4Gz6K6i2",
+  "sessionTimeout": 15,
+  "siteId": "1"
+}`, ctx.Output.Format())
+			}
+
+			// Read input (JSON or YAML). When file flags are present, empty input
+			// is OK — the file-field injector constructs a minimal body.
+			data, err := readApplyInput(fromFile)
+			if err != nil {
+				return err
+			}
+			if len(data) > 0 {
+				data, err = normalizeInputToJSON(data)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Extract name from JSON input
+			name, err := extractJSONField(data, "name")
+			if err != nil {
+				return fmt.Errorf("input must include a %q field: %w", "name", err)
+			}
+
+			// Check if resource exists by name (read-only, runs even in dry-run)
+			noInput, _ := cmd.Flags().GetBool("no-input")
+			id, err := resolveNameToIDForApply(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "name", "id", name, noInput)
+			if err != nil {
+				return err
+			}
+
+			if id == "" {
+				// Not found — create
+				if flagDryRun {
+					fmt.Fprintf(os.Stderr, "[dry-run] Would create team-viewer-remote-administration %q\n", name)
+					return nil
+				}
+				resp, err := ctx.Client.Do(reqCtx, "POST", "/preview/remote-administration-configurations/team-viewer", bytes.NewReader(data))
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				fmt.Fprintf(os.Stderr, "Created team-viewer-remote-administration %q\n", name)
+				return ctx.Output.PrintResponse(resp)
+			}
+
+			// Found — replace
+			if flagDryRun {
+				fmt.Fprintf(os.Stderr, "[dry-run] Would replace team-viewer-remote-administration %q (id: %s)\n", name, id)
+				return nil
+			}
+			if !flagYes {
+				if noInput {
+					return fmt.Errorf("team-viewer-remote-administration %q already exists (id: %s); use --yes to replace when --no-input is set", name, id)
+				}
+				fmt.Fprintf(os.Stderr, "team-viewer-remote-administration %q already exists (id: %s) and will be replaced. Type 'yes' to confirm: ", name, id)
+				var confirm string
+				fmt.Scanln(&confirm)
+				if confirm != "yes" {
+					return fmt.Errorf("aborted")
+				}
+			}
+
+			updatePath := strings.Replace("/preview/remote-administration-configurations/team-viewer/{id}", "{id}", url.PathEscape(id), 1)
+			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			resp, err := ctx.Client.Do(reqCtx, "PATCH", updatePath, bytes.NewReader(data))
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			fmt.Fprintf(os.Stderr, "Replaced team-viewer-remote-administration %q (id: %s)\n", name, id)
+			return ctx.Output.PrintResponse(resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to JSON or YAML input file (or pipe to stdin)")
+	cmd.Flags().BoolVar(&flagYes, "yes", false, "Skip confirmation prompt when replacing")
+	cmd.Flags().BoolVarP(&flagDryRun, "dry-run", "n", false, "Preview without executing")
+	cmd.Flags().BoolVar(&flagScaffold, "scaffold", false, "Print a JSON template for the request body and exit")
 
 	return cmd
 }

--- a/internal/commands/pro/generated/venafis.go
+++ b/internal/commands/pro/generated/venafis.go
@@ -36,6 +36,7 @@ func NewVenafisCmd(ctx *registry.CLIContext) *cobra.Command {
 	cmd.AddCommand(newVenafisDependentProfilesCmd(ctx))
 	cmd.AddCommand(newVenafisDownloadCmd(ctx))
 	cmd.AddCommand(newVenafisRegenerateCmd(ctx))
+	cmd.AddCommand(newVenafisApplyCmd(ctx))
 
 	return cmd
 }
@@ -877,6 +878,126 @@ func newVenafisRegenerateCmd(ctx *registry.CLIContext) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flagName, "name", "", "Look up venafi by name")
+
+	return cmd
+}
+
+func newVenafisApplyCmd(ctx *registry.CLIContext) *cobra.Command {
+	var (
+		fromFile     string
+		flagYes      bool
+		flagDryRun   bool
+		flagScaffold bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Create or replace a venafi by name",
+		Long: `Create or replace a venafi. Reads JSON or YAML from --from-file or stdin.
+
+The name field in the input is used to check if the resource
+already exists. If it does, the resource is replaced (with confirmation).
+If not, a new resource is created.`,
+		Example: `  # Apply a venafi from a JSON file
+  jamf-cli venafis apply --from-file venafi.json
+
+  # Apply a venafi from a YAML file
+  jamf-cli venafis apply --from-file venafi.yaml
+
+  # Apply from stdin
+  cat venafi.json | jamf-cli venafis apply
+
+  # Apply without replacement confirmation
+  jamf-cli venafis apply --from-file venafi.json --yes
+
+  # Preview what would happen
+  jamf-cli venafis apply --from-file venafi.json --dry-run`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reqCtx := cmd.Context()
+			if flagScaffold {
+				return printScaffoldOutput(`{
+  "clientId": "jamf-pro",
+  "name": "Venafi Certificate Authority",
+  "proxyAddress": "localhost:9443",
+  "refreshToken": "qdkP4SrCFKd7tefAVM6N",
+  "revocationEnabled": true
+}`, ctx.Output.Format())
+			}
+
+			// Read input (JSON or YAML). When file flags are present, empty input
+			// is OK — the file-field injector constructs a minimal body.
+			data, err := readApplyInput(fromFile)
+			if err != nil {
+				return err
+			}
+			if len(data) > 0 {
+				data, err = normalizeInputToJSON(data)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Extract name from JSON input
+			name, err := extractJSONField(data, "name")
+			if err != nil {
+				return fmt.Errorf("input must include a %q field: %w", "name", err)
+			}
+
+			// Check if resource exists by name (read-only, runs even in dry-run)
+			noInput, _ := cmd.Flags().GetBool("no-input")
+			id, err := resolveNameToIDForApply(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", name, noInput)
+			if err != nil {
+				return err
+			}
+
+			if id == "" {
+				// Not found — create
+				if flagDryRun {
+					fmt.Fprintf(os.Stderr, "[dry-run] Would create venafi %q\n", name)
+					return nil
+				}
+				resp, err := ctx.Client.Do(reqCtx, "POST", "/v1/pki/venafi", bytes.NewReader(data))
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				fmt.Fprintf(os.Stderr, "Created venafi %q\n", name)
+				return ctx.Output.PrintResponse(resp)
+			}
+
+			// Found — replace
+			if flagDryRun {
+				fmt.Fprintf(os.Stderr, "[dry-run] Would replace venafi %q (id: %s)\n", name, id)
+				return nil
+			}
+			if !flagYes {
+				if noInput {
+					return fmt.Errorf("venafi %q already exists (id: %s); use --yes to replace when --no-input is set", name, id)
+				}
+				fmt.Fprintf(os.Stderr, "venafi %q already exists (id: %s) and will be replaced. Type 'yes' to confirm: ", name, id)
+				var confirm string
+				fmt.Scanln(&confirm)
+				if confirm != "yes" {
+					return fmt.Errorf("aborted")
+				}
+			}
+
+			updatePath := strings.Replace("/v1/pki/venafi/{id}", "{id}", url.PathEscape(id), 1)
+			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			resp, err := ctx.Client.Do(reqCtx, "PATCH", updatePath, bytes.NewReader(data))
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			fmt.Fprintf(os.Stderr, "Replaced venafi %q (id: %s)\n", name, id)
+			return ctx.Output.PrintResponse(resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to JSON or YAML input file (or pipe to stdin)")
+	cmd.Flags().BoolVar(&flagYes, "yes", false, "Skip confirmation prompt when replacing")
+	cmd.Flags().BoolVarP(&flagDryRun, "dry-run", "n", false, "Preview without executing")
+	cmd.Flags().BoolVar(&flagScaffold, "scaffold", false, "Print a JSON template for the request body and exit")
 
 	return cmd
 }

--- a/internal/commands/pro/generated/vpp_locations.go
+++ b/internal/commands/pro/generated/vpp_locations.go
@@ -36,6 +36,7 @@ func NewVppLocationsCmd(ctx *registry.CLIContext) *cobra.Command {
 	cmd.AddCommand(newVppLocationsContentCmd(ctx))
 	cmd.AddCommand(newVppLocationsReclaimCmd(ctx))
 	cmd.AddCommand(newVppLocationsRevokeLicensesCmd(ctx))
+	cmd.AddCommand(newVppLocationsApplyCmd(ctx))
 
 	return cmd
 }
@@ -1009,6 +1010,145 @@ func newVppLocationsRevokeLicensesCmd(ctx *registry.CLIContext) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flagName, "name", "", "Look up vpp-location by name")
+
+	return cmd
+}
+
+func newVppLocationsApplyCmd(ctx *registry.CLIContext) *cobra.Command {
+	var (
+		fromFile      string
+		flagYes       bool
+		flagDryRun    bool
+		flagScaffold  bool
+		flagTokenFile string
+
+		flagBodyName string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Create or replace a vpp-location by name",
+		Long: `Create or replace a vpp-location. Reads JSON or YAML from --from-file or stdin.
+
+The name field in the input is used to check if the resource
+already exists. If it does, the resource is replaced (with confirmation).
+If not, a new resource is created.`,
+		Example: `  # Apply a vpp-location from a JSON file
+  jamf-cli vpp-locations apply --from-file vpp-location.json
+
+  # Apply a vpp-location from a YAML file
+  jamf-cli vpp-locations apply --from-file vpp-location.yaml
+
+  # Apply from stdin
+  cat vpp-location.json | jamf-cli vpp-locations apply
+
+  # Apply without replacement confirmation
+  jamf-cli vpp-locations apply --from-file vpp-location.json --yes
+
+  # Preview what would happen
+  jamf-cli vpp-locations apply --from-file vpp-location.json --dry-run`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reqCtx := cmd.Context()
+			if flagScaffold {
+				return printScaffoldOutput(`{
+  "autoRegisterManagedUsers": false,
+  "automaticallyPopulatePurchasedContent": false,
+  "name": "Example Location",
+  "sendNotificationWhenNoLongerAssigned": false,
+  "serviceToken": "eyJleHBEYXRlIjoiMjAyMi0wMy0yOVQxNTozNjoyNiswMDAwIiwidG9rZW4iOiJWR2hwY3lCcGN5QnViM1FnWVNCMGIydGxiaTRnU0c5d1pXWjFiR3g1SUdsMElHeHZiMnR6SUd4cGEyVWdZU0IwYjJ0bGJpd2dZblYwSUdsMEozTWdibTkwTGc9PSIsIm9yZ05hbWUiOiJFeGFtcGxlIE9yZyJ9",
+  "siteId": "1"
+}`, ctx.Output.Format())
+			}
+
+			// Read input (JSON or YAML). When file flags are present, empty input
+			// is OK — the file-field injector constructs a minimal body.
+			data, err := readApplyInput(fromFile)
+			anyFileFlag := flagTokenFile != ""
+			if err != nil && !anyFileFlag {
+				return err
+			}
+			err = nil
+			if len(data) > 0 {
+				data, err = normalizeInputToJSON(data)
+				if err != nil {
+					return err
+				}
+			}
+			data, err = setBodyStringField(data, "name", flagBodyName)
+			if err != nil {
+				return err
+			}
+			data, err = injectFileFields(data, []fileFieldSpec{
+				{FilePath: flagTokenFile, Field: "serviceToken", Encoding: "raw", CompanionField: "", NameFallback: "none", NameField: "name"},
+			})
+			if err != nil {
+				return err
+			}
+
+			// Extract name from JSON input
+			name, err := extractJSONField(data, "name")
+			if err != nil {
+				return fmt.Errorf("input must include a %q field: %w", "name", err)
+			}
+
+			// Check if resource exists by name (read-only, runs even in dry-run)
+			noInput, _ := cmd.Flags().GetBool("no-input")
+			id, err := resolveNameToIDForApply(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", name, noInput)
+			if err != nil {
+				return err
+			}
+
+			if id == "" {
+				// Not found — create
+				if flagDryRun {
+					fmt.Fprintf(os.Stderr, "[dry-run] Would create vpp-location %q\n", name)
+					return nil
+				}
+				resp, err := ctx.Client.Do(reqCtx, "POST", "/v1/volume-purchasing-locations", bytes.NewReader(data))
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				fmt.Fprintf(os.Stderr, "Created vpp-location %q\n", name)
+				return ctx.Output.PrintResponse(resp)
+			}
+
+			// Found — replace
+			if flagDryRun {
+				fmt.Fprintf(os.Stderr, "[dry-run] Would replace vpp-location %q (id: %s)\n", name, id)
+				return nil
+			}
+			if !flagYes {
+				if noInput {
+					return fmt.Errorf("vpp-location %q already exists (id: %s); use --yes to replace when --no-input is set", name, id)
+				}
+				fmt.Fprintf(os.Stderr, "vpp-location %q already exists (id: %s) and will be replaced. Type 'yes' to confirm: ", name, id)
+				var confirm string
+				fmt.Scanln(&confirm)
+				if confirm != "yes" {
+					return fmt.Errorf("aborted")
+				}
+			}
+
+			updatePath := strings.Replace("/v1/volume-purchasing-locations/{id}", "{id}", url.PathEscape(id), 1)
+			reqCtx = registry.WithContentType(reqCtx, "application/merge-patch+json")
+			resp, err := ctx.Client.Do(reqCtx, "PATCH", updatePath, bytes.NewReader(data))
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			fmt.Fprintf(os.Stderr, "Replaced vpp-location %q (id: %s)\n", name, id)
+			return ctx.Output.PrintResponse(resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to JSON or YAML input file (or pipe to stdin)")
+	cmd.Flags().BoolVar(&flagYes, "yes", false, "Skip confirmation prompt when replacing")
+	cmd.Flags().BoolVarP(&flagDryRun, "dry-run", "n", false, "Preview without executing")
+	cmd.Flags().BoolVar(&flagScaffold, "scaffold", false, "Print a JSON template for the request body and exit")
+	cmd.Flags().StringVar(&flagTokenFile, "token-file", "", "Path to a VPP service token (.vpptoken); contents populate serviceToken verbatim")
+
+	cmd.Flags().StringVar(&flagBodyName, "name", "", "Name for the vpp-location (sets the body's name field)")
 
 	return cmd
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -407,6 +407,34 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 				noColor = true
 			}
 
+			// Load config up-front so the formatter honours default-output
+			// for every command, including those that skip auth.
+			cfg, err := config.Load()
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			// Apply default output from config if flag not explicitly set
+			if !cmd.Flags().Changed("output") && cfg.DefaultOutput != "" {
+				outputFmt = cfg.DefaultOutput
+			}
+
+			// Build output formatter (shared by all products and by skipped
+			// commands like config/completion/version).
+			if outFile != "" {
+				f, err := os.Create(outFile)
+				if err != nil {
+					return fmt.Errorf("opening output file: %w", err)
+				}
+				outFileHandle = f
+				noColor = true
+			}
+			formatter := output.New(outputFmt, noColor, wide)
+			if outFileHandle != nil {
+				formatter.SetWriter(outFileHandle)
+			}
+			cliCtx.Output = &cliOutput{formatter}
+
 			// Skip auth for commands that don't need it. Most are matched
 			// anywhere in the chain (e.g. "config" covers all subcommands,
 			// "setup" covers both "pro setup" and "protect setup").
@@ -433,38 +461,9 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 			}
 
 			// --scaffold just prints a JSON template — no auth needed.
-			// Set up a basic formatter first so commands can call ctx.Output.Format()
-			// to respect -o yaml even without a full auth round-trip.
 			if scaffold, _ := cmd.Flags().GetBool("scaffold"); scaffold {
-				cliCtx.Output = &cliOutput{output.New(outputFmt, noColor, wide)}
 				return nil
 			}
-
-			// Load config and resolve auth
-			cfg, err := config.Load()
-			if err != nil {
-				return fmt.Errorf("loading config: %w", err)
-			}
-
-			// Apply default output from config if flag not explicitly set
-			if !cmd.Flags().Changed("output") && cfg.DefaultOutput != "" {
-				outputFmt = cfg.DefaultOutput
-			}
-
-			// Build output formatter (shared by all products)
-			if outFile != "" {
-				f, err := os.Create(outFile)
-				if err != nil {
-					return fmt.Errorf("opening output file: %w", err)
-				}
-				outFileHandle = f
-				noColor = true
-			}
-			formatter := output.New(outputFmt, noColor, wide)
-			if outFileHandle != nil {
-				formatter.SetWriter(outFileHandle)
-			}
-			cliCtx.Output = &cliOutput{formatter}
 
 			// Determine product type from command hierarchy or profile
 			product := resolveProduct(cmd, cfg)
@@ -574,7 +573,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 	})
 
 	// Config command group
-	cmd.AddCommand(newConfigCmd())
+	cmd.AddCommand(newConfigCmd(cliCtx))
 
 	// Completion command
 	cmd.AddCommand(newCompletionCmd())


### PR DESCRIPTION
## Summary

Three related improvements to the Jamf Pro CLI:

**1. `apply` for PATCH-only resources** (`2743b11`)

`hasApply` previously required POST + PUT. Many resources (vpp-locations, computers-inventory, mobile-device-groups-static-groups, patch-software-title-configurations, adcs-settings, digi-cert-settings, team-viewer-remote-administrations, venafis) only expose PATCH on `/{id}` and so had no `apply` subcommand. Now `hasApply` accepts either a PUT or a PATCH (with path param + JSON body), preferring PUT. When the update branch is PATCH, the generated code sets `application/merge-patch+json` via `registry.WithContentType` before the request.

**2. Composite `create`/`update`/`apply` for `device-enrollment-instances`** (`c27ea31`)

Jamf Pro has no `POST /v1/device-enrollments`; creation goes through `POST /v1/device-enrollments/upload-token`, and token rotation goes through `PUT /v1/device-enrollments/{id}/upload-token`. Previously these surfaced as standalone `upload-token` / `upload-token-by-id` subcommands, with a `--rename` follow-up — no canonical create/update/apply UX.

The fix introduces two declarative overrides in `parser.go`:
- `resourceCreateOpOverrides` renames a sub-path POST to `"create"` so the standard create subcommand is generated.
- `resourceUpdateTokenOpOverrides` detaches a `/{id}/<action>` PUT onto `Resource.UpdateTokenOp`; no standalone subcommand is emitted for it.

Template changes then compose the flows:
- `update`: `--token-file` routes to the auxiliary PUT; body fields go to the main PUT; either or both may fire; clear error when neither is supplied.
- `apply`: composite create POSTs a separate token body then PUTs main-body fields to `/{id}`; composite update conditionally PUTs token and/or body, returning the auxiliary response when only the token changed.
- `--rename` renamed to `--name` so the upload-style create matches the mental model used elsewhere.

Also adds a `removeJSONFields` helper in the registry template for future composite-body use cases.

**3. Structured output for `config show`/`list`/`validate`** (`fe2109c`)

Config commands emitted ad-hoc formatted text that ignored `-o`. They now marshal structured data and delegate to the output formatter so `table`, `json`, `yaml`, `csv`, and `plain` all work consistently:
- `show` → `{config-file, default-profile, default-output, profiles[]}`
- `list` → profile rows with `default`/`status`/`healthy` columns; empty case prints hint to stderr + `[]`
- `validate` → check rows with `scope`/`name`/`status`/`message`; non-zero exit when any row is `fail`

`PersistentPreRunE` builds the formatter before the auth-skip branch so skipped commands (config, completion, version) also get `cliCtx.Output` populated.

**4. Tests** (`dafbe88`)

New unit coverage for `hasApply` (PATCH+path-param case), `applyUpdateOp` (PUT-preferred / PATCH-fallback / nil), both override maps, and `removeJSONFields`. Config subcommand tests updated to assert against structured JSON output.

## Test plan
- [x] `make generate && make test` — all packages pass
- [x] `make lint` — 0 issues
- [x] Live-tested `apply` on vpp-locations (full round-trip: create + PATCH replace using \`--token-file\`)
- [x] Live-tested `apply` on mobile-device-groups-static-groups (create + PATCH replace)
- [x] Live-tested device-enrollment-instances \`create --token-file --name\` (POST + follow-up PUT rename)
- [x] Live-tested \`update 25 --token-file\` only (token PUT only)
- [x] Live-tested \`update 25\` with stdin body only (main PUT only)
- [x] Live-tested \`update 25 --token-file\` + stdin body (composite)
- [x] Live-tested \`update 25\` with no input → clean error \"nothing to update: provide --from-file, stdin body, or --token-file\"
- [x] Live-tested \`apply --name --token-file\` with no stdin (flags-only composite create)
- [x] Live-tested re-apply same name (flags-only composite update)
- [x] Live-tested \`config show\`/\`list\`/\`validate\` across -o json/yaml/table/csv
- [x] All test resources deleted; tenant left in original state

🤖 Generated with [Claude Code](https://claude.com/claude-code)