### PR TITLE
feat(client): streaming multipart + tuned HTTP transport

### DIFF
--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -225,10 +225,11 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 				return ""
 			}
 		},
-		"hasPostOrPut":   hasPostOrPut,
-		"hasDelete":      hasDelete,
-		"hasDestructive": hasDestructive,
-		"hasApply":       func(ops []*Operation) bool { return hasApply(ops) },
+		"hasPostOrPut":             hasPostOrPut,
+		"hasNonMultipartPostOrPut": hasNonMultipartPostOrPut,
+		"hasDelete":                hasDelete,
+		"hasDestructive":           hasDestructive,
+		"hasApply":                 func(ops []*Operation) bool { return hasApply(ops) },
 		"applyUpdateMethod": func(ops []*Operation) string {
 			op := applyUpdateOp(ops)
 			if op == nil {
@@ -828,6 +829,23 @@ func hasPostOrPut(ops []*Operation) bool {
 	return false
 }
 
+// hasNonMultipartPostOrPut is hasPostOrPut minus multipart ops. Used to gate
+// imports of "bytes" and "io" in the generated template: multipart upload now
+// streams through client.NewMultipartFileUpload and no longer pulls either
+// package into the emitted command body.
+func hasNonMultipartPostOrPut(ops []*Operation) bool {
+	for _, op := range ops {
+		if op.Method != "POST" && op.Method != "PUT" && op.Method != "PATCH" {
+			continue
+		}
+		if op.RequestBody != nil && op.RequestBody.IsMultipart {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 func hasDelete(ops []*Operation) bool {
 	for _, op := range ops {
 		if op.Method == "DELETE" {
@@ -1285,7 +1303,7 @@ const resourceTemplate = `// Copyright 2026, Jamf Software LLC
 package generated
 
 import (
-{{- if or (shouldGenerateApply .) (needsMultipart .) (hasPatchOp .Operations) (hasPostOrPut .Operations) }}
+{{- if or (shouldGenerateApply .) (hasPatchOp .Operations) (hasNonMultipartPostOrPut .Operations) }}
 	"bytes"
 {{- end }}
 {{- if or (hasList .Operations) (hasDeleteMultiple .Operations) }}
@@ -1294,11 +1312,8 @@ import (
 {{- if or (needsFmt .) (hasList .Operations) (hasPostOrPut .Operations) }}
 	"fmt"
 {{- end }}
-{{- if or (hasPostOrPut .Operations) (hasList .Operations) (hasAnyBinaryResponse .) }}
+{{- if or (hasNonMultipartPostOrPut .Operations) (hasList .Operations) (hasAnyBinaryResponse .) }}
 	"io"
-{{- end }}
-{{- if needsMultipart . }}
-	"mime/multipart"
 {{- end }}
 {{- if or (hasDelete .Operations) .UpdateTokenOp }}
 	"net/http"
@@ -1306,11 +1321,8 @@ import (
 {{- if needsURL . }}
 	"net/url"
 {{- end }}
-{{- if or (hasPostOrPut .Operations) (hasDestructive .Operations) (hasDelete .Operations) (shouldGenerateApply .) (hasAnyBinaryResponse .) }}
+{{- if or (hasPostOrPut .Operations) (hasDestructive .Operations) (hasDelete .Operations) (shouldGenerateApply .) (hasAnyBinaryResponse .) (needsMultipart .) }}
 	"os"
-{{- end }}
-{{- if needsMultipart . }}
-	"path/filepath"
 {{- end }}
 {{- if anyOpHasRenameFlag . }}
 	"strconv"
@@ -1319,6 +1331,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+{{- if needsMultipart . }}
+	"github.com/Jamf-Concepts/jamf-cli/internal/client"
+{{- end }}
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 {{- if hasDestructive .Operations }}
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
@@ -1714,17 +1729,14 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 				return fmt.Errorf("opening %s: %w", flagFile, err)
 			}
 			defer f.Close()
-			var buf bytes.Buffer
-			mw := multipart.NewWriter(&buf)
-			fw, err := mw.CreateFormFile("{{ .RequestBody.FileField }}", filepath.Base(flagFile))
+			// Stream the file through a seekable multipart body so Upload can
+			// precompute Content-Length and retry on HTTP 429 without
+			// re-buffering the file.
+			body, contentType, contentLength, err := client.NewMultipartFileUpload("{{ .RequestBody.FileField }}", f)
 			if err != nil {
-				return fmt.Errorf("creating form file: %w", err)
+				return fmt.Errorf("building multipart body: %w", err)
 			}
-			if _, err := io.Copy(fw, f); err != nil {
-				return fmt.Errorf("writing file: %w", err)
-			}
-			mw.Close()
-			resp, err := ctx.Uploader.Upload(reqCtx, path, &buf, mw.FormDataContentType(), int64(buf.Len()))
+			resp, err := ctx.Uploader.Upload(reqCtx, path, body, contentType, contentLength)
 {{- else if eq .Method "GET" "DELETE" }}
 			resp, err := ctx.Client.Do(reqCtx, "{{ .Method }}", path, nil)
 {{- else }}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/httptransport"
 )
 
 // Provider defines the interface for authentication providers
@@ -303,8 +305,8 @@ func NewOAuth2Provider(baseURL, clientID, clientSecret string) *OAuth2Provider {
 		clientSecret: clientSecret,
 		jar:          jar,
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-			Jar:     jar,
+			Transport: httptransport.New(),
+			Jar:       jar,
 		},
 		refreshBuffer: 10 * time.Second,
 	}
@@ -453,8 +455,8 @@ func NewPlatformOAuth2Provider(baseURL, clientID, clientSecret, tenantID string)
 		tenantID:     tenantID,
 		jar:          jar,
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-			Jar:     jar,
+			Transport: httptransport.New(),
+			Jar:       jar,
 		},
 		refreshBuffer: 10 * time.Second,
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/auth"
 	"github.com/Jamf-Concepts/jamf-cli/internal/exitcode"
+	"github.com/Jamf-Concepts/jamf-cli/internal/httptransport"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 )
 
@@ -58,8 +59,10 @@ func WithCookieJar(jar http.CookieJar) Option {
 func New(baseURL string, authProvider auth.Provider, opts ...Option) *Client {
 	c := &Client{
 		baseURL: baseURL,
+		// No Client.Timeout — bound by ctx; per-phase timeouts live on
+		// the tuned Transport. See NewTunedTransport for rationale.
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Transport: httptransport.New(),
 		},
 		auth: authProvider,
 	}
@@ -162,8 +165,13 @@ func (c *Client) Do(ctx context.Context, method, path string, body io.Reader) (*
 }
 
 // Upload executes a streaming HTTP request with a caller-specified Content-Type
-// and Content-Length. Unlike Do, it does not buffer the body (supporting multi-GB
-// files) and does not retry (the body stream cannot be replayed).
+// and Content-Length. The body is never buffered, so multi-GB files stream
+// straight through.
+//
+// 429 retry: when body implements io.Seeker (e.g. *os.File, *bytes.Reader, or
+// the seekable multipart body from NewMultipartFileUpload), Upload retries up
+// to 3 times on HTTP 429, honoring Retry-After. Non-seekable bodies surface
+// 429 to the caller immediately — retrying would corrupt the upload.
 func (c *Client) Upload(ctx context.Context, path string, body io.Reader, contentType string, contentLength int64) (*http.Response, error) {
 	if !strings.HasPrefix(path, "/api") && !strings.HasPrefix(path, "/JSSResource") {
 		path = "/api" + path
@@ -172,48 +180,95 @@ func (c *Client) Upload(ctx context.Context, path string, body io.Reader, conten
 		path = rewritePathForGateway(path, c.tenantID)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+path, body)
-	if err != nil {
-		return nil, fmt.Errorf("creating upload request: %w", err)
+	seeker, _ := body.(io.Seeker)
+	maxAttempts := 1
+	if seeker != nil {
+		maxAttempts = 3
 	}
 
-	token, err := c.auth.GetToken(ctx)
-	if err != nil {
-		return nil, exitcode.Wrap(exitcode.Authentication, fmt.Errorf("getting auth token: %w", err))
+	// Dedicated client: the shared tuned Transport plus session-affinity
+	// cookie jar. No Client.Timeout — ctx bounds the whole upload.
+	uploadClient := &http.Client{Transport: httptransport.New(), Jar: c.httpClient.Jar}
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+				return nil, exitcode.Wrap(exitcode.General, fmt.Errorf("rewinding upload body for retry: %w", err))
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+path, body)
+		if err != nil {
+			return nil, fmt.Errorf("creating upload request: %w", err)
+		}
+
+		token, err := c.auth.GetToken(ctx)
+		if err != nil {
+			return nil, exitcode.Wrap(exitcode.Authentication, fmt.Errorf("getting auth token: %w", err))
+		}
+
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("User-Agent", "jamf-cli/1.0 (+https://github.com/Jamf-Concepts/jamf-cli)")
+		req.Header.Set("Content-Type", contentType)
+		req.Header.Set("Accept", "application/json")
+		req.ContentLength = contentLength
+
+		if c.verbose {
+			if maxAttempts > 1 {
+				fmt.Fprintf(os.Stderr, "--> POST %s (%d bytes, attempt %d/%d)\n", req.URL, contentLength, attempt+1, maxAttempts)
+			} else {
+				fmt.Fprintf(os.Stderr, "--> POST %s (%d bytes)\n", req.URL, contentLength)
+			}
+		}
+
+		resp, err := uploadClient.Do(req)
+		if err != nil {
+			return nil, exitcode.Wrap(exitcode.General, fmt.Errorf("upload request failed: %w", err))
+		}
+
+		// Rate limited and rewindable — sleep, rewind on next iteration, retry.
+		if resp.StatusCode == http.StatusTooManyRequests && seeker != nil && attempt+1 < maxAttempts {
+			delay := parseRetryAfter(resp.Header.Get("Retry-After"), time.Second*time.Duration(1<<attempt))
+			_ = resp.Body.Close()
+			if c.verbose {
+				fmt.Fprintf(os.Stderr, "<-- 429 Too Many Requests, retrying in %v\n", delay)
+			}
+			if err := sleepWithContext(ctx, delay); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		if c.verbose {
+			fmt.Fprintf(os.Stderr, "<-- %d %s\n", resp.StatusCode, resp.Status)
+		}
+
+		if resp.StatusCode >= 400 {
+			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusTooManyRequests {
+				return nil, exitcode.New(exitcode.RateLimited, fmt.Sprintf("upload rate limited (HTTP 429) after %d attempt(s): %s", attempt+1, string(respBody)))
+			}
+			return nil, exitcode.Wrap(exitcode.General, fmt.Errorf("upload failed (HTTP %d): %s", resp.StatusCode, string(respBody)))
+		}
+
+		return resp, nil
 	}
 
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("User-Agent", "jamf-cli/1.0 (+https://github.com/Jamf-Concepts/jamf-cli)")
-	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("Accept", "application/json")
-	req.ContentLength = contentLength
+	return nil, exitcode.New(exitcode.RateLimited, fmt.Sprintf("upload rate limited: server returned HTTP 429 on all %d attempts", maxAttempts))
+}
 
-	if c.verbose {
-		fmt.Fprintf(os.Stderr, "--> POST %s (%d bytes)\n", req.URL, contentLength)
+// parseRetryAfter returns the delay from a Retry-After header value.
+// Supports the delta-seconds form only (Jamf uses integers). Falls back to
+// the caller-supplied default when the header is missing or malformed.
+func parseRetryAfter(header string, fallback time.Duration) time.Duration {
+	if header == "" {
+		return fallback
 	}
-
-	// Use a dedicated client with no timeout for uploads. The standard client's
-	// 30-second timeout covers the entire request lifecycle including body transfer,
-	// which is too short for multi-GB packages. Context cancellation provides the
-	// safety net instead. Share the main client's cookie jar so session-affinity
-	// cookies (e.g. APBALANCEID on Jamf Cloud) are included in upload requests.
-	uploadClient := &http.Client{Timeout: 0, Jar: c.httpClient.Jar}
-	resp, err := uploadClient.Do(req)
-	if err != nil {
-		return nil, exitcode.Wrap(exitcode.General, fmt.Errorf("upload request failed: %w", err))
+	if secs, err := strconv.Atoi(strings.TrimSpace(header)); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
 	}
-
-	if c.verbose {
-		fmt.Fprintf(os.Stderr, "<-- %d %s\n", resp.StatusCode, resp.Status)
-	}
-
-	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		_ = resp.Body.Close()
-		return nil, exitcode.Wrap(exitcode.General, fmt.Errorf("upload failed (HTTP %d): %s", resp.StatusCode, string(respBody)))
-	}
-
-	return resp, nil
+	return fallback
 }
 
 func (c *Client) doWithRetry(ctx context.Context, req *http.Request, bodyData []byte) (*http.Response, error) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -186,10 +186,6 @@ func (c *Client) Upload(ctx context.Context, path string, body io.Reader, conten
 		maxAttempts = 3
 	}
 
-	// Dedicated client: the shared tuned Transport plus session-affinity
-	// cookie jar. No Client.Timeout — ctx bounds the whole upload.
-	uploadClient := &http.Client{Transport: httptransport.New(), Jar: c.httpClient.Jar}
-
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if attempt > 0 {
 			if _, err := seeker.Seek(0, io.SeekStart); err != nil {
@@ -221,7 +217,7 @@ func (c *Client) Upload(ctx context.Context, path string, body io.Reader, conten
 			}
 		}
 
-		resp, err := uploadClient.Do(req)
+		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			return nil, exitcode.Wrap(exitcode.General, fmt.Errorf("upload request failed: %w", err))
 		}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/auth"
 	"github.com/Jamf-Concepts/jamf-cli/internal/exitcode"
@@ -606,5 +607,118 @@ func TestWithTenantID_SetsField(t *testing.T) {
 	c = New("https://example.com", auth.NewTokenProvider("tok"), WithTenantID("my-tenant"))
 	if c.tenantID != "my-tenant" {
 		t.Errorf("tenantID = %q, want %q", c.tenantID, "my-tenant")
+	}
+}
+
+// --- Upload tests ---
+
+func TestUpload_NonSeekable_NoRetry(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("slow down"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("test-token"))
+
+	// A strings.Reader is a Seeker, so wrap it to hide that interface.
+	body := io.NopCloser(strings.NewReader("some-content"))
+	_, err := c.Upload(context.Background(), "/v1/packages/1/upload", body, "application/octet-stream", 12)
+	if err == nil {
+		t.Fatal("expected error on 429")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("attempts = %d, want 1 (non-seekable should not retry)", got)
+	}
+}
+
+func TestUpload_Seekable_RetriesOn429(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Drain body so upload reader is exhausted each attempt.
+		_, _ = io.Copy(io.Discard, r.Body)
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 2 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("slow down"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("test-token"))
+
+	body := strings.NewReader("retry-me-please") // io.ReadSeeker
+	resp, err := c.Upload(context.Background(), "/v1/packages/1/upload", body, "application/octet-stream", int64(body.Len()))
+	if err != nil {
+		t.Fatalf("Upload() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("attempts = %d, want 2 (should retry seekable body)", got)
+	}
+}
+
+func TestUpload_Seekable_RewindsBetweenAttempts(t *testing.T) {
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, b)
+		if len(bodies) < 2 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("test-token"))
+
+	payload := "the-quick-brown-fox"
+	body := strings.NewReader(payload)
+	resp, err := c.Upload(context.Background(), "/v1/packages/1/upload", body, "application/octet-stream", int64(body.Len()))
+	if err != nil {
+		t.Fatalf("Upload() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 request bodies, got %d", len(bodies))
+	}
+	if string(bodies[0]) != payload {
+		t.Errorf("first body = %q, want %q", bodies[0], payload)
+	}
+	if string(bodies[1]) != payload {
+		t.Errorf("second body = %q, want %q (rewind produced different bytes)", bodies[1], payload)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   string
+		fallback time.Duration
+		want     time.Duration
+	}{
+		{"numeric seconds", "5", time.Second, 5 * time.Second},
+		{"numeric with whitespace", "  3 ", time.Second, 3 * time.Second},
+		{"empty uses fallback", "", 2 * time.Second, 2 * time.Second},
+		{"malformed uses fallback", "Wed, 21 Oct 2025 07:28:00 GMT", 2 * time.Second, 2 * time.Second},
+		{"zero is valid", "0", time.Second, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseRetryAfter(tt.header, tt.fallback); got != tt.want {
+				t.Errorf("parseRetryAfter(%q, %v) = %v, want %v", tt.header, tt.fallback, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,6 +4,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -698,6 +699,39 @@ func TestUpload_Seekable_RewindsBetweenAttempts(t *testing.T) {
 	}
 	if string(bodies[1]) != payload {
 		t.Errorf("second body = %q, want %q (rewind produced different bytes)", bodies[1], payload)
+	}
+}
+
+func TestUpload_Seekable_MaxRetriesExhausted(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		atomic.AddInt32(&attempts, 1)
+		// Retry-After "0" keeps the test fast; value is validated by
+		// TestParseRetryAfter.
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("still rate limited"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, auth.NewTokenProvider("test-token"))
+
+	body := strings.NewReader("retry-me") // io.ReadSeeker
+	_, err := c.Upload(context.Background(), "/v1/packages/1/upload", body, "application/octet-stream", int64(body.Len()))
+	if err == nil {
+		t.Fatal("expected error after all retries exhausted")
+	}
+
+	var ec *exitcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *exitcode.Error, got %T: %v", err, err)
+	}
+	if ec.Code != exitcode.RateLimited {
+		t.Errorf("exit code = %v, want %v", ec.Code, exitcode.RateLimited)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("attempts = %d, want 3 (all retries should fire)", got)
 	}
 }
 

--- a/internal/client/multipart.go
+++ b/internal/client/multipart.go
@@ -123,9 +123,11 @@ func (s *seekableMultipartBody) Read(p []byte) (int, error) {
 				return n, err
 			}
 			if m == 0 {
-				// Defensive: the file ended early compared to Stat().Size().
-				// Skip to the footer so we don't loop.
-				s.pos = fileEnd
+				// File ended earlier than Stat().Size() indicated (e.g.
+				// truncated mid-upload). Content-Length has already been
+				// committed to the wire, so we cannot paper over this —
+				// surface the mismatch instead of sending a short body.
+				return n, io.ErrUnexpectedEOF
 			}
 		default: // footer
 			offset := s.pos - fileEnd

--- a/internal/client/multipart.go
+++ b/internal/client/multipart.go
@@ -1,0 +1,149 @@
+// Copyright 2026, Jamf Software LLC
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// NewMultipartFileUpload builds a streaming multipart/form-data body wrapping
+// a single file part and returns the body, Content-Type, and exact
+// Content-Length.
+//
+// The returned io.ReadSeeker streams directly from the underlying *os.File —
+// no in-memory copy of the file. Seek(0, SeekStart) rewinds the body so
+// Client.Upload can retry on HTTP 429.
+//
+// The caller owns the file and must close it after Upload returns. filename
+// in the multipart header is derived from filepath.Base(f.Name()).
+func NewMultipartFileUpload(fieldName string, f *os.File) (body io.ReadSeeker, contentType string, contentLength int64, err error) {
+	info, err := f.Stat()
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("stat upload file: %w", err)
+	}
+	if info.IsDir() {
+		return nil, "", 0, fmt.Errorf("upload source is a directory: %s", f.Name())
+	}
+
+	boundary := randomBoundary()
+	filename := filepath.Base(f.Name())
+	header := buildFilePartHeader(boundary, fieldName, filename)
+	footer := []byte("\r\n--" + boundary + "--\r\n")
+
+	body = &seekableMultipartBody{
+		header:   header,
+		file:     f,
+		footer:   footer,
+		fileSize: info.Size(),
+	}
+	contentType = "multipart/form-data; boundary=" + boundary
+	contentLength = int64(len(header)) + info.Size() + int64(len(footer))
+	return body, contentType, contentLength, nil
+}
+
+// buildFilePartHeader writes the opening boundary + Content-Disposition +
+// Content-Type for a single file part. The Content-Type is sniffed from the
+// filename extension: Jamf's image-upload endpoints (enrollment-customization,
+// icon) reject the stdlib default "application/octet-stream" for PNG uploads,
+// so a correct MIME type is required. Falls back to octet-stream for unknown
+// extensions and strips any "; charset=..." parameter that mime.TypeByExtension
+// attaches to text/* types (binary uploads should not carry a charset).
+func buildFilePartHeader(boundary, fieldName, filename string) []byte {
+	ct := mime.TypeByExtension(filepath.Ext(filename))
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	if semi := strings.Index(ct, ";"); semi >= 0 {
+		ct = strings.TrimSpace(ct[:semi])
+	}
+	h := fmt.Sprintf(
+		"--%s\r\nContent-Disposition: form-data; name=%q; filename=%q\r\nContent-Type: %s\r\n\r\n",
+		boundary, fieldName, filename, ct,
+	)
+	return []byte(h)
+}
+
+// randomBoundary reuses stdlib multipart.Writer's default 30-hex-char boundary
+// generator via a throwaway writer — avoids reinventing RNG code.
+func randomBoundary() string {
+	return multipart.NewWriter(io.Discard).Boundary()
+}
+
+// seekableMultipartBody composes a byte-array header, a seekable file body,
+// and a byte-array footer into a single streaming io.ReadSeeker. Only
+// Seek(0, SeekStart) is supported — that's all Client.Upload needs for retry.
+type seekableMultipartBody struct {
+	header   []byte
+	file     io.ReadSeeker
+	footer   []byte
+	fileSize int64
+	pos      int64 // absolute position across header|file|footer
+}
+
+func (s *seekableMultipartBody) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	headerLen := int64(len(s.header))
+	fileEnd := headerLen + s.fileSize
+	totalLen := fileEnd + int64(len(s.footer))
+
+	n := 0
+	for n < len(p) {
+		if s.pos >= totalLen {
+			if n == 0 {
+				return 0, io.EOF
+			}
+			return n, nil
+		}
+		switch {
+		case s.pos < headerLen:
+			m := copy(p[n:], s.header[s.pos:])
+			s.pos += int64(m)
+			n += m
+		case s.pos < fileEnd:
+			// Cap the read at the file boundary so a short Read on the
+			// underlying file doesn't leak past the declared fileSize.
+			remaining := fileEnd - s.pos
+			dst := p[n:]
+			if int64(len(dst)) > remaining {
+				dst = dst[:remaining]
+			}
+			m, err := s.file.Read(dst)
+			s.pos += int64(m)
+			n += m
+			if err != nil && !errors.Is(err, io.EOF) {
+				return n, err
+			}
+			if m == 0 {
+				// Defensive: the file ended early compared to Stat().Size().
+				// Skip to the footer so we don't loop.
+				s.pos = fileEnd
+			}
+		default: // footer
+			offset := s.pos - fileEnd
+			m := copy(p[n:], s.footer[offset:])
+			s.pos += int64(m)
+			n += m
+		}
+	}
+	return n, nil
+}
+
+func (s *seekableMultipartBody) Seek(offset int64, whence int) (int64, error) {
+	if offset != 0 || whence != io.SeekStart {
+		return 0, fmt.Errorf("seekableMultipartBody: only Seek(0, SeekStart) is supported")
+	}
+	if _, err := s.file.Seek(0, io.SeekStart); err != nil {
+		return 0, fmt.Errorf("rewinding underlying file: %w", err)
+	}
+	s.pos = 0
+	return 0, nil
+}

--- a/internal/client/multipart_test.go
+++ b/internal/client/multipart_test.go
@@ -4,6 +4,7 @@ package client
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -127,6 +128,25 @@ func TestSeekableMultipartBody_RewindForRetry(t *testing.T) {
 
 	if !bytes.Equal(first, second) {
 		t.Errorf("rewind produced different bytes:\nfirst:  %q\nsecond: %q", first, second)
+	}
+}
+
+func TestSeekableMultipartBody_ShortFileErrors(t *testing.T) {
+	// Fake the mismatch between declared fileSize and what the reader actually
+	// yields: stat said 100, reader delivers 5. Content-Length has already
+	// been committed, so Read must surface io.ErrUnexpectedEOF instead of
+	// silently sending a short body.
+	body := &seekableMultipartBody{
+		header:   []byte("--b\r\n\r\n"),
+		file:     strings.NewReader("short"), // only 5 bytes
+		footer:   []byte("\r\n--b--\r\n"),
+		fileSize: 100, // lie about the size
+	}
+
+	buf := make([]byte, 200)
+	_, err := io.ReadFull(body, buf)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("expected io.ErrUnexpectedEOF, got %v", err)
 	}
 }
 

--- a/internal/client/multipart_test.go
+++ b/internal/client/multipart_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026, Jamf Software LLC
+
+package client
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTempFile(t *testing.T, name string, payload []byte) *os.File {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("opening temp file: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	return f
+}
+
+func TestNewMultipartFileUpload_StreamsCorrectBody(t *testing.T) {
+	payload := []byte("hello multipart world")
+	f := writeTempFile(t, "test.bin", payload)
+
+	body, contentType, contentLength, err := NewMultipartFileUpload("file", f)
+	if err != nil {
+		t.Fatalf("NewMultipartFileUpload: %v", err)
+	}
+
+	// Read the whole streamed body
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	if int64(len(got)) != contentLength {
+		t.Errorf("body length = %d, Content-Length = %d; should match", len(got), contentLength)
+	}
+
+	// Parse the multipart body back and verify the file part
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("parse content-type: %v", err)
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		t.Fatal("no boundary in content-type")
+	}
+
+	mr := multipart.NewReader(bytes.NewReader(got), boundary)
+	part, err := mr.NextPart()
+	if err != nil {
+		t.Fatalf("reading part: %v", err)
+	}
+	if part.FormName() != "file" {
+		t.Errorf("form name = %q, want %q", part.FormName(), "file")
+	}
+	if part.FileName() != "test.bin" {
+		t.Errorf("file name = %q, want %q", part.FileName(), "test.bin")
+	}
+	partBytes, err := io.ReadAll(part)
+	if err != nil {
+		t.Fatalf("reading part body: %v", err)
+	}
+	if !bytes.Equal(partBytes, payload) {
+		t.Errorf("part body = %q, want %q", partBytes, payload)
+	}
+
+	if _, err := mr.NextPart(); err != io.EOF {
+		t.Errorf("expected EOF after single part, got %v", err)
+	}
+}
+
+func TestNewMultipartFileUpload_ContentLengthExact(t *testing.T) {
+	payload := make([]byte, 5*1024*1024) // 5 MiB
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	f := writeTempFile(t, "big.pkg", payload)
+
+	body, _, contentLength, err := NewMultipartFileUpload("file", f)
+	if err != nil {
+		t.Fatalf("NewMultipartFileUpload: %v", err)
+	}
+
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	if int64(len(got)) != contentLength {
+		t.Errorf("streamed bytes = %d, Content-Length = %d", len(got), contentLength)
+	}
+}
+
+func TestSeekableMultipartBody_RewindForRetry(t *testing.T) {
+	payload := []byte("retry me")
+	f := writeTempFile(t, "retry.bin", payload)
+
+	body, _, _, err := NewMultipartFileUpload("file", f)
+	if err != nil {
+		t.Fatalf("NewMultipartFileUpload: %v", err)
+	}
+
+	first, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("reading body first time: %v", err)
+	}
+
+	if _, err := body.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("seek rewind: %v", err)
+	}
+
+	second, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("reading body second time: %v", err)
+	}
+
+	if !bytes.Equal(first, second) {
+		t.Errorf("rewind produced different bytes:\nfirst:  %q\nsecond: %q", first, second)
+	}
+}
+
+func TestSeekableMultipartBody_UnsupportedSeekRejected(t *testing.T) {
+	f := writeTempFile(t, "x.bin", []byte("x"))
+	body, _, _, err := NewMultipartFileUpload("file", f)
+	if err != nil {
+		t.Fatalf("NewMultipartFileUpload: %v", err)
+	}
+
+	if _, err := body.Seek(10, io.SeekStart); err == nil {
+		t.Error("Seek(10, SeekStart) should fail")
+	}
+	if _, err := body.Seek(0, io.SeekCurrent); err == nil {
+		t.Error("Seek(0, SeekCurrent) should fail")
+	}
+	if _, err := body.Seek(0, io.SeekEnd); err == nil {
+		t.Error("Seek(0, SeekEnd) should fail")
+	}
+}
+
+func TestBuildFilePartHeader_SniffsContentType(t *testing.T) {
+	h := string(buildFilePartHeader("b", "file", "icon.png"))
+
+	var mh textproto.MIMEHeader
+	// The header is raw bytes ending with CRLFCRLF; fake parse by splitting on CRLF
+	lines := strings.Split(h, "\r\n")
+	mh = make(textproto.MIMEHeader)
+	for _, line := range lines {
+		if line == "" || strings.HasPrefix(line, "--") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, ": ")
+		if !ok {
+			continue
+		}
+		mh.Add(k, v)
+	}
+
+	if got := mh.Get("Content-Type"); got != "image/png" {
+		t.Errorf("Content-Type = %q, want %q", got, "image/png")
+	}
+	// Binary extension falls through to octet-stream
+	h2 := string(buildFilePartHeader("b", "file", "blob.bin"))
+	if !strings.Contains(h2, "Content-Type: application/octet-stream") {
+		t.Errorf("blob.bin should get octet-stream, got: %s", h2)
+	}
+}
+
+func TestBuildFilePartHeader_StripsCharset(t *testing.T) {
+	// Text extensions default to "text/plain; charset=utf-8" — the charset
+	// param must be stripped for multipart uploads.
+	h := string(buildFilePartHeader("b", "file", "notes.txt"))
+	if strings.Contains(h, "charset=") {
+		t.Errorf("charset param should be stripped, got: %s", h)
+	}
+}
+
+func TestRandomBoundary_UniquePerCall(t *testing.T) {
+	b1 := randomBoundary()
+	b2 := randomBoundary()
+	if b1 == b2 {
+		t.Errorf("two consecutive boundaries are equal (%q); expected random", b1)
+	}
+}

--- a/internal/commands/pro/generated/access_managements.go
+++ b/internal/commands/pro/generated/access_managements.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewAccessManagementsCmd creates the access-managements command group

--- a/internal/commands/pro/generated/account_driven_user_enrollment_session_token_settings.go
+++ b/internal/commands/pro/generated/account_driven_user_enrollment_session_token_settings.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewAccountDrivenUserEnrollmentSessionTokenSettingsCmd creates the account-driven-user-enrollment-session-token-settings command group

--- a/internal/commands/pro/generated/account_preferences.go
+++ b/internal/commands/pro/generated/account_preferences.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewAccountPreferencesCmd creates the account-preferences command group

--- a/internal/commands/pro/generated/activation_codes.go
+++ b/internal/commands/pro/generated/activation_codes.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewActivationCodesCmd creates the activation-codes command group

--- a/internal/commands/pro/generated/adcs_settings.go
+++ b/internal/commands/pro/generated/adcs_settings.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewAdcsSettingsCmd creates the adcs-settings command group

--- a/internal/commands/pro/generated/advanced_mobile_device_searches.go
+++ b/internal/commands/pro/generated/advanced_mobile_device_searches.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewAdvancedMobileDeviceSearchesCmd creates the advanced-mobile-device-searches command group

--- a/internal/commands/pro/generated/advanced_user_content_searches.go
+++ b/internal/commands/pro/generated/advanced_user_content_searches.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewAdvancedUserContentSearchesCmd creates the advanced-user-content-searches command group

--- a/internal/commands/pro/generated/api_integrations.go
+++ b/internal/commands/pro/generated/api_integrations.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewApiIntegrationsCmd creates the api-integrations command group

--- a/internal/commands/pro/generated/api_roles.go
+++ b/internal/commands/pro/generated/api_roles.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewApiRolesCmd creates the api-roles command group

--- a/internal/commands/pro/generated/api_roles_privileges.go
+++ b/internal/commands/pro/generated/api_roles_privileges.go
@@ -6,9 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewApiRolesPrivilegesCmd creates the api-roles-privileges command group

--- a/internal/commands/pro/generated/apns_client_push_status.go
+++ b/internal/commands/pro/generated/apns_client_push_status.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewApnsClientPushStatusCmd creates the apns-client-push-status command group

--- a/internal/commands/pro/generated/app_installer_deployments.go
+++ b/internal/commands/pro/generated/app_installer_deployments.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewAppInstallerDeploymentsCmd creates the app-installer-deployments command group

--- a/internal/commands/pro/generated/app_installer_titles.go
+++ b/internal/commands/pro/generated/app_installer_titles.go
@@ -9,9 +9,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewAppInstallerTitlesCmd creates the app-installer-titles command group

--- a/internal/commands/pro/generated/app_requests.go
+++ b/internal/commands/pro/generated/app_requests.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewAppRequestsCmd creates the app-requests command group

--- a/internal/commands/pro/generated/authentications.go
+++ b/internal/commands/pro/generated/authentications.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewAuthenticationsCmd creates the authentications command group

--- a/internal/commands/pro/generated/buildings.go
+++ b/internal/commands/pro/generated/buildings.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewBuildingsCmd creates the buildings command group

--- a/internal/commands/pro/generated/cache.go
+++ b/internal/commands/pro/generated/cache.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCacheCmd creates the cache command group

--- a/internal/commands/pro/generated/categories.go
+++ b/internal/commands/pro/generated/categories.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCategoriesCmd creates the categories command group

--- a/internal/commands/pro/generated/certificate_authorities.go
+++ b/internal/commands/pro/generated/certificate_authorities.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCertificateAuthoritiesCmd creates the certificate-authorities command group

--- a/internal/commands/pro/generated/change_passwords.go
+++ b/internal/commands/pro/generated/change_passwords.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewChangePasswordsCmd creates the change-passwords command group

--- a/internal/commands/pro/generated/classic_ldaps.go
+++ b/internal/commands/pro/generated/classic_ldaps.go
@@ -7,9 +7,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewClassicLdapsCmd creates the classic-ldaps command group

--- a/internal/commands/pro/generated/client_check_in.go
+++ b/internal/commands/pro/generated/client_check_in.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewClientCheckInCmd creates the client-check-in command group

--- a/internal/commands/pro/generated/cloud_azure_defaults.go
+++ b/internal/commands/pro/generated/cloud_azure_defaults.go
@@ -5,9 +5,8 @@ package generated
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCloudAzureDefaultsCmd creates the cloud-azure-defaults command group

--- a/internal/commands/pro/generated/cloud_azures.go
+++ b/internal/commands/pro/generated/cloud_azures.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCloudAzuresCmd creates the cloud-azures command group

--- a/internal/commands/pro/generated/cloud_distribution_points.go
+++ b/internal/commands/pro/generated/cloud_distribution_points.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCloudDistributionPointsCmd creates the cloud-distribution-points command group

--- a/internal/commands/pro/generated/cloud_id_p_configurations.go
+++ b/internal/commands/pro/generated/cloud_id_p_configurations.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCloudIdPConfigurationsCmd creates the cloud-id-p-configurations command group

--- a/internal/commands/pro/generated/cloud_id_p_histories.go
+++ b/internal/commands/pro/generated/cloud_id_p_histories.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCloudIdPHistoriesCmd creates the cloud-id-p-histories command group

--- a/internal/commands/pro/generated/cloud_id_p_test_searches.go
+++ b/internal/commands/pro/generated/cloud_id_p_test_searches.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCloudIdPTestSearchesCmd creates the cloud-id-p-test-searches command group

--- a/internal/commands/pro/generated/cloud_informations.go
+++ b/internal/commands/pro/generated/cloud_informations.go
@@ -5,9 +5,8 @@ package generated
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCloudInformationsCmd creates the cloud-informations command group

--- a/internal/commands/pro/generated/cloud_ldap_connections.go
+++ b/internal/commands/pro/generated/cloud_ldap_connections.go
@@ -6,9 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCloudLdapConnectionsCmd creates the cloud-ldap-connections command group

--- a/internal/commands/pro/generated/cloud_ldap_defaults.go
+++ b/internal/commands/pro/generated/cloud_ldap_defaults.go
@@ -6,9 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCloudLdapDefaultsCmd creates the cloud-ldap-defaults command group

--- a/internal/commands/pro/generated/cloud_ldap_key_stores.go
+++ b/internal/commands/pro/generated/cloud_ldap_key_stores.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCloudLdapKeyStoresCmd creates the cloud-ldap-key-stores command group

--- a/internal/commands/pro/generated/cloud_ldap_mappings.go
+++ b/internal/commands/pro/generated/cloud_ldap_mappings.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCloudLdapMappingsCmd creates the cloud-ldap-mappings command group

--- a/internal/commands/pro/generated/cloud_ldaps.go
+++ b/internal/commands/pro/generated/cloud_ldaps.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCloudLdapsCmd creates the cloud-ldaps command group

--- a/internal/commands/pro/generated/computer_extension_attributes.go
+++ b/internal/commands/pro/generated/computer_extension_attributes.go
@@ -7,17 +7,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/spf13/cobra"
-
+	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewComputerExtensionAttributesCmd creates the computer-extension-attributes command group
@@ -910,17 +908,14 @@ func newComputerExtensionAttributesUploadCmd(ctx *registry.CLIContext) *cobra.Co
 				return fmt.Errorf("opening %s: %w", flagFile, err)
 			}
 			defer f.Close()
-			var buf bytes.Buffer
-			mw := multipart.NewWriter(&buf)
-			fw, err := mw.CreateFormFile("file", filepath.Base(flagFile))
+			// Stream the file through a seekable multipart body so Upload can
+			// precompute Content-Length and retry on HTTP 429 without
+			// re-buffering the file.
+			body, contentType, contentLength, err := client.NewMultipartFileUpload("file", f)
 			if err != nil {
-				return fmt.Errorf("creating form file: %w", err)
+				return fmt.Errorf("building multipart body: %w", err)
 			}
-			if _, err := io.Copy(fw, f); err != nil {
-				return fmt.Errorf("writing file: %w", err)
-			}
-			mw.Close()
-			resp, err := ctx.Uploader.Upload(reqCtx, path, &buf, mw.FormDataContentType(), int64(buf.Len()))
+			resp, err := ctx.Uploader.Upload(reqCtx, path, body, contentType, contentLength)
 			if err != nil {
 				return err
 			}

--- a/internal/commands/pro/generated/computer_groups.go
+++ b/internal/commands/pro/generated/computer_groups.go
@@ -5,9 +5,8 @@ package generated
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewComputerGroupsCmd creates the computer-groups command group

--- a/internal/commands/pro/generated/computer_inventory_collection_settings.go
+++ b/internal/commands/pro/generated/computer_inventory_collection_settings.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewComputerInventoryCollectionSettingsCmd creates the computer-inventory-collection-settings command group

--- a/internal/commands/pro/generated/computer_prestage_scopes.go
+++ b/internal/commands/pro/generated/computer_prestage_scopes.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewComputerPrestageScopesCmd creates the computer-prestage-scopes command group

--- a/internal/commands/pro/generated/computer_prestages.go
+++ b/internal/commands/pro/generated/computer_prestages.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewComputerPrestagesCmd creates the computer-prestages command group

--- a/internal/commands/pro/generated/computer_smart_groups.go
+++ b/internal/commands/pro/generated/computer_smart_groups.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewComputerSmartGroupsCmd creates the computer-smart-groups command group

--- a/internal/commands/pro/generated/computers.go
+++ b/internal/commands/pro/generated/computers.go
@@ -9,9 +9,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewComputersCmd creates the computers command group

--- a/internal/commands/pro/generated/computers_inventory.go
+++ b/internal/commands/pro/generated/computers_inventory.go
@@ -7,17 +7,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/spf13/cobra"
-
+	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewComputersInventoryCmd creates the computers-inventory command group
@@ -830,17 +828,14 @@ func newComputersInventoryUploadCmd(ctx *registry.CLIContext) *cobra.Command {
 				return fmt.Errorf("opening %s: %w", flagFile, err)
 			}
 			defer f.Close()
-			var buf bytes.Buffer
-			mw := multipart.NewWriter(&buf)
-			fw, err := mw.CreateFormFile("file", filepath.Base(flagFile))
+			// Stream the file through a seekable multipart body so Upload can
+			// precompute Content-Length and retry on HTTP 429 without
+			// re-buffering the file.
+			body, contentType, contentLength, err := client.NewMultipartFileUpload("file", f)
 			if err != nil {
-				return fmt.Errorf("creating form file: %w", err)
+				return fmt.Errorf("building multipart body: %w", err)
 			}
-			if _, err := io.Copy(fw, f); err != nil {
-				return fmt.Errorf("writing file: %w", err)
-			}
-			mw.Close()
-			resp, err := ctx.Uploader.Upload(reqCtx, path, &buf, mw.FormDataContentType(), int64(buf.Len()))
+			resp, err := ctx.Uploader.Upload(reqCtx, path, body, contentType, contentLength)
 			if err != nil {
 				return err
 			}

--- a/internal/commands/pro/generated/country_codes.go
+++ b/internal/commands/pro/generated/country_codes.go
@@ -5,9 +5,8 @@ package generated
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCountryCodesCmd creates the country-codes command group

--- a/internal/commands/pro/generated/csas.go
+++ b/internal/commands/pro/generated/csas.go
@@ -8,10 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewCsasCmd creates the csas command group

--- a/internal/commands/pro/generated/dashboards.go
+++ b/internal/commands/pro/generated/dashboards.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDashboardsCmd creates the dashboards command group

--- a/internal/commands/pro/generated/database_connections.go
+++ b/internal/commands/pro/generated/database_connections.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDatabaseConnectionsCmd creates the database-connections command group

--- a/internal/commands/pro/generated/ddm_status.go
+++ b/internal/commands/pro/generated/ddm_status.go
@@ -6,9 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDdmStatusCmd creates the ddm-status command group

--- a/internal/commands/pro/generated/ddm_syncs.go
+++ b/internal/commands/pro/generated/ddm_syncs.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDdmSyncsCmd creates the ddm-syncs command group

--- a/internal/commands/pro/generated/departments.go
+++ b/internal/commands/pro/generated/departments.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDepartmentsCmd creates the departments command group

--- a/internal/commands/pro/generated/device_communication_settings.go
+++ b/internal/commands/pro/generated/device_communication_settings.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDeviceCommunicationSettingsCmd creates the device-communication-settings command group

--- a/internal/commands/pro/generated/device_compliance_informations.go
+++ b/internal/commands/pro/generated/device_compliance_informations.go
@@ -7,9 +7,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDeviceComplianceInformationsCmd creates the device-compliance-informations command group

--- a/internal/commands/pro/generated/device_enrollment_instance_sync_states.go
+++ b/internal/commands/pro/generated/device_enrollment_instance_sync_states.go
@@ -6,9 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDeviceEnrollmentInstanceSyncStatesCmd creates the device-enrollment-instance-sync-states command group

--- a/internal/commands/pro/generated/device_enrollment_instances.go
+++ b/internal/commands/pro/generated/device_enrollment_instances.go
@@ -13,10 +13,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDeviceEnrollmentInstancesCmd creates the device-enrollment-instances command group

--- a/internal/commands/pro/generated/digi_cert_settings.go
+++ b/internal/commands/pro/generated/digi_cert_settings.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDigiCertSettingsCmd creates the digi-cert-settings command group

--- a/internal/commands/pro/generated/distribution_points.go
+++ b/internal/commands/pro/generated/distribution_points.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDistributionPointsCmd creates the distribution-points command group

--- a/internal/commands/pro/generated/dock_items.go
+++ b/internal/commands/pro/generated/dock_items.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDockItemsCmd creates the dock-items command group

--- a/internal/commands/pro/generated/dss_proxies.go
+++ b/internal/commands/pro/generated/dss_proxies.go
@@ -6,9 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewDssProxiesCmd creates the dss-proxies command group

--- a/internal/commands/pro/generated/ebooks.go
+++ b/internal/commands/pro/generated/ebooks.go
@@ -9,9 +9,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewEbooksCmd creates the ebooks command group

--- a/internal/commands/pro/generated/enrollment_customization_panels.go
+++ b/internal/commands/pro/generated/enrollment_customization_panels.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewEnrollmentCustomizationPanelsCmd creates the enrollment-customization-panels command group

--- a/internal/commands/pro/generated/enrollment_customizations.go
+++ b/internal/commands/pro/generated/enrollment_customizations.go
@@ -7,17 +7,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/spf13/cobra"
-
+	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewEnrollmentCustomizationsCmd creates the enrollment-customizations command group
@@ -756,17 +754,14 @@ func newEnrollmentCustomizationsUploadCmd(ctx *registry.CLIContext) *cobra.Comma
 				return fmt.Errorf("opening %s: %w", flagFile, err)
 			}
 			defer f.Close()
-			var buf bytes.Buffer
-			mw := multipart.NewWriter(&buf)
-			fw, err := mw.CreateFormFile("file", filepath.Base(flagFile))
+			// Stream the file through a seekable multipart body so Upload can
+			// precompute Content-Length and retry on HTTP 429 without
+			// re-buffering the file.
+			body, contentType, contentLength, err := client.NewMultipartFileUpload("file", f)
 			if err != nil {
-				return fmt.Errorf("creating form file: %w", err)
+				return fmt.Errorf("building multipart body: %w", err)
 			}
-			if _, err := io.Copy(fw, f); err != nil {
-				return fmt.Errorf("writing file: %w", err)
-			}
-			mw.Close()
-			resp, err := ctx.Uploader.Upload(reqCtx, path, &buf, mw.FormDataContentType(), int64(buf.Len()))
+			resp, err := ctx.Uploader.Upload(reqCtx, path, body, contentType, contentLength)
 			if err != nil {
 				return err
 			}

--- a/internal/commands/pro/generated/enrollment_languages.go
+++ b/internal/commands/pro/generated/enrollment_languages.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewEnrollmentLanguagesCmd creates the enrollment-languages command group

--- a/internal/commands/pro/generated/enrollment_settings.go
+++ b/internal/commands/pro/generated/enrollment_settings.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewEnrollmentSettingsCmd creates the enrollment-settings command group

--- a/internal/commands/pro/generated/erase_device_computers.go
+++ b/internal/commands/pro/generated/erase_device_computers.go
@@ -10,10 +10,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewEraseDeviceComputersCmd creates the erase-device-computers command group

--- a/internal/commands/pro/generated/erase_device_mobiles.go
+++ b/internal/commands/pro/generated/erase_device_mobiles.go
@@ -10,10 +10,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewEraseDeviceMobilesCmd creates the erase-device-mobiles command group

--- a/internal/commands/pro/generated/groups.go
+++ b/internal/commands/pro/generated/groups.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewGroupsCmd creates the groups command group

--- a/internal/commands/pro/generated/gsx_connection.go
+++ b/internal/commands/pro/generated/gsx_connection.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewGsxConnectionCmd creates the gsx-connection command group

--- a/internal/commands/pro/generated/health_checks.go
+++ b/internal/commands/pro/generated/health_checks.go
@@ -5,9 +5,8 @@ package generated
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewHealthChecksCmd creates the health-checks command group

--- a/internal/commands/pro/generated/icons.go
+++ b/internal/commands/pro/generated/icons.go
@@ -3,18 +3,15 @@
 package generated
 
 import (
-	"bytes"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/spf13/cobra"
-
+	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewIconsCmd creates the icons command group
@@ -123,17 +120,14 @@ func newIconsUploadCmd(ctx *registry.CLIContext) *cobra.Command {
 				return fmt.Errorf("opening %s: %w", flagFile, err)
 			}
 			defer f.Close()
-			var buf bytes.Buffer
-			mw := multipart.NewWriter(&buf)
-			fw, err := mw.CreateFormFile("file", filepath.Base(flagFile))
+			// Stream the file through a seekable multipart body so Upload can
+			// precompute Content-Length and retry on HTTP 429 without
+			// re-buffering the file.
+			body, contentType, contentLength, err := client.NewMultipartFileUpload("file", f)
 			if err != nil {
-				return fmt.Errorf("creating form file: %w", err)
+				return fmt.Errorf("building multipart body: %w", err)
 			}
-			if _, err := io.Copy(fw, f); err != nil {
-				return fmt.Errorf("writing file: %w", err)
-			}
-			mw.Close()
-			resp, err := ctx.Uploader.Upload(reqCtx, path, &buf, mw.FormDataContentType(), int64(buf.Len()))
+			resp, err := ctx.Uploader.Upload(reqCtx, path, body, contentType, contentLength)
 			if err != nil {
 				return err
 			}

--- a/internal/commands/pro/generated/impact_alert_notification_settings.go
+++ b/internal/commands/pro/generated/impact_alert_notification_settings.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewImpactAlertNotificationSettingsCmd creates the impact-alert-notification-settings command group

--- a/internal/commands/pro/generated/inventory_informations.go
+++ b/internal/commands/pro/generated/inventory_informations.go
@@ -5,9 +5,8 @@ package generated
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewInventoryInformationsCmd creates the inventory-informations command group

--- a/internal/commands/pro/generated/inventory_preloads.go
+++ b/internal/commands/pro/generated/inventory_preloads.go
@@ -7,17 +7,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/spf13/cobra"
-
+	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewInventoryPreloadsCmd creates the inventory-preloads command group
@@ -1065,17 +1063,14 @@ func newInventoryPreloadsCsvValidateCmd(ctx *registry.CLIContext) *cobra.Command
 				return fmt.Errorf("opening %s: %w", flagFile, err)
 			}
 			defer f.Close()
-			var buf bytes.Buffer
-			mw := multipart.NewWriter(&buf)
-			fw, err := mw.CreateFormFile("file", filepath.Base(flagFile))
+			// Stream the file through a seekable multipart body so Upload can
+			// precompute Content-Length and retry on HTTP 429 without
+			// re-buffering the file.
+			body, contentType, contentLength, err := client.NewMultipartFileUpload("file", f)
 			if err != nil {
-				return fmt.Errorf("creating form file: %w", err)
+				return fmt.Errorf("building multipart body: %w", err)
 			}
-			if _, err := io.Copy(fw, f); err != nil {
-				return fmt.Errorf("writing file: %w", err)
-			}
-			mw.Close()
-			resp, err := ctx.Uploader.Upload(reqCtx, path, &buf, mw.FormDataContentType(), int64(buf.Len()))
+			resp, err := ctx.Uploader.Upload(reqCtx, path, body, contentType, contentLength)
 			if err != nil {
 				return err
 			}
@@ -1178,17 +1173,14 @@ func newInventoryPreloadsUploadCmd(ctx *registry.CLIContext) *cobra.Command {
 				return fmt.Errorf("opening %s: %w", flagFile, err)
 			}
 			defer f.Close()
-			var buf bytes.Buffer
-			mw := multipart.NewWriter(&buf)
-			fw, err := mw.CreateFormFile("file", filepath.Base(flagFile))
+			// Stream the file through a seekable multipart body so Upload can
+			// precompute Content-Length and retry on HTTP 429 without
+			// re-buffering the file.
+			body, contentType, contentLength, err := client.NewMultipartFileUpload("file", f)
 			if err != nil {
-				return fmt.Errorf("creating form file: %w", err)
+				return fmt.Errorf("building multipart body: %w", err)
 			}
-			if _, err := io.Copy(fw, f); err != nil {
-				return fmt.Errorf("writing file: %w", err)
-			}
-			mw.Close()
-			resp, err := ctx.Uploader.Upload(reqCtx, path, &buf, mw.FormDataContentType(), int64(buf.Len()))
+			resp, err := ctx.Uploader.Upload(reqCtx, path, body, contentType, contentLength)
 			if err != nil {
 				return err
 			}

--- a/internal/commands/pro/generated/jamf_connect_deployment_tasks.go
+++ b/internal/commands/pro/generated/jamf_connect_deployment_tasks.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewJamfConnectDeploymentTasksCmd creates the jamf-connect-deployment-tasks command group

--- a/internal/commands/pro/generated/jamf_connects.go
+++ b/internal/commands/pro/generated/jamf_connects.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewJamfConnectsCmd creates the jamf-connects command group

--- a/internal/commands/pro/generated/jamf_packages.go
+++ b/internal/commands/pro/generated/jamf_packages.go
@@ -6,9 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewJamfPackagesCmd creates the jamf-packages command group

--- a/internal/commands/pro/generated/jamf_pro_informations.go
+++ b/internal/commands/pro/generated/jamf_pro_informations.go
@@ -5,9 +5,8 @@ package generated
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewJamfProInformationsCmd creates the jamf-pro-informations command group

--- a/internal/commands/pro/generated/jamf_pro_server_url.go
+++ b/internal/commands/pro/generated/jamf_pro_server_url.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewJamfProServerUrlCmd creates the jamf-pro-server-url command group

--- a/internal/commands/pro/generated/jamf_pro_versions.go
+++ b/internal/commands/pro/generated/jamf_pro_versions.go
@@ -5,9 +5,8 @@ package generated
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewJamfProVersionsCmd creates the jamf-pro-versions command group

--- a/internal/commands/pro/generated/jamf_protect.go
+++ b/internal/commands/pro/generated/jamf_protect.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewJamfProtectCmd creates the jamf-protect command group

--- a/internal/commands/pro/generated/jamf_protect_deployment_tasks.go
+++ b/internal/commands/pro/generated/jamf_protect_deployment_tasks.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewJamfProtectDeploymentTasksCmd creates the jamf-protect-deployment-tasks command group

--- a/internal/commands/pro/generated/jamf_protect_plans.go
+++ b/internal/commands/pro/generated/jamf_protect_plans.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewJamfProtectPlansCmd creates the jamf-protect-plans command group

--- a/internal/commands/pro/generated/jamf_remote_assist_session_histories.go
+++ b/internal/commands/pro/generated/jamf_remote_assist_session_histories.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewJamfRemoteAssistSessionHistoriesCmd creates the jamf-remote-assist-session-histories command group

--- a/internal/commands/pro/generated/jcds.go
+++ b/internal/commands/pro/generated/jcds.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewJcdsCmd creates the jcds command group

--- a/internal/commands/pro/generated/ldap_rs.go
+++ b/internal/commands/pro/generated/ldap_rs.go
@@ -6,9 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewLdapRsCmd creates the ldap-rs command group

--- a/internal/commands/pro/generated/local_admin_passwords.go
+++ b/internal/commands/pro/generated/local_admin_passwords.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewLocalAdminPasswordsCmd creates the local-admin-passwords command group

--- a/internal/commands/pro/generated/locales.go
+++ b/internal/commands/pro/generated/locales.go
@@ -5,9 +5,8 @@ package generated
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewLocalesCmd creates the locales command group

--- a/internal/commands/pro/generated/log_flushings.go
+++ b/internal/commands/pro/generated/log_flushings.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewLogFlushingsCmd creates the log-flushings command group

--- a/internal/commands/pro/generated/login_customization.go
+++ b/internal/commands/pro/generated/login_customization.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewLoginCustomizationCmd creates the login-customization command group

--- a/internal/commands/pro/generated/mac_os_managed_software_updates.go
+++ b/internal/commands/pro/generated/mac_os_managed_software_updates.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMacOsManagedSoftwareUpdatesCmd creates the mac-os-managed-software-updates command group

--- a/internal/commands/pro/generated/managed_software_updates.go
+++ b/internal/commands/pro/generated/managed_software_updates.go
@@ -7,9 +7,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewManagedSoftwareUpdatesCmd creates the managed-software-updates command group

--- a/internal/commands/pro/generated/managed_software_updates_plans.go
+++ b/internal/commands/pro/generated/managed_software_updates_plans.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewManagedSoftwareUpdatesPlansCmd creates the managed-software-updates-plans command group

--- a/internal/commands/pro/generated/mdm_commands.go
+++ b/internal/commands/pro/generated/mdm_commands.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMdmCommandsCmd creates the mdm-commands command group

--- a/internal/commands/pro/generated/mdm_renewals.go
+++ b/internal/commands/pro/generated/mdm_renewals.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMdmRenewalsCmd creates the mdm-renewals command group

--- a/internal/commands/pro/generated/mobile_device_apps.go
+++ b/internal/commands/pro/generated/mobile_device_apps.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMobileDeviceAppsCmd creates the mobile-device-apps command group

--- a/internal/commands/pro/generated/mobile_device_enrollment_profiles.go
+++ b/internal/commands/pro/generated/mobile_device_enrollment_profiles.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMobileDeviceEnrollmentProfilesCmd creates the mobile-device-enrollment-profiles command group

--- a/internal/commands/pro/generated/mobile_device_extension_attributes.go
+++ b/internal/commands/pro/generated/mobile_device_extension_attributes.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMobileDeviceExtensionAttributesCmd creates the mobile-device-extension-attributes command group

--- a/internal/commands/pro/generated/mobile_device_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups.go
@@ -10,10 +10,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMobileDeviceGroupsCmd creates the mobile-device-groups command group

--- a/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMobileDeviceGroupsSmartGroupsCmd creates the mobile-device-groups-smart-groups command group

--- a/internal/commands/pro/generated/mobile_device_groups_static_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_static_groups.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMobileDeviceGroupsStaticGroupsCmd creates the mobile-device-groups-static-groups command group

--- a/internal/commands/pro/generated/mobile_device_inventory_details.go
+++ b/internal/commands/pro/generated/mobile_device_inventory_details.go
@@ -9,9 +9,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMobileDeviceInventoryDetailsCmd creates the mobile-device-inventory-details command group

--- a/internal/commands/pro/generated/mobile_device_prestage_scopes.go
+++ b/internal/commands/pro/generated/mobile_device_prestage_scopes.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMobileDevicePrestageScopesCmd creates the mobile-device-prestage-scopes command group

--- a/internal/commands/pro/generated/mobile_device_prestage_sync_states.go
+++ b/internal/commands/pro/generated/mobile_device_prestage_sync_states.go
@@ -6,9 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMobileDevicePrestageSyncStatesCmd creates the mobile-device-prestage-sync-states command group

--- a/internal/commands/pro/generated/mobile_device_prestages.go
+++ b/internal/commands/pro/generated/mobile_device_prestages.go
@@ -7,17 +7,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/spf13/cobra"
-
+	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMobileDevicePrestagesCmd creates the mobile-device-prestages command group
@@ -1058,17 +1056,14 @@ func newMobileDevicePrestagesUploadCmd(ctx *registry.CLIContext) *cobra.Command 
 				return fmt.Errorf("opening %s: %w", flagFile, err)
 			}
 			defer f.Close()
-			var buf bytes.Buffer
-			mw := multipart.NewWriter(&buf)
-			fw, err := mw.CreateFormFile("file", filepath.Base(flagFile))
+			// Stream the file through a seekable multipart body so Upload can
+			// precompute Content-Length and retry on HTTP 429 without
+			// re-buffering the file.
+			body, contentType, contentLength, err := client.NewMultipartFileUpload("file", f)
 			if err != nil {
-				return fmt.Errorf("creating form file: %w", err)
+				return fmt.Errorf("building multipart body: %w", err)
 			}
-			if _, err := io.Copy(fw, f); err != nil {
-				return fmt.Errorf("writing file: %w", err)
-			}
-			mw.Close()
-			resp, err := ctx.Uploader.Upload(reqCtx, path, &buf, mw.FormDataContentType(), int64(buf.Len()))
+			resp, err := ctx.Uploader.Upload(reqCtx, path, body, contentType, contentLength)
 			if err != nil {
 				return err
 			}

--- a/internal/commands/pro/generated/mobile_device_smart_groups.go
+++ b/internal/commands/pro/generated/mobile_device_smart_groups.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMobileDeviceSmartGroupsCmd creates the mobile-device-smart-groups command group

--- a/internal/commands/pro/generated/mobile_devices.go
+++ b/internal/commands/pro/generated/mobile_devices.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewMobileDevicesCmd creates the mobile-devices command group

--- a/internal/commands/pro/generated/notifications.go
+++ b/internal/commands/pro/generated/notifications.go
@@ -9,10 +9,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewNotificationsCmd creates the notifications command group

--- a/internal/commands/pro/generated/oauth_token_sessions.go
+++ b/internal/commands/pro/generated/oauth_token_sessions.go
@@ -5,9 +5,8 @@ package generated
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewOauthTokenSessionsCmd creates the oauth-token-sessions command group

--- a/internal/commands/pro/generated/oidcs.go
+++ b/internal/commands/pro/generated/oidcs.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewOidcsCmd creates the oidcs command group

--- a/internal/commands/pro/generated/onboarding_configuration.go
+++ b/internal/commands/pro/generated/onboarding_configuration.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewOnboardingConfigurationCmd creates the onboarding-configuration command group

--- a/internal/commands/pro/generated/onboardings.go
+++ b/internal/commands/pro/generated/onboardings.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewOnboardingsCmd creates the onboardings command group

--- a/internal/commands/pro/generated/package_deployments.go
+++ b/internal/commands/pro/generated/package_deployments.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewPackageDeploymentsCmd creates the package-deployments command group

--- a/internal/commands/pro/generated/packages.go
+++ b/internal/commands/pro/generated/packages.go
@@ -7,17 +7,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/spf13/cobra"
-
+	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewPackagesCmd creates the packages command group
@@ -1200,17 +1198,14 @@ func newPackagesUploadCmd(ctx *registry.CLIContext) *cobra.Command {
 				return fmt.Errorf("opening %s: %w", flagFile, err)
 			}
 			defer f.Close()
-			var buf bytes.Buffer
-			mw := multipart.NewWriter(&buf)
-			fw, err := mw.CreateFormFile("file", filepath.Base(flagFile))
+			// Stream the file through a seekable multipart body so Upload can
+			// precompute Content-Length and retry on HTTP 429 without
+			// re-buffering the file.
+			body, contentType, contentLength, err := client.NewMultipartFileUpload("file", f)
 			if err != nil {
-				return fmt.Errorf("creating form file: %w", err)
+				return fmt.Errorf("building multipart body: %w", err)
 			}
-			if _, err := io.Copy(fw, f); err != nil {
-				return fmt.Errorf("writing file: %w", err)
-			}
-			mw.Close()
-			resp, err := ctx.Uploader.Upload(reqCtx, path, &buf, mw.FormDataContentType(), int64(buf.Len()))
+			resp, err := ctx.Uploader.Upload(reqCtx, path, body, contentType, contentLength)
 			if err != nil {
 				return err
 			}

--- a/internal/commands/pro/generated/parent_app.go
+++ b/internal/commands/pro/generated/parent_app.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewParentAppCmd creates the parent-app command group

--- a/internal/commands/pro/generated/patch_policies.go
+++ b/internal/commands/pro/generated/patch_policies.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewPatchPoliciesCmd creates the patch-policies command group

--- a/internal/commands/pro/generated/patch_policy_logs.go
+++ b/internal/commands/pro/generated/patch_policy_logs.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewPatchPolicyLogsCmd creates the patch-policy-logs command group

--- a/internal/commands/pro/generated/patch_software_title_configurations.go
+++ b/internal/commands/pro/generated/patch_software_title_configurations.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewPatchSoftwareTitleConfigurationsCmd creates the patch-software-title-configurations command group

--- a/internal/commands/pro/generated/patch_titles.go
+++ b/internal/commands/pro/generated/patch_titles.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewPatchTitlesCmd creates the patch-titles command group

--- a/internal/commands/pro/generated/policy_properties.go
+++ b/internal/commands/pro/generated/policy_properties.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewPolicyPropertiesCmd creates the policy-properties command group

--- a/internal/commands/pro/generated/redeploy_jamf_management_frameworks.go
+++ b/internal/commands/pro/generated/redeploy_jamf_management_frameworks.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewRedeployJamfManagementFrameworksCmd creates the redeploy-jamf-management-frameworks command group

--- a/internal/commands/pro/generated/reenrollment.go
+++ b/internal/commands/pro/generated/reenrollment.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewReenrollmentCmd creates the reenrollment command group

--- a/internal/commands/pro/generated/remote_administration_configurations.go
+++ b/internal/commands/pro/generated/remote_administration_configurations.go
@@ -8,9 +8,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewRemoteAdministrationConfigurationsCmd creates the remote-administration-configurations command group

--- a/internal/commands/pro/generated/remove_computer_mdm_profiles.go
+++ b/internal/commands/pro/generated/remove_computer_mdm_profiles.go
@@ -10,10 +10,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewRemoveComputerMdmProfilesCmd creates the remove-computer-mdm-profiles command group

--- a/internal/commands/pro/generated/remove_mobile_device_mdm_profiles.go
+++ b/internal/commands/pro/generated/remove_mobile_device_mdm_profiles.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewRemoveMobileDeviceMdmProfilesCmd creates the remove-mobile-device-mdm-profiles command group

--- a/internal/commands/pro/generated/renew_mdm_profiles.go
+++ b/internal/commands/pro/generated/renew_mdm_profiles.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewRenewMdmProfilesCmd creates the renew-mdm-profiles command group

--- a/internal/commands/pro/generated/return_to_service_configurations.go
+++ b/internal/commands/pro/generated/return_to_service_configurations.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewReturnToServiceConfigurationsCmd creates the return-to-service-configurations command group

--- a/internal/commands/pro/generated/schedulers.go
+++ b/internal/commands/pro/generated/schedulers.go
@@ -7,9 +7,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSchedulersCmd creates the schedulers command group

--- a/internal/commands/pro/generated/scripts.go
+++ b/internal/commands/pro/generated/scripts.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewScriptsCmd creates the scripts command group

--- a/internal/commands/pro/generated/self_service_branding_images.go
+++ b/internal/commands/pro/generated/self_service_branding_images.go
@@ -3,17 +3,13 @@
 package generated
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"mime/multipart"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/spf13/cobra"
-
+	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSelfServiceBrandingImagesCmd creates the self-service-branding-images command group
@@ -59,17 +55,14 @@ func newSelfServiceBrandingImagesUploadCmd(ctx *registry.CLIContext) *cobra.Comm
 				return fmt.Errorf("opening %s: %w", flagFile, err)
 			}
 			defer f.Close()
-			var buf bytes.Buffer
-			mw := multipart.NewWriter(&buf)
-			fw, err := mw.CreateFormFile("file", filepath.Base(flagFile))
+			// Stream the file through a seekable multipart body so Upload can
+			// precompute Content-Length and retry on HTTP 429 without
+			// re-buffering the file.
+			body, contentType, contentLength, err := client.NewMultipartFileUpload("file", f)
 			if err != nil {
-				return fmt.Errorf("creating form file: %w", err)
+				return fmt.Errorf("building multipart body: %w", err)
 			}
-			if _, err := io.Copy(fw, f); err != nil {
-				return fmt.Errorf("writing file: %w", err)
-			}
-			mw.Close()
-			resp, err := ctx.Uploader.Upload(reqCtx, path, &buf, mw.FormDataContentType(), int64(buf.Len()))
+			resp, err := ctx.Uploader.Upload(reqCtx, path, body, contentType, contentLength)
 			if err != nil {
 				return err
 			}

--- a/internal/commands/pro/generated/self_service_branding_ios_resource.go
+++ b/internal/commands/pro/generated/self_service_branding_ios_resource.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSelfServiceBrandingIosCmd creates the self-service-branding-ios command group

--- a/internal/commands/pro/generated/self_service_branding_macos.go
+++ b/internal/commands/pro/generated/self_service_branding_macos.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSelfServiceBrandingMacosCmd creates the self-service-branding-macos command group

--- a/internal/commands/pro/generated/self_service_plus.go
+++ b/internal/commands/pro/generated/self_service_plus.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSelfServicePlusCmd creates the self-service-plus command group

--- a/internal/commands/pro/generated/self_service_settings.go
+++ b/internal/commands/pro/generated/self_service_settings.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSelfServiceSettingsCmd creates the self-service-settings command group

--- a/internal/commands/pro/generated/servers.go
+++ b/internal/commands/pro/generated/servers.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewServersCmd creates the servers command group

--- a/internal/commands/pro/generated/service_discovery.go
+++ b/internal/commands/pro/generated/service_discovery.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewServiceDiscoveryCmd creates the service-discovery command group

--- a/internal/commands/pro/generated/sites.go
+++ b/internal/commands/pro/generated/sites.go
@@ -7,9 +7,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSitesCmd creates the sites command group

--- a/internal/commands/pro/generated/slasas.go
+++ b/internal/commands/pro/generated/slasas.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSlasasCmd creates the slasas command group

--- a/internal/commands/pro/generated/smart_computer_groups.go
+++ b/internal/commands/pro/generated/smart_computer_groups.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSmartComputerGroupsCmd creates the smart-computer-groups command group

--- a/internal/commands/pro/generated/smtp_server.go
+++ b/internal/commands/pro/generated/smtp_server.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSmtpServerCmd creates the smtp-server command group

--- a/internal/commands/pro/generated/sso_failovers.go
+++ b/internal/commands/pro/generated/sso_failovers.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSsoFailoversCmd creates the sso-failovers command group

--- a/internal/commands/pro/generated/sso_settings.go
+++ b/internal/commands/pro/generated/sso_settings.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSsoSettingsCmd creates the sso-settings command group

--- a/internal/commands/pro/generated/sso_settings_cert.go
+++ b/internal/commands/pro/generated/sso_settings_cert.go
@@ -10,10 +10,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSsoSettingsCertCmd creates the sso-settings-cert command group

--- a/internal/commands/pro/generated/startup_status.go
+++ b/internal/commands/pro/generated/startup_status.go
@@ -5,9 +5,8 @@ package generated
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewStartupStatusCmd creates the startup-status command group

--- a/internal/commands/pro/generated/static_computer_groups.go
+++ b/internal/commands/pro/generated/static_computer_groups.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewStaticComputerGroupsCmd creates the static-computer-groups command group

--- a/internal/commands/pro/generated/static_user_groups.go
+++ b/internal/commands/pro/generated/static_user_groups.go
@@ -7,9 +7,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewStaticUserGroupsCmd creates the static-user-groups command group

--- a/internal/commands/pro/generated/supervision_identities.go
+++ b/internal/commands/pro/generated/supervision_identities.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSupervisionIdentitiesCmd creates the supervision-identities command group

--- a/internal/commands/pro/generated/systems.go
+++ b/internal/commands/pro/generated/systems.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewSystemsCmd creates the systems command group

--- a/internal/commands/pro/generated/teacher_settings.go
+++ b/internal/commands/pro/generated/teacher_settings.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewTeacherSettingsCmd creates the teacher-settings command group

--- a/internal/commands/pro/generated/team_viewer_remote_administrations.go
+++ b/internal/commands/pro/generated/team_viewer_remote_administrations.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewTeamViewerRemoteAdministrationsCmd creates the team-viewer-remote-administrations command group

--- a/internal/commands/pro/generated/time_zones.go
+++ b/internal/commands/pro/generated/time_zones.go
@@ -5,9 +5,8 @@ package generated
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewTimeZonesCmd creates the time-zones command group

--- a/internal/commands/pro/generated/user_accounts.go
+++ b/internal/commands/pro/generated/user_accounts.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewUserAccountsCmd creates the user-accounts command group

--- a/internal/commands/pro/generated/user_preferences.go
+++ b/internal/commands/pro/generated/user_preferences.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewUserPreferencesCmd creates the user-preferences command group

--- a/internal/commands/pro/generated/user_sessions.go
+++ b/internal/commands/pro/generated/user_sessions.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewUserSessionsCmd creates the user-sessions command group

--- a/internal/commands/pro/generated/user_smart_groups.go
+++ b/internal/commands/pro/generated/user_smart_groups.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewUserSmartGroupsCmd creates the user-smart-groups command group

--- a/internal/commands/pro/generated/users.go
+++ b/internal/commands/pro/generated/users.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewUsersCmd creates the users command group

--- a/internal/commands/pro/generated/venafis.go
+++ b/internal/commands/pro/generated/venafis.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewVenafisCmd creates the venafis command group

--- a/internal/commands/pro/generated/vpp_locations.go
+++ b/internal/commands/pro/generated/vpp_locations.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewVppLocationsCmd creates the vpp-locations command group

--- a/internal/commands/pro/generated/vpp_subscriptions.go
+++ b/internal/commands/pro/generated/vpp_subscriptions.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
 )
 
 // NewVppSubscriptionsCmd creates the vpp-subscriptions command group

--- a/internal/commands/pro_packages_upload.go
+++ b/internal/commands/pro_packages_upload.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 )
 
@@ -124,7 +125,7 @@ them to the package metadata after upload.`,
 
 			// 5. Upload the binary
 			fmt.Fprintf(os.Stderr, "Uploading %s...\n", fileName)
-			if err := uploadPackageFile(ctx, uploader, pkgID, filePath, fileName, fileSize); err != nil {
+			if err := uploadPackageFile(ctx, uploader, pkgID, filePath); err != nil {
 				return err
 			}
 			fmt.Fprintf(os.Stderr, "Upload complete\n")
@@ -273,46 +274,23 @@ func createPackage(ctx context.Context, client registry.HTTPClient, name, fileNa
 }
 
 // uploadPackageFile streams a local file to the Jamf Pro upload endpoint
-// as multipart/form-data.
-func uploadPackageFile(ctx context.Context, uploader registry.FileUploader, pkgID, filePath, fileName string, fileSize int64) error {
-	boundary := "jamf-cli-upload-boundary"
+// as multipart/form-data. The body is a seekable composite of header +
+// *os.File + footer — enabling Upload to retry on HTTP 429 without
+// re-reading the file into memory.
+func uploadPackageFile(ctx context.Context, uploader registry.FileUploader, pkgID, filePath string) error {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("opening upload file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
 
-	header := fmt.Sprintf("--%s\r\nContent-Disposition: form-data; name=\"file\"; filename=\"%s\"\r\nContent-Type: application/octet-stream\r\n\r\n",
-		boundary, fileName)
-	footer := fmt.Sprintf("\r\n--%s--\r\n", boundary)
-	contentLength := int64(len(header)) + fileSize + int64(len(footer))
-
-	pr, pw := io.Pipe()
-	go func() {
-		defer func() { _ = pw.Close() }()
-
-		if _, err := pw.Write([]byte(header)); err != nil {
-			pw.CloseWithError(err)
-			return
-		}
-
-		f, err := os.Open(filePath)
-		if err != nil {
-			pw.CloseWithError(err)
-			return
-		}
-		defer func() { _ = f.Close() }()
-
-		if _, err := io.Copy(pw, f); err != nil {
-			pw.CloseWithError(err)
-			return
-		}
-
-		if _, err := pw.Write([]byte(footer)); err != nil {
-			pw.CloseWithError(err)
-			return
-		}
-	}()
+	body, contentType, contentLength, err := client.NewMultipartFileUpload("file", f)
+	if err != nil {
+		return fmt.Errorf("building multipart body: %w", err)
+	}
 
 	path := fmt.Sprintf("/v1/packages/%s/upload", url.PathEscape(pkgID))
-	contentType := "multipart/form-data; boundary=" + boundary
-
-	resp, err := uploader.Upload(ctx, path, pr, contentType, contentLength)
+	resp, err := uploader.Upload(ctx, path, body, contentType, contentLength)
 	if err != nil {
 		return fmt.Errorf("uploading package: %w", err)
 	}

--- a/internal/commands/pro_packages_upload.go
+++ b/internal/commands/pro_packages_upload.go
@@ -29,6 +29,7 @@ func newPackagesUploadCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		filePath    string
 		packageName string
 		categoryID  string
+		priority    int
 		flagYes     bool
 	)
 
@@ -49,7 +50,10 @@ them to the package metadata after upload.`,
   jamf-cli pro packages upload --file ./Firefox-134.0.pkg --name "Firefox"
 
   # Upload and assign to a category by ID
-  jamf-cli pro packages upload --file ./Firefox-134.0.pkg --category-id 5`,
+  jamf-cli pro packages upload --file ./Firefox-134.0.pkg --category-id 5
+
+  # Upload and set installation priority
+  jamf-cli pro packages upload --file ./Firefox-134.0.pkg --priority 10`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			client := cliCtx.Client
@@ -116,7 +120,7 @@ them to the package metadata after upload.`,
 			} else {
 				// 4. Create package metadata
 				fmt.Fprintf(os.Stderr, "Creating package record...\n")
-				pkgID, err = createPackage(ctx, client, packageName, fileName, categoryID)
+				pkgID, err = createPackage(ctx, client, packageName, fileName, categoryID, priority)
 				if err != nil {
 					return fmt.Errorf("creating package: %w", err)
 				}
@@ -168,6 +172,7 @@ them to the package metadata after upload.`,
 	_ = cmd.MarkFlagRequired("file")
 	cmd.Flags().StringVar(&packageName, "name", "", "display name for the package (defaults to filename)")
 	cmd.Flags().StringVar(&categoryID, "category-id", "-1", "category ID for the package")
+	cmd.Flags().IntVar(&priority, "priority", 10, "installation priority for the package (1-20)")
 	cmd.Flags().BoolVar(&flagYes, "yes", false, "skip confirmation when replacing an existing package")
 
 	return cmd
@@ -231,12 +236,12 @@ func findPackageByFileName(ctx context.Context, client registry.HTTPClient, file
 }
 
 // createPackage creates a new package record and returns its ID.
-func createPackage(ctx context.Context, client registry.HTTPClient, name, fileName, categoryID string) (string, error) {
+func createPackage(ctx context.Context, client registry.HTTPClient, name, fileName, categoryID string, priority int) (string, error) {
 	payload := map[string]any{
 		"packageName":          name,
 		"fileName":             fileName,
 		"categoryId":           categoryID,
-		"priority":             3,
+		"priority":             priority,
 		"fillUserTemplate":     false,
 		"suppressEula":         false,
 		"suppressUpdates":      false,

--- a/internal/httptransport/transport.go
+++ b/internal/httptransport/transport.go
@@ -1,0 +1,52 @@
+// Copyright 2026, Jamf Software LLC
+
+// Package httptransport provides a shared *http.Transport factory used by the
+// Jamf Pro HTTP client and the auth providers. Lives in its own package so
+// both can import it without creating a cycle (client already depends on auth).
+package httptransport
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+// Per-phase HTTP timeouts. http.Client.Timeout is deliberately unset — it's a
+// whole-request deadline that caps body transfer, which breaks multi-GB
+// package uploads and silently overrides caller-supplied context deadlines.
+// Body transfer time is bounded solely by ctx; these phase timeouts exist to
+// fail fast on dead networks, not healthy long transfers.
+const (
+	dialTimeout           = 10 * time.Second
+	tlsHandshakeTimeout   = 10 * time.Second
+	responseHeaderTimeout = 60 * time.Second
+	idleConnTimeout       = 90 * time.Second
+	// maxIdleConnsPerHost: Go default of 2 serialises parallel commands at
+	// the connection pool. HTTP/2 multiplexes on a single conn when the
+	// server speaks it, so this only binds on the HTTP/1.1 fallback path.
+	maxIdleConnsPerHost = 10
+)
+
+// New returns a fresh *http.Transport tuned for the CLI's workload: large
+// package uploads, bursts of small API calls, HTTP/2 where the server
+// supports it. Each caller owns its pool.
+func New() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   dialTimeout,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
+		IdleConnTimeout:       idleConnTimeout,
+		TLSHandshakeTimeout:   tlsHandshakeTimeout,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: responseHeaderTimeout,
+		// 1 MiB write buffer pairs with the upload copy path — fewer
+		// syscalls when streaming big package bodies.
+		WriteBufferSize: 1 << 20,
+		ReadBufferSize:  1 << 16,
+	}
+}

--- a/internal/httptransport/transport_test.go
+++ b/internal/httptransport/transport_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026, Jamf Software LLC
+
+package httptransport
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNew_NoClientTimeout(t *testing.T) {
+	// The package exposes only a Transport factory; Client.Timeout must be
+	// set by callers (they deliberately leave it zero). Guard against a
+	// future edit that accidentally re-introduces a whole-request deadline
+	// here by asserting the transport carries only per-phase deadlines.
+	tr := New()
+
+	if tr.TLSHandshakeTimeout != tlsHandshakeTimeout {
+		t.Errorf("TLSHandshakeTimeout = %v, want %v", tr.TLSHandshakeTimeout, tlsHandshakeTimeout)
+	}
+	if tr.ResponseHeaderTimeout != responseHeaderTimeout {
+		t.Errorf("ResponseHeaderTimeout = %v, want %v", tr.ResponseHeaderTimeout, responseHeaderTimeout)
+	}
+	if !tr.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 should be true")
+	}
+	if tr.MaxIdleConnsPerHost != maxIdleConnsPerHost {
+		t.Errorf("MaxIdleConnsPerHost = %d, want %d", tr.MaxIdleConnsPerHost, maxIdleConnsPerHost)
+	}
+	if tr.WriteBufferSize != 1<<20 {
+		t.Errorf("WriteBufferSize = %d, want %d", tr.WriteBufferSize, 1<<20)
+	}
+	if tr.IdleConnTimeout != 90*time.Second {
+		t.Errorf("IdleConnTimeout = %v, want 90s", tr.IdleConnTimeout)
+	}
+}
+
+func TestNew_FreshPerCall(t *testing.T) {
+	a := New()
+	b := New()
+	if a == b {
+		t.Error("New() returned the same *http.Transport twice; callers must own their pool")
+	}
+}


### PR DESCRIPTION
## Summary

Ports the transport performance pass from [jamfplatform-go-sdk PR #9](https://github.com/Jamf-Concepts/jamfplatform-go-sdk/pull/9) to the Jamf Pro HTTP client. Driven by the need to upload multi-GB package files reliably without RAM-bounding the binary or losing uploads to transient 429s.

### What changed

- **Shared tuned `*http.Transport`** (`internal/httptransport`) — `ForceAttemptHTTP2`, `MaxIdleConnsPerHost: 10`, 1 MiB write buffer, per-phase dial/TLS/response-header timeouts. Used by the main client, `Upload`'s dedicated client, and the OAuth2 + Platform auth providers. `http.Client.Timeout` dropped — `ctx` bounds request lifetime; per-phase timeouts fail fast on dead networks without killing healthy long transfers.
- **Streaming multipart helper** (`internal/client/multipart.go`) — `NewMultipartFileUpload` returns an `io.ReadSeeker` composite of header + `*os.File` + footer with pre-computed Content-Length. `Seek(0, SeekStart)` rewinds the whole body (including the underlying file) for retry.
- **429 rewind on `Upload`** — detects `io.Seeker` bodies and retries up to 3× on HTTP 429, honoring `Retry-After`. Non-seekable bodies keep single-attempt semantics (unchanged behaviour).
- **Handwritten `pro packages upload`** — swaps `io.Pipe` + goroutine for the new helper. 600 MB uploads now retry-safe without re-buffering.
- **`--priority` flag on `pro packages upload`** — sets installation priority when creating a new package record (default 10). Closes #160.
- **Generator template** — multipart block switched from `bytes.Buffer` + `mime/multipart` to the new streaming helper. All 9 generated multipart commands (icons, manifests, branding images, inventory preloads, etc.) now stream the file through the network instead of buffering it first. New `hasNonMultipartPostOrPut` helper prunes now-unused `bytes`/`io` imports from generated files.

### Live-tested

| Test | Default (Pro OAuth2, `nmartin.jamfcloud.com`) | Platform-nmartin (EU gateway) |
|---|---|---|
| 600 MB pkg upload (handwritten streaming) | ✅ 1m37s, server hash verified | 🔴 502 at ~1m03s — **reproduces on `main`, pre-existing** |
| Tiny PNG icon upload (generated streaming path) | ✅ | ✅ |
| Modern API list (buildings/computers/categories) | ✅ | ✅ |
| Classic API list (sites/policies) | ✅ | ✅ |
| Platform SDK (blueprints/benchmarks/devices) | n/a | ✅ |
| `pro overview` (~37 parallel calls) | ✅ 1.3s | ✅ 3.9s |

**Note on the platform-gateway 502:** checked out `main`, ran the same 600 MB upload against the same profile, got the same 502 at the same ~1m mark. Pre-existing gateway-side issue on the Pro API package-upload route when fronted by `eu.apigw.jamf.com` — not a regression from this branch. Worth raising separately.

## Test plan

- [x] `go test ./...` — all packages pass (new tests for seek rewind, 429 retry, Content-Length precompute, transport factory)
- [x] `make lint` — clean
- [x] `make generate` — 9 generated multipart commands rewritten to streaming
- [x] 600 MB .pkg upload end-to-end, server hash verified, hashes round-tripped
- [x] Generated icon multipart upload through both OAuth2 and platform-gateway profiles
- [x] Overview dashboard (37 parallel calls) — connection pool + HTTP/2 exercised
- [x] Regression-tested against `main` for the platform-gateway 502
- [x] `--priority` flag: new package created with correct priority in metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)