### PR TITLE
Add 'pro' prefix to all --help command examples

### DIFF
--- a/generator/classic/generator.go
+++ b/generator/classic/generator.go
@@ -94,7 +94,7 @@ func templateFuncs() template.FuncMap {
 		"hasLookup":    hasLookup,
 		"extraLookups": extraLookups,
 		"classicExample": func(r ClassicResource, op string) string {
-			bin := "jamf-cli"
+			bin := "jamf-cli pro"
 			name := r.CLIName
 			singular := r.Singular
 			switch op {

--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -110,7 +110,7 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 			return false
 		},
 		"exampleText": func(r *Resource, op *Operation) string {
-			bin := "jamf-cli"
+			bin := "jamf-cli pro"
 			resourceName := r.Name
 			nameSingular := r.NameSingular
 			switch op.Name {
@@ -141,7 +141,7 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 					nameSingular, bin, resourceName, nameSingular, bin, resourceName)
 			case "create":
 				if op.RequestBody != nil && op.RequestBody.IsMultipart {
-					return fmt.Sprintf("  # Upload a file\n  %s pro %s create --file /path/to/file",
+					return fmt.Sprintf("  # Upload a file\n  %s %s create --file /path/to/file",
 						bin, resourceName)
 				}
 				return fmt.Sprintf("  # Show the JSON template for creating a %s\n  %s %s create --scaffold\n\n  # Create a %s from JSON\n  echo '{\"name\":\"Example\"}' | %s %s create\n\n  # Get a %s, modify it, and create a copy\n  %s %s get 1 -o json | jq '.name = \"Copy\"' | %s %s create",
@@ -218,7 +218,7 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 						idArg = " <id>"
 					}
 					return fmt.Sprintf(
-						"  # Save to file\n  %s pro %s %s%s -O output.bin\n\n  # Pipe to stdout\n  %s pro %s %s%s > output.bin",
+						"  # Save to file\n  %s %s %s%s -O output.bin\n\n  # Pipe to stdout\n  %s %s %s%s > output.bin",
 						bin, resourceName, op.Name, idArg,
 						bin, resourceName, op.Name, idArg)
 				}
@@ -1054,7 +1054,7 @@ func opHasNameLookup(op *Operation, r *Resource) bool {
 
 // patchExampleText builds the Example string for a unified patch command.
 func patchExampleText(r *Resource, op *Operation) string {
-	bin := "jamf-cli"
+	bin := "jamf-cli pro"
 	if !hasPathParam(op.Path) {
 		// Singleton PATCH — no ID
 		return fmt.Sprintf("  # Update a field\n  %s %s patch --set field=value\n\n  # Update using JSON\n  %s %s get -o json | jq '.field = \"value\"' | %s %s patch",
@@ -2072,19 +2072,19 @@ The {{ .NameField }} field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.` + "`" + `,
 		Example: ` + "`" + `  # Apply a {{ .NameSingular }} from a JSON file
-  jamf-cli {{ .Name }} apply --from-file {{ .NameSingular }}.json
+  jamf-cli pro {{ .Name }} apply --from-file {{ .NameSingular }}.json
 
   # Apply a {{ .NameSingular }} from a YAML file
-  jamf-cli {{ .Name }} apply --from-file {{ .NameSingular }}.yaml
+  jamf-cli pro {{ .Name }} apply --from-file {{ .NameSingular }}.yaml
 
   # Apply from stdin
-  cat {{ .NameSingular }}.json | jamf-cli {{ .Name }} apply
+  cat {{ .NameSingular }}.json | jamf-cli pro {{ .Name }} apply
 
   # Apply without replacement confirmation
-  jamf-cli {{ .Name }} apply --from-file {{ .NameSingular }}.json --yes
+  jamf-cli pro {{ .Name }} apply --from-file {{ .NameSingular }}.json --yes
 
   # Preview what would happen
-  jamf-cli {{ .Name }} apply --from-file {{ .NameSingular }}.json --dry-run` + "`" + `,
+  jamf-cli pro {{ .Name }} apply --from-file {{ .NameSingular }}.json --dry-run` + "`" + `,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/access_managements.go
+++ b/internal/commands/pro/generated/access_managements.go
@@ -36,10 +36,10 @@ func newAccessManagementsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Access Management settings",
 		Long:  "Get Access Management settings",
 		Example: `  # List all access-managements
-  jamf-cli access-managements list
+  jamf-cli pro access-managements list
 
   # List access-managements and extract IDs
-  jamf-cli access-managements list --field id`,
+  jamf-cli pro access-managements list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/account_driven_user_enrollment_session_token_settings.go
+++ b/internal/commands/pro/generated/account_driven_user_enrollment_session_token_settings.go
@@ -36,10 +36,10 @@ func newAccountDrivenUserEnrollmentSessionTokenSettingsGetCmd(ctx *registry.CLIC
 		Short: "Retrieve the Account Driven User Enrollment Session Token Settings",
 		Long:  "Retrieve the Account Driven User Enrollment Session Token Settings",
 		Example: `  # Get account-driven-user-enrollment-session-token-settings
-  jamf-cli account-driven-user-enrollment-session-token-settings get
+  jamf-cli pro account-driven-user-enrollment-session-token-settings get
 
   # Get account-driven-user-enrollment-session-token-settings and output as YAML
-  jamf-cli account-driven-user-enrollment-session-token-settings get -o yaml`,
+  jamf-cli pro account-driven-user-enrollment-session-token-settings get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -76,10 +76,10 @@ func newAccountDrivenUserEnrollmentSessionTokenSettingsUpdateCmd(ctx *registry.C
 		Short: "Update Account Driven User Enrollment Session Token Settings.",
 		Long:  "Update the Account Driven User Enrollment Session Token Settings object.",
 		Example: `  # Update account-driven-user-enrollment-session-token-settings
-  jamf-cli account-driven-user-enrollment-session-token-settings get -o json | jq '.field = "value"' | jamf-cli account-driven-user-enrollment-session-token-settings update
+  jamf-cli pro account-driven-user-enrollment-session-token-settings get -o json | jq '.field = "value"' | jamf-cli pro account-driven-user-enrollment-session-token-settings update
 
   # Update from a file
-  jamf-cli account-driven-user-enrollment-session-token-settings update --from-file account-driven-user-enrollment-session-token-settings.json`,
+  jamf-cli pro account-driven-user-enrollment-session-token-settings update --from-file account-driven-user-enrollment-session-token-settings.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/account_preferences.go
+++ b/internal/commands/pro/generated/account_preferences.go
@@ -36,10 +36,10 @@ func newAccountPreferencesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Jamf Pro account preferences",
 		Long:  "Get Jamf Pro account preferences",
 		Example: `  # List all account-preferences
-  jamf-cli account-preferences list
+  jamf-cli pro account-preferences list
 
   # List account-preferences and extract IDs
-  jamf-cli account-preferences list --field id`,
+  jamf-cli pro account-preferences list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -78,10 +78,10 @@ func newAccountPreferencesPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update Jamf Pro account preferences",
 		Long:  "Update Jamf Pro account preferences\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  computerApplicationSearchMethod              string\n  computerApplicationUsageSearchMethod         string\n  computerLocalUserAccountSearchMethod         string\n  computerPackageReceiptSearchMethod           string\n  computerPeripheralSearchMethod               string\n  computerPrinterSearchMethod                  string\n  computerSearchMethod                         string\n  computerServiceSearchMethod                  string\n  computerSoftwareUpdateSearchMethod           string\n  configProfilesSortingMethod                  string\n  dateFormat                                   string\n  disablePageLeaveCheck                        boolean\n  disableRelativeDates                         boolean\n  disableShortcutsTooltips                     boolean\n  disableTablePagination                       boolean\n  language                                     string\n  mobileDeviceAppSearchMethod                  string\n  mobileDeviceSearchMethod                     string\n  resultsPerPage                               integer\n  timezone                                     string\n  userAllContentSearchMethod                   string\n  userEbookSearchMethod                        string\n  userInterfaceDisplayTheme                    string\n  userMacAppStoreAppSearchMethod               string\n  userMobileDeviceAppSearchMethod              string\n  userSearchMethod                             string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field
-  jamf-cli account-preferences patch --set field=value
+  jamf-cli pro account-preferences patch --set field=value
 
   # Update using JSON
-  jamf-cli account-preferences get -o json | jq '.field = "value"' | jamf-cli account-preferences patch`,
+  jamf-cli pro account-preferences get -o json | jq '.field = "value"' | jamf-cli pro account-preferences patch`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/activation_codes.go
+++ b/internal/commands/pro/generated/activation_codes.go
@@ -43,10 +43,10 @@ func newActivationCodesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Updates Activation Code",
 		Long:  "Updates Activation Code in Jamf Pro.",
 		Example: `  # Update activation-codes
-  jamf-cli activation-codes get -o json | jq '.field = "value"' | jamf-cli activation-codes update
+  jamf-cli pro activation-codes get -o json | jq '.field = "value"' | jamf-cli pro activation-codes update
 
   # Update from a file
-  jamf-cli activation-codes update --from-file activation-codes.json`,
+  jamf-cli pro activation-codes update --from-file activation-codes.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -113,7 +113,7 @@ func newActivationCodesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Activation Code history object",
 		Long:  "Get Activation Code history object",
 		Example: `  # Get history for a activation-code
-  jamf-cli activation-codes history 1`,
+  jamf-cli pro activation-codes history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -422,10 +422,10 @@ func newActivationCodesPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Updates Organization Name",
 		Long:  "Updates Organization Name in Jamf Pro.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  organizationName                             string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field
-  jamf-cli activation-codes patch --set field=value
+  jamf-cli pro activation-codes patch --set field=value
 
   # Update using JSON
-  jamf-cli activation-codes get -o json | jq '.field = "value"' | jamf-cli activation-codes patch`,
+  jamf-cli pro activation-codes get -o json | jq '.field = "value"' | jamf-cli pro activation-codes patch`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/adcs_settings.go
+++ b/internal/commands/pro/generated/adcs_settings.go
@@ -50,13 +50,13 @@ func newAdcsSettingsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get AD CS Settings configuration for the ID value",
 		Long:  "Get AD CS Settings configuration for the ID value including public key information, but not including any password information.",
 		Example: `  # Get a adcs-setting by ID
-  jamf-cli adcs-settings get 1
+  jamf-cli pro adcs-settings get 1
 
   # Get a adcs-setting by name
-  jamf-cli adcs-settings get --name "Example"
+  jamf-cli pro adcs-settings get --name "Example"
 
   # Get a adcs-setting and output as YAML
-  jamf-cli adcs-settings get 1 -o yaml`,
+  jamf-cli pro adcs-settings get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -111,13 +111,13 @@ func newAdcsSettingsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create AD CS Settings configuration for either inbound or outbound mode",
 		Long:  "Create AD CS Settings configuration and initialize renewal monitor. Once set, the configuration cannot change between inbound and outbound modes.",
 		Example: `  # Show the JSON template for creating a adcs-setting
-  jamf-cli adcs-settings create --scaffold
+  jamf-cli pro adcs-settings create --scaffold
 
   # Create a adcs-setting from JSON
-  echo '{"name":"Example"}' | jamf-cli adcs-settings create
+  echo '{"name":"Example"}' | jamf-cli pro adcs-settings create
 
   # Get a adcs-setting, modify it, and create a copy
-  jamf-cli adcs-settings get 1 -o json | jq '.name = "Copy"' | jamf-cli adcs-settings create`,
+  jamf-cli pro adcs-settings get 1 -o json | jq '.name = "Copy"' | jamf-cli pro adcs-settings create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -189,13 +189,13 @@ func newAdcsSettingsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete AD CS Settings configuration by ID",
 		Long:  "Delete AD CS Settings configuration, only if reassignment of Certificate Authority succeeds and no config profiles are using the configuration.",
 		Example: `  # Delete a adcs-setting (with confirmation)
-  jamf-cli adcs-settings delete 1
+  jamf-cli pro adcs-settings delete 1
 
   # Delete by name
-  jamf-cli adcs-settings delete --name "Example" --yes
+  jamf-cli pro adcs-settings delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli adcs-settings delete 1 --yes`,
+  jamf-cli pro adcs-settings delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -306,10 +306,10 @@ func newAdcsSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified AD CS Settings history object",
 		Long:  "Get specified AD CS Settings history object.",
 		Example: `  # Get history for a adcs-setting by ID
-  jamf-cli adcs-settings history 1
+  jamf-cli pro adcs-settings history 1
 
   # Get history by name
-  jamf-cli adcs-settings history --name "Example"`,
+  jamf-cli pro adcs-settings history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -655,16 +655,16 @@ func newAdcsSettingsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update AD CS Settings configuration",
 		Long:  "Update AD CS Settings configuration, where certificate information must be provided in full, or not at all. Cannot change between inbound and outbound modes.\n\nIdentify the resource by ID (positional arg), --name, . Omit ID to use a lookup flag.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  adcsUrl                                      string\n  apiClientId                                  string\n  caName                                       string\n  clientCert.filename                          string\n  clientCert.password                          string\n  displayName                                  string\n  fqdn                                         string\n  outbound                                     boolean\n  revocationEnabled                            boolean\n  serverCert.filename                          string\n  serverCert.password                          string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field by ID
-  jamf-cli adcs-settings patch 1 --set general.managed=true
+  jamf-cli pro adcs-settings patch 1 --set general.managed=true
 
   # Update multiple fields
-  jamf-cli adcs-settings patch 1 --set field1=value1 --set field2=value2
+  jamf-cli pro adcs-settings patch 1 --set field1=value1 --set field2=value2
 
   # Update by name
-  jamf-cli adcs-settings patch --name "Example" --set general.managed=true
+  jamf-cli pro adcs-settings patch --name "Example" --set general.managed=true
 
   # Patch from a file
-  jamf-cli adcs-settings patch 1 --from-file changes.json`,
+  jamf-cli pro adcs-settings patch 1 --from-file changes.json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -832,19 +832,19 @@ The displayName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a adcs-setting from a JSON file
-  jamf-cli adcs-settings apply --from-file adcs-setting.json
+  jamf-cli pro adcs-settings apply --from-file adcs-setting.json
 
   # Apply a adcs-setting from a YAML file
-  jamf-cli adcs-settings apply --from-file adcs-setting.yaml
+  jamf-cli pro adcs-settings apply --from-file adcs-setting.yaml
 
   # Apply from stdin
-  cat adcs-setting.json | jamf-cli adcs-settings apply
+  cat adcs-setting.json | jamf-cli pro adcs-settings apply
 
   # Apply without replacement confirmation
-  jamf-cli adcs-settings apply --from-file adcs-setting.json --yes
+  jamf-cli pro adcs-settings apply --from-file adcs-setting.json --yes
 
   # Preview what would happen
-  jamf-cli adcs-settings apply --from-file adcs-setting.json --dry-run`,
+  jamf-cli pro adcs-settings apply --from-file adcs-setting.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/advanced_mobile_device_searches.go
+++ b/internal/commands/pro/generated/advanced_mobile_device_searches.go
@@ -46,10 +46,10 @@ func newAdvancedMobileDeviceSearchesListCmd(ctx *registry.CLIContext) *cobra.Com
 		Short: "Get Advanced Search objects",
 		Long:  "Gets Advanced Search Objects",
 		Example: `  # List all advanced-mobile-device-searches
-  jamf-cli advanced-mobile-device-searches list
+  jamf-cli pro advanced-mobile-device-searches list
 
   # List advanced-mobile-device-searches and extract IDs
-  jamf-cli advanced-mobile-device-searches list --field id`,
+  jamf-cli pro advanced-mobile-device-searches list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -86,13 +86,13 @@ func newAdvancedMobileDeviceSearchesGetCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Get specified Advanced Search object",
 		Long:  "Gets Specified Advanced Search Object",
 		Example: `  # Get a advanced-mobile-device-searche by ID
-  jamf-cli advanced-mobile-device-searches get 1
+  jamf-cli pro advanced-mobile-device-searches get 1
 
   # Get a advanced-mobile-device-searche by name
-  jamf-cli advanced-mobile-device-searches get --name "Example"
+  jamf-cli pro advanced-mobile-device-searches get --name "Example"
 
   # Get a advanced-mobile-device-searche and output as YAML
-  jamf-cli advanced-mobile-device-searches get 1 -o yaml`,
+  jamf-cli pro advanced-mobile-device-searches get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -147,13 +147,13 @@ func newAdvancedMobileDeviceSearchesCreateCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Create Advanced Search object",
 		Long:  "Creates Advanced Search Object",
 		Example: `  # Show the JSON template for creating a advanced-mobile-device-searche
-  jamf-cli advanced-mobile-device-searches create --scaffold
+  jamf-cli pro advanced-mobile-device-searches create --scaffold
 
   # Create a advanced-mobile-device-searche from JSON
-  echo '{"name":"Example"}' | jamf-cli advanced-mobile-device-searches create
+  echo '{"name":"Example"}' | jamf-cli pro advanced-mobile-device-searches create
 
   # Get a advanced-mobile-device-searche, modify it, and create a copy
-  jamf-cli advanced-mobile-device-searches get 1 -o json | jq '.name = "Copy"' | jamf-cli advanced-mobile-device-searches create`,
+  jamf-cli pro advanced-mobile-device-searches get 1 -o json | jq '.name = "Copy"' | jamf-cli pro advanced-mobile-device-searches create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -222,13 +222,13 @@ func newAdvancedMobileDeviceSearchesUpdateCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Get specified Advanced Search object",
 		Long:  "Gets Specified Advanced Search Object",
 		Example: `  # Update a advanced-mobile-device-searche from JSON
-  echo '{"name":"Updated"}' | jamf-cli advanced-mobile-device-searches update 1
+  echo '{"name":"Updated"}' | jamf-cli pro advanced-mobile-device-searches update 1
 
   # Update by name
-  jamf-cli advanced-mobile-device-searches get --name "Example" -o json | jq '.field = "value"' | jamf-cli advanced-mobile-device-searches update --name "Example"
+  jamf-cli pro advanced-mobile-device-searches get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro advanced-mobile-device-searches update --name "Example"
 
   # Get a advanced-mobile-device-searche, modify, and update
-  jamf-cli advanced-mobile-device-searches get 1 -o json | jq '.name = "New Name"' | jamf-cli advanced-mobile-device-searches update 1`,
+  jamf-cli pro advanced-mobile-device-searches get 1 -o json | jq '.name = "New Name"' | jamf-cli pro advanced-mobile-device-searches update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -315,13 +315,13 @@ func newAdvancedMobileDeviceSearchesDeleteCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Remove specified Advanced Search object",
 		Long:  "Removes specified Advanced Search Object",
 		Example: `  # Delete a advanced-mobile-device-searche (with confirmation)
-  jamf-cli advanced-mobile-device-searches delete 1
+  jamf-cli pro advanced-mobile-device-searches delete 1
 
   # Delete by name
-  jamf-cli advanced-mobile-device-searches delete --name "Example" --yes
+  jamf-cli pro advanced-mobile-device-searches delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli advanced-mobile-device-searches delete 1 --yes`,
+  jamf-cli pro advanced-mobile-device-searches delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -429,7 +429,7 @@ func newAdvancedMobileDeviceSearchesDeleteMultipleCmd(ctx *registry.CLIContext) 
 		Short: "Remove specified Advanced Search objects",
 		Long:  "Removes specified Advanced Search Objects",
 		Example: `  # Delete multiple advanced-mobile-device-searches by IDs
-  jamf-cli advanced-mobile-device-searches delete-multiple --ids 1,2,3 --yes`,
+  jamf-cli pro advanced-mobile-device-searches delete-multiple --ids 1,2,3 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -580,19 +580,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a advanced-mobile-device-searche from a JSON file
-  jamf-cli advanced-mobile-device-searches apply --from-file advanced-mobile-device-searche.json
+  jamf-cli pro advanced-mobile-device-searches apply --from-file advanced-mobile-device-searche.json
 
   # Apply a advanced-mobile-device-searche from a YAML file
-  jamf-cli advanced-mobile-device-searches apply --from-file advanced-mobile-device-searche.yaml
+  jamf-cli pro advanced-mobile-device-searches apply --from-file advanced-mobile-device-searche.yaml
 
   # Apply from stdin
-  cat advanced-mobile-device-searche.json | jamf-cli advanced-mobile-device-searches apply
+  cat advanced-mobile-device-searche.json | jamf-cli pro advanced-mobile-device-searches apply
 
   # Apply without replacement confirmation
-  jamf-cli advanced-mobile-device-searches apply --from-file advanced-mobile-device-searche.json --yes
+  jamf-cli pro advanced-mobile-device-searches apply --from-file advanced-mobile-device-searche.json --yes
 
   # Preview what would happen
-  jamf-cli advanced-mobile-device-searches apply --from-file advanced-mobile-device-searche.json --dry-run`,
+  jamf-cli pro advanced-mobile-device-searches apply --from-file advanced-mobile-device-searche.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/advanced_user_content_searches.go
+++ b/internal/commands/pro/generated/advanced_user_content_searches.go
@@ -43,10 +43,10 @@ func newAdvancedUserContentSearchesListCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Get All Advanced User Content Search objects",
 		Long:  "Get All Advanced User Content Search Objects",
 		Example: `  # List all advanced-user-content-searches
-  jamf-cli advanced-user-content-searches list
+  jamf-cli pro advanced-user-content-searches list
 
   # List advanced-user-content-searches and extract IDs
-  jamf-cli advanced-user-content-searches list --field id`,
+  jamf-cli pro advanced-user-content-searches list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -83,13 +83,13 @@ func newAdvancedUserContentSearchesGetCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Get Specified Advanced User Content Search object",
 		Long:  "Gets Specified Advanced User Content Search Object",
 		Example: `  # Get a advanced-user-content-searche by ID
-  jamf-cli advanced-user-content-searches get 1
+  jamf-cli pro advanced-user-content-searches get 1
 
   # Get a advanced-user-content-searche by name
-  jamf-cli advanced-user-content-searches get --name "Example"
+  jamf-cli pro advanced-user-content-searches get --name "Example"
 
   # Get a advanced-user-content-searche and output as YAML
-  jamf-cli advanced-user-content-searches get 1 -o yaml`,
+  jamf-cli pro advanced-user-content-searches get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -144,13 +144,13 @@ func newAdvancedUserContentSearchesCreateCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Create Advanced User Content Search object",
 		Long:  "Creates Advanced User Content Search Object",
 		Example: `  # Show the JSON template for creating a advanced-user-content-searche
-  jamf-cli advanced-user-content-searches create --scaffold
+  jamf-cli pro advanced-user-content-searches create --scaffold
 
   # Create a advanced-user-content-searche from JSON
-  echo '{"name":"Example"}' | jamf-cli advanced-user-content-searches create
+  echo '{"name":"Example"}' | jamf-cli pro advanced-user-content-searches create
 
   # Get a advanced-user-content-searche, modify it, and create a copy
-  jamf-cli advanced-user-content-searches get 1 -o json | jq '.name = "Copy"' | jamf-cli advanced-user-content-searches create`,
+  jamf-cli pro advanced-user-content-searches get 1 -o json | jq '.name = "Copy"' | jamf-cli pro advanced-user-content-searches create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -219,13 +219,13 @@ func newAdvancedUserContentSearchesUpdateCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Get Specified Advanced User Content Search object",
 		Long:  "Gets Specified Advanced User Content Search Object",
 		Example: `  # Update a advanced-user-content-searche from JSON
-  echo '{"name":"Updated"}' | jamf-cli advanced-user-content-searches update 1
+  echo '{"name":"Updated"}' | jamf-cli pro advanced-user-content-searches update 1
 
   # Update by name
-  jamf-cli advanced-user-content-searches get --name "Example" -o json | jq '.field = "value"' | jamf-cli advanced-user-content-searches update --name "Example"
+  jamf-cli pro advanced-user-content-searches get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro advanced-user-content-searches update --name "Example"
 
   # Get a advanced-user-content-searche, modify, and update
-  jamf-cli advanced-user-content-searches get 1 -o json | jq '.name = "New Name"' | jamf-cli advanced-user-content-searches update 1`,
+  jamf-cli pro advanced-user-content-searches get 1 -o json | jq '.name = "New Name"' | jamf-cli pro advanced-user-content-searches update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -312,13 +312,13 @@ func newAdvancedUserContentSearchesDeleteCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Remove specified Advanced User Content Search object",
 		Long:  "Removes specified Advanced User Content Search Object",
 		Example: `  # Delete a advanced-user-content-searche (with confirmation)
-  jamf-cli advanced-user-content-searches delete 1
+  jamf-cli pro advanced-user-content-searches delete 1
 
   # Delete by name
-  jamf-cli advanced-user-content-searches delete --name "Example" --yes
+  jamf-cli pro advanced-user-content-searches delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli advanced-user-content-searches delete 1 --yes`,
+  jamf-cli pro advanced-user-content-searches delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -430,19 +430,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a advanced-user-content-searche from a JSON file
-  jamf-cli advanced-user-content-searches apply --from-file advanced-user-content-searche.json
+  jamf-cli pro advanced-user-content-searches apply --from-file advanced-user-content-searche.json
 
   # Apply a advanced-user-content-searche from a YAML file
-  jamf-cli advanced-user-content-searches apply --from-file advanced-user-content-searche.yaml
+  jamf-cli pro advanced-user-content-searches apply --from-file advanced-user-content-searche.yaml
 
   # Apply from stdin
-  cat advanced-user-content-searche.json | jamf-cli advanced-user-content-searches apply
+  cat advanced-user-content-searche.json | jamf-cli pro advanced-user-content-searches apply
 
   # Apply without replacement confirmation
-  jamf-cli advanced-user-content-searches apply --from-file advanced-user-content-searche.json --yes
+  jamf-cli pro advanced-user-content-searches apply --from-file advanced-user-content-searche.json --yes
 
   # Preview what would happen
-  jamf-cli advanced-user-content-searches apply --from-file advanced-user-content-searche.json --dry-run`,
+  jamf-cli pro advanced-user-content-searches apply --from-file advanced-user-content-searche.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/api_integrations.go
+++ b/internal/commands/pro/generated/api_integrations.go
@@ -52,10 +52,10 @@ func newApiIntegrationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get the current API Integrations",
 		Long:  "Get Jamf|Pro API Integrations with Search Criteria",
 		Example: `  # List all api-integrations
-  jamf-cli api-integrations list
+  jamf-cli pro api-integrations list
 
   # List api-integrations and extract IDs
-  jamf-cli api-integrations list --field id`,
+  jamf-cli pro api-integrations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -178,13 +178,13 @@ func newApiIntegrationsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified API integration object",
 		Long:  "Gets specified API integration object",
 		Example: `  # Get a api-integration by ID
-  jamf-cli api-integrations get 1
+  jamf-cli pro api-integrations get 1
 
   # Get a api-integration by name
-  jamf-cli api-integrations get --name "Example"
+  jamf-cli pro api-integrations get --name "Example"
 
   # Get a api-integration and output as YAML
-  jamf-cli api-integrations get 1 -o yaml`,
+  jamf-cli pro api-integrations get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -239,13 +239,13 @@ func newApiIntegrationsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create API integration object",
 		Long:  "Create API integration object",
 		Example: `  # Show the JSON template for creating a api-integration
-  jamf-cli api-integrations create --scaffold
+  jamf-cli pro api-integrations create --scaffold
 
   # Create a api-integration from JSON
-  echo '{"name":"Example"}' | jamf-cli api-integrations create
+  echo '{"name":"Example"}' | jamf-cli pro api-integrations create
 
   # Get a api-integration, modify it, and create a copy
-  jamf-cli api-integrations get 1 -o json | jq '.name = "Copy"' | jamf-cli api-integrations create`,
+  jamf-cli pro api-integrations get 1 -o json | jq '.name = "Copy"' | jamf-cli pro api-integrations create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -314,13 +314,13 @@ func newApiIntegrationsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update specified API integration object",
 		Long:  "Update specified API integration object",
 		Example: `  # Update a api-integration from JSON
-  echo '{"name":"Updated"}' | jamf-cli api-integrations update 1
+  echo '{"name":"Updated"}' | jamf-cli pro api-integrations update 1
 
   # Update by name
-  jamf-cli api-integrations get --name "Example" -o json | jq '.field = "value"' | jamf-cli api-integrations update --name "Example"
+  jamf-cli pro api-integrations get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro api-integrations update --name "Example"
 
   # Get a api-integration, modify, and update
-  jamf-cli api-integrations get 1 -o json | jq '.name = "New Name"' | jamf-cli api-integrations update 1`,
+  jamf-cli pro api-integrations get 1 -o json | jq '.name = "New Name"' | jamf-cli pro api-integrations update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -407,13 +407,13 @@ func newApiIntegrationsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Remove specified API integration",
 		Long:  "Removes specified API integration",
 		Example: `  # Delete a api-integration (with confirmation)
-  jamf-cli api-integrations delete 1
+  jamf-cli pro api-integrations delete 1
 
   # Delete by name
-  jamf-cli api-integrations delete --name "Example" --yes
+  jamf-cli pro api-integrations delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli api-integrations delete 1 --yes`,
+  jamf-cli pro api-integrations delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -595,19 +595,19 @@ The displayName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a api-integration from a JSON file
-  jamf-cli api-integrations apply --from-file api-integration.json
+  jamf-cli pro api-integrations apply --from-file api-integration.json
 
   # Apply a api-integration from a YAML file
-  jamf-cli api-integrations apply --from-file api-integration.yaml
+  jamf-cli pro api-integrations apply --from-file api-integration.yaml
 
   # Apply from stdin
-  cat api-integration.json | jamf-cli api-integrations apply
+  cat api-integration.json | jamf-cli pro api-integrations apply
 
   # Apply without replacement confirmation
-  jamf-cli api-integrations apply --from-file api-integration.json --yes
+  jamf-cli pro api-integrations apply --from-file api-integration.json --yes
 
   # Preview what would happen
-  jamf-cli api-integrations apply --from-file api-integration.json --dry-run`,
+  jamf-cli pro api-integrations apply --from-file api-integration.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/api_roles.go
+++ b/internal/commands/pro/generated/api_roles.go
@@ -51,10 +51,10 @@ func newApiRolesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get the current Jamf API Roles",
 		Long:  "Get roles with Search Criteria",
 		Example: `  # List all api-roles
-  jamf-cli api-roles list
+  jamf-cli pro api-roles list
 
   # List api-roles and extract IDs
-  jamf-cli api-roles list --field id`,
+  jamf-cli pro api-roles list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -177,13 +177,13 @@ func newApiRolesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get the specific Jamf API Role",
 		Long:  "Get specific Role",
 		Example: `  # Get a api-role by ID
-  jamf-cli api-roles get 1
+  jamf-cli pro api-roles get 1
 
   # Get a api-role by name
-  jamf-cli api-roles get --name "Example"
+  jamf-cli pro api-roles get --name "Example"
 
   # Get a api-role and output as YAML
-  jamf-cli api-roles get 1 -o yaml`,
+  jamf-cli pro api-roles get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -238,13 +238,13 @@ func newApiRolesCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a new API role",
 		Long:  "Post to create new Role",
 		Example: `  # Show the JSON template for creating a api-role
-  jamf-cli api-roles create --scaffold
+  jamf-cli pro api-roles create --scaffold
 
   # Create a api-role from JSON
-  echo '{"name":"Example"}' | jamf-cli api-roles create
+  echo '{"name":"Example"}' | jamf-cli pro api-roles create
 
   # Get a api-role, modify it, and create a copy
-  jamf-cli api-roles get 1 -o json | jq '.name = "Copy"' | jamf-cli api-roles create`,
+  jamf-cli pro api-roles get 1 -o json | jq '.name = "Copy"' | jamf-cli pro api-roles create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -308,13 +308,13 @@ func newApiRolesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update API Integrations Role",
 		Long:  "Update specific Role",
 		Example: `  # Update a api-role from JSON
-  echo '{"name":"Updated"}' | jamf-cli api-roles update 1
+  echo '{"name":"Updated"}' | jamf-cli pro api-roles update 1
 
   # Update by name
-  jamf-cli api-roles get --name "Example" -o json | jq '.field = "value"' | jamf-cli api-roles update --name "Example"
+  jamf-cli pro api-roles get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro api-roles update --name "Example"
 
   # Get a api-role, modify, and update
-  jamf-cli api-roles get 1 -o json | jq '.name = "New Name"' | jamf-cli api-roles update 1`,
+  jamf-cli pro api-roles get 1 -o json | jq '.name = "New Name"' | jamf-cli pro api-roles update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -396,13 +396,13 @@ func newApiRolesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete API Integrations Role",
 		Long:  "Delete specific Role",
 		Example: `  # Delete a api-role (with confirmation)
-  jamf-cli api-roles delete 1
+  jamf-cli pro api-roles delete 1
 
   # Delete by name
-  jamf-cli api-roles delete --name "Example" --yes
+  jamf-cli pro api-roles delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli api-roles delete 1 --yes`,
+  jamf-cli pro api-roles delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -514,19 +514,19 @@ The displayName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a api-role from a JSON file
-  jamf-cli api-roles apply --from-file api-role.json
+  jamf-cli pro api-roles apply --from-file api-role.json
 
   # Apply a api-role from a YAML file
-  jamf-cli api-roles apply --from-file api-role.yaml
+  jamf-cli pro api-roles apply --from-file api-role.yaml
 
   # Apply from stdin
-  cat api-role.json | jamf-cli api-roles apply
+  cat api-role.json | jamf-cli pro api-roles apply
 
   # Apply without replacement confirmation
-  jamf-cli api-roles apply --from-file api-role.json --yes
+  jamf-cli pro api-roles apply --from-file api-role.json --yes
 
   # Preview what would happen
-  jamf-cli api-roles apply --from-file api-role.json --dry-run`,
+  jamf-cli pro api-roles apply --from-file api-role.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/app_installer_deployments.go
+++ b/internal/commands/pro/generated/app_installer_deployments.go
@@ -43,10 +43,10 @@ func newAppInstallerDeploymentsListCmd(ctx *registry.CLIContext) *cobra.Command 
 		Short: "Get all App Installer deployments",
 		Long:  "Retrieves all App Installer deployment configurations",
 		Example: `  # List all app-installer-deployments
-  jamf-cli app-installer-deployments list
+  jamf-cli pro app-installer-deployments list
 
   # List app-installer-deployments and extract IDs
-  jamf-cli app-installer-deployments list --field id`,
+  jamf-cli pro app-installer-deployments list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -83,13 +83,13 @@ func newAppInstallerDeploymentsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get an App Installer deployment by ID",
 		Long:  "Retrieves a specific App Installer deployment by its ID",
 		Example: `  # Get a app-installer-deployment by ID
-  jamf-cli app-installer-deployments get 1
+  jamf-cli pro app-installer-deployments get 1
 
   # Get a app-installer-deployment by name
-  jamf-cli app-installer-deployments get --name "Example"
+  jamf-cli pro app-installer-deployments get --name "Example"
 
   # Get a app-installer-deployment and output as YAML
-  jamf-cli app-installer-deployments get 1 -o yaml`,
+  jamf-cli pro app-installer-deployments get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -144,13 +144,13 @@ func newAppInstallerDeploymentsCreateCmd(ctx *registry.CLIContext) *cobra.Comman
 		Short: "Create an App Installer deployment",
 		Long:  "Creates a new App Installer deployment configuration",
 		Example: `  # Show the JSON template for creating a app-installer-deployment
-  jamf-cli app-installer-deployments create --scaffold
+  jamf-cli pro app-installer-deployments create --scaffold
 
   # Create a app-installer-deployment from JSON
-  echo '{"name":"Example"}' | jamf-cli app-installer-deployments create
+  echo '{"name":"Example"}' | jamf-cli pro app-installer-deployments create
 
   # Get a app-installer-deployment, modify it, and create a copy
-  jamf-cli app-installer-deployments get 1 -o json | jq '.name = "Copy"' | jamf-cli app-installer-deployments create`,
+  jamf-cli pro app-installer-deployments get 1 -o json | jq '.name = "Copy"' | jamf-cli pro app-installer-deployments create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -222,13 +222,13 @@ func newAppInstallerDeploymentsUpdateCmd(ctx *registry.CLIContext) *cobra.Comman
 		Short: "Update an App Installer deployment",
 		Long:  "Updates an existing App Installer deployment configuration",
 		Example: `  # Update a app-installer-deployment from JSON
-  echo '{"name":"Updated"}' | jamf-cli app-installer-deployments update 1
+  echo '{"name":"Updated"}' | jamf-cli pro app-installer-deployments update 1
 
   # Update by name
-  jamf-cli app-installer-deployments get --name "Example" -o json | jq '.field = "value"' | jamf-cli app-installer-deployments update --name "Example"
+  jamf-cli pro app-installer-deployments get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro app-installer-deployments update --name "Example"
 
   # Get a app-installer-deployment, modify, and update
-  jamf-cli app-installer-deployments get 1 -o json | jq '.name = "New Name"' | jamf-cli app-installer-deployments update 1`,
+  jamf-cli pro app-installer-deployments get 1 -o json | jq '.name = "New Name"' | jamf-cli pro app-installer-deployments update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -318,13 +318,13 @@ func newAppInstallerDeploymentsDeleteCmd(ctx *registry.CLIContext) *cobra.Comman
 		Short: "Delete an App Installer deployment",
 		Long:  "Deletes an App Installer deployment by ID",
 		Example: `  # Delete a app-installer-deployment (with confirmation)
-  jamf-cli app-installer-deployments delete 1
+  jamf-cli pro app-installer-deployments delete 1
 
   # Delete by name
-  jamf-cli app-installer-deployments delete --name "Example" --yes
+  jamf-cli pro app-installer-deployments delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli app-installer-deployments delete 1 --yes`,
+  jamf-cli pro app-installer-deployments delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -436,19 +436,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a app-installer-deployment from a JSON file
-  jamf-cli app-installer-deployments apply --from-file app-installer-deployment.json
+  jamf-cli pro app-installer-deployments apply --from-file app-installer-deployment.json
 
   # Apply a app-installer-deployment from a YAML file
-  jamf-cli app-installer-deployments apply --from-file app-installer-deployment.yaml
+  jamf-cli pro app-installer-deployments apply --from-file app-installer-deployment.yaml
 
   # Apply from stdin
-  cat app-installer-deployment.json | jamf-cli app-installer-deployments apply
+  cat app-installer-deployment.json | jamf-cli pro app-installer-deployments apply
 
   # Apply without replacement confirmation
-  jamf-cli app-installer-deployments apply --from-file app-installer-deployment.json --yes
+  jamf-cli pro app-installer-deployments apply --from-file app-installer-deployment.json --yes
 
   # Preview what would happen
-  jamf-cli app-installer-deployments apply --from-file app-installer-deployment.json --dry-run`,
+  jamf-cli pro app-installer-deployments apply --from-file app-installer-deployment.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/app_installer_titles.go
+++ b/internal/commands/pro/generated/app_installer_titles.go
@@ -41,10 +41,10 @@ func newAppInstallerTitlesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get all available App Installer titles",
 		Long:  "Retrieves all available App Installer titles from the Jamf App Catalog with pagination support",
 		Example: `  # List all app-installer-titles
-  jamf-cli app-installer-titles list
+  jamf-cli pro app-installer-titles list
 
   # List app-installer-titles and extract IDs
-  jamf-cli app-installer-titles list --field id`,
+  jamf-cli pro app-installer-titles list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -157,13 +157,13 @@ func newAppInstallerTitlesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get an App Installer title by ID",
 		Long:  "Retrieves a specific App Installer title from the catalog",
 		Example: `  # Get a app-installer-title by ID
-  jamf-cli app-installer-titles get 1
+  jamf-cli pro app-installer-titles get 1
 
   # Get a app-installer-title by name
-  jamf-cli app-installer-titles get --name "Example"
+  jamf-cli pro app-installer-titles get --name "Example"
 
   # Get a app-installer-title and output as YAML
-  jamf-cli app-installer-titles get 1 -o yaml`,
+  jamf-cli pro app-installer-titles get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/app_requests.go
+++ b/internal/commands/pro/generated/app_requests.go
@@ -45,10 +45,10 @@ func newAppRequestsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Search for Form Input Fields",
 		Long:  "Search for form input fields",
 		Example: `  # List all app-requests
-  jamf-cli app-requests list
+  jamf-cli pro app-requests list
 
   # List app-requests and extract IDs
-  jamf-cli app-requests list --field id`,
+  jamf-cli pro app-requests list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -85,13 +85,13 @@ func newAppRequestsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Form Input Field object",
 		Long:  "Gets specified form input field object",
 		Example: `  # Get a app-request by ID
-  jamf-cli app-requests get 1
+  jamf-cli pro app-requests get 1
 
   # Get a app-request by name
-  jamf-cli app-requests get --name "Example"
+  jamf-cli pro app-requests get --name "Example"
 
   # Get a app-request and output as YAML
-  jamf-cli app-requests get 1 -o yaml`,
+  jamf-cli pro app-requests get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -146,13 +146,13 @@ func newAppRequestsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create Form Input Field record",
 		Long:  "Create form input field record",
 		Example: `  # Show the JSON template for creating a app-request
-  jamf-cli app-requests create --scaffold
+  jamf-cli pro app-requests create --scaffold
 
   # Create a app-request from JSON
-  echo '{"name":"Example"}' | jamf-cli app-requests create
+  echo '{"name":"Example"}' | jamf-cli pro app-requests create
 
   # Get a app-request, modify it, and create a copy
-  jamf-cli app-requests get 1 -o json | jq '.name = "Copy"' | jamf-cli app-requests create`,
+  jamf-cli pro app-requests get 1 -o json | jq '.name = "Copy"' | jamf-cli pro app-requests create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -214,10 +214,10 @@ func newAppRequestsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Replace all Form Input Fields",
 		Long:  "Replace all form input fields. Will delete, update, and create all input fields accordingly.",
 		Example: `  # Update app-requests
-  jamf-cli app-requests get -o json | jq '.field = "value"' | jamf-cli app-requests update
+  jamf-cli pro app-requests get -o json | jq '.field = "value"' | jamf-cli pro app-requests update
 
   # Update from a file
-  jamf-cli app-requests update --from-file app-requests.json`,
+  jamf-cli pro app-requests update --from-file app-requests.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -273,13 +273,13 @@ func newAppRequestsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Remove specified Form Input Field record",
 		Long:  "Removes specified form input field record",
 		Example: `  # Delete a app-request (with confirmation)
-  jamf-cli app-requests delete 1
+  jamf-cli pro app-requests delete 1
 
   # Delete by name
-  jamf-cli app-requests delete --name "Example" --yes
+  jamf-cli pro app-requests delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli app-requests delete 1 --yes`,
+  jamf-cli pro app-requests delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -487,19 +487,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a app-request from a JSON file
-  jamf-cli app-requests apply --from-file app-request.json
+  jamf-cli pro app-requests apply --from-file app-request.json
 
   # Apply a app-request from a YAML file
-  jamf-cli app-requests apply --from-file app-request.yaml
+  jamf-cli pro app-requests apply --from-file app-request.yaml
 
   # Apply from stdin
-  cat app-request.json | jamf-cli app-requests apply
+  cat app-request.json | jamf-cli pro app-requests apply
 
   # Apply without replacement confirmation
-  jamf-cli app-requests apply --from-file app-request.json --yes
+  jamf-cli pro app-requests apply --from-file app-request.json --yes
 
   # Preview what would happen
-  jamf-cli app-requests apply --from-file app-request.json --dry-run`,
+  jamf-cli pro app-requests apply --from-file app-request.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/authentications.go
+++ b/internal/commands/pro/generated/authentications.go
@@ -39,10 +39,10 @@ func newAuthenticationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get all the Authorization details associated with the current api",
 		Long:  "Get all the authorization details associated with the current api token",
 		Example: `  # List all authentications
-  jamf-cli authentications list
+  jamf-cli pro authentications list
 
   # List authentications and extract IDs
-  jamf-cli authentications list --field id`,
+  jamf-cli pro authentications list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/buildings.go
+++ b/internal/commands/pro/generated/buildings.go
@@ -56,10 +56,10 @@ func newBuildingsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Search for sorted and paged Buildings",
 		Long:  "Search for sorted and paged buildings",
 		Example: `  # List all buildings
-  jamf-cli buildings list
+  jamf-cli pro buildings list
 
   # List buildings and extract IDs
-  jamf-cli buildings list --field id`,
+  jamf-cli pro buildings list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -182,13 +182,13 @@ func newBuildingsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Building object",
 		Long:  "Gets specified Building object",
 		Example: `  # Get a building by ID
-  jamf-cli buildings get 1
+  jamf-cli pro buildings get 1
 
   # Get a building by name
-  jamf-cli buildings get --name "Example"
+  jamf-cli pro buildings get --name "Example"
 
   # Get a building and output as YAML
-  jamf-cli buildings get 1 -o yaml`,
+  jamf-cli pro buildings get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -243,13 +243,13 @@ func newBuildingsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create Building record",
 		Long:  "Create building record",
 		Example: `  # Show the JSON template for creating a building
-  jamf-cli buildings create --scaffold
+  jamf-cli pro buildings create --scaffold
 
   # Create a building from JSON
-  echo '{"name":"Example"}' | jamf-cli buildings create
+  echo '{"name":"Example"}' | jamf-cli pro buildings create
 
   # Get a building, modify it, and create a copy
-  jamf-cli buildings get 1 -o json | jq '.name = "Copy"' | jamf-cli buildings create`,
+  jamf-cli pro buildings get 1 -o json | jq '.name = "Copy"' | jamf-cli pro buildings create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -318,13 +318,13 @@ func newBuildingsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update specified Building object",
 		Long:  "Update specified building object",
 		Example: `  # Update a building from JSON
-  echo '{"name":"Updated"}' | jamf-cli buildings update 1
+  echo '{"name":"Updated"}' | jamf-cli pro buildings update 1
 
   # Update by name
-  jamf-cli buildings get --name "Example" -o json | jq '.field = "value"' | jamf-cli buildings update --name "Example"
+  jamf-cli pro buildings get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro buildings update --name "Example"
 
   # Get a building, modify, and update
-  jamf-cli buildings get 1 -o json | jq '.name = "New Name"' | jamf-cli buildings update 1`,
+  jamf-cli pro buildings get 1 -o json | jq '.name = "New Name"' | jamf-cli pro buildings update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -411,13 +411,13 @@ func newBuildingsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Remove specified Building record",
 		Long:  "Removes specified building record",
 		Example: `  # Delete a building (with confirmation)
-  jamf-cli buildings delete 1
+  jamf-cli pro buildings delete 1
 
   # Delete by name
-  jamf-cli buildings delete --name "Example" --yes
+  jamf-cli pro buildings delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli buildings delete 1 --yes`,
+  jamf-cli pro buildings delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -525,7 +525,7 @@ func newBuildingsDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete multiple Buildings by their ids",
 		Long:  "multiple many Buildings by their ids",
 		Example: `  # Delete multiple buildings by IDs
-  jamf-cli buildings delete-multiple --ids 1,2,3 --yes`,
+  jamf-cli pro buildings delete-multiple --ids 1,2,3 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -625,10 +625,10 @@ func newBuildingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Building History object",
 		Long:  "Gets specified Building history object",
 		Example: `  # Get history for a building by ID
-  jamf-cli buildings history 1
+  jamf-cli pro buildings history 1
 
   # Get history by name
-  jamf-cli buildings history --name "Example"`,
+  jamf-cli pro buildings history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -854,7 +854,7 @@ func newBuildingsExportCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Export Buildings collection",
 		Long:  "Export Buildings collection",
 		Example: `  # Export buildings to CSV
-  jamf-cli buildings export --out-file buildings.csv`,
+  jamf-cli pro buildings export --out-file buildings.csv`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			reqCtx = registry.WithAccept(reqCtx, "*/*")
@@ -1117,19 +1117,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a building from a JSON file
-  jamf-cli buildings apply --from-file building.json
+  jamf-cli pro buildings apply --from-file building.json
 
   # Apply a building from a YAML file
-  jamf-cli buildings apply --from-file building.yaml
+  jamf-cli pro buildings apply --from-file building.yaml
 
   # Apply from stdin
-  cat building.json | jamf-cli buildings apply
+  cat building.json | jamf-cli pro buildings apply
 
   # Apply without replacement confirmation
-  jamf-cli buildings apply --from-file building.json --yes
+  jamf-cli pro buildings apply --from-file building.json --yes
 
   # Preview what would happen
-  jamf-cli buildings apply --from-file building.json --dry-run`,
+  jamf-cli pro buildings apply --from-file building.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/cache.go
+++ b/internal/commands/pro/generated/cache.go
@@ -36,10 +36,10 @@ func newCacheGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Cache Settings",
 		Long:  "gets cache settings",
 		Example: `  # Get cache
-  jamf-cli cache get
+  jamf-cli pro cache get
 
   # Get cache and output as YAML
-  jamf-cli cache get -o yaml`,
+  jamf-cli pro cache get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -76,10 +76,10 @@ func newCacheUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update Cache Settings",
 		Long:  "updates cache settings",
 		Example: `  # Update cache
-  jamf-cli cache get -o json | jq '.field = "value"' | jamf-cli cache update
+  jamf-cli pro cache get -o json | jq '.field = "value"' | jamf-cli pro cache update
 
   # Update from a file
-  jamf-cli cache update --from-file cache.json`,
+  jamf-cli pro cache update --from-file cache.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/categories.go
+++ b/internal/commands/pro/generated/categories.go
@@ -54,10 +54,10 @@ func newCategoriesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Category objects",
 		Long:  "Gets 'Category' objects.",
 		Example: `  # List all categories
-  jamf-cli categories list
+  jamf-cli pro categories list
 
   # List categories and extract IDs
-  jamf-cli categories list --field id`,
+  jamf-cli pro categories list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -180,13 +180,13 @@ func newCategoriesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Category object",
 		Long:  "Gets specified Category object",
 		Example: `  # Get a category by ID
-  jamf-cli categories get 1
+  jamf-cli pro categories get 1
 
   # Get a category by name
-  jamf-cli categories get --name "Example"
+  jamf-cli pro categories get --name "Example"
 
   # Get a category and output as YAML
-  jamf-cli categories get 1 -o yaml`,
+  jamf-cli pro categories get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -241,13 +241,13 @@ func newCategoriesCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create Category record",
 		Long:  "Create category record",
 		Example: `  # Show the JSON template for creating a category
-  jamf-cli categories create --scaffold
+  jamf-cli pro categories create --scaffold
 
   # Create a category from JSON
-  echo '{"name":"Example"}' | jamf-cli categories create
+  echo '{"name":"Example"}' | jamf-cli pro categories create
 
   # Get a category, modify it, and create a copy
-  jamf-cli categories get 1 -o json | jq '.name = "Copy"' | jamf-cli categories create`,
+  jamf-cli pro categories get 1 -o json | jq '.name = "Copy"' | jamf-cli pro categories create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -311,13 +311,13 @@ func newCategoriesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update specified Category object",
 		Long:  "Update specified category object",
 		Example: `  # Update a category from JSON
-  echo '{"name":"Updated"}' | jamf-cli categories update 1
+  echo '{"name":"Updated"}' | jamf-cli pro categories update 1
 
   # Update by name
-  jamf-cli categories get --name "Example" -o json | jq '.field = "value"' | jamf-cli categories update --name "Example"
+  jamf-cli pro categories get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro categories update --name "Example"
 
   # Get a category, modify, and update
-  jamf-cli categories get 1 -o json | jq '.name = "New Name"' | jamf-cli categories update 1`,
+  jamf-cli pro categories get 1 -o json | jq '.name = "New Name"' | jamf-cli pro categories update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -399,13 +399,13 @@ func newCategoriesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Remove specified Category record",
 		Long:  "Removes specified category record",
 		Example: `  # Delete a category (with confirmation)
-  jamf-cli categories delete 1
+  jamf-cli pro categories delete 1
 
   # Delete by name
-  jamf-cli categories delete --name "Example" --yes
+  jamf-cli pro categories delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli categories delete 1 --yes`,
+  jamf-cli pro categories delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -513,7 +513,7 @@ func newCategoriesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete multiple Categories by their IDs",
 		Long:  "Delete multiple Categories by their IDs",
 		Example: `  # Delete multiple categories by IDs
-  jamf-cli categories delete-multiple --ids 1,2,3 --yes`,
+  jamf-cli pro categories delete-multiple --ids 1,2,3 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -613,10 +613,10 @@ func newCategoriesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Category history object",
 		Long:  "Gets specified Category history object",
 		Example: `  # Get history for a category by ID
-  jamf-cli categories history 1
+  jamf-cli pro categories history 1
 
   # Get history by name
-  jamf-cli categories history --name "Example"`,
+  jamf-cli pro categories history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -842,19 +842,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a category from a JSON file
-  jamf-cli categories apply --from-file category.json
+  jamf-cli pro categories apply --from-file category.json
 
   # Apply a category from a YAML file
-  jamf-cli categories apply --from-file category.yaml
+  jamf-cli pro categories apply --from-file category.yaml
 
   # Apply from stdin
-  cat category.json | jamf-cli categories apply
+  cat category.json | jamf-cli pro categories apply
 
   # Apply without replacement confirmation
-  jamf-cli categories apply --from-file category.json --yes
+  jamf-cli pro categories apply --from-file category.json --yes
 
   # Preview what would happen
-  jamf-cli categories apply --from-file category.json --dry-run`,
+  jamf-cli pro categories apply --from-file category.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/certificate_authorities.go
+++ b/internal/commands/pro/generated/certificate_authorities.go
@@ -40,10 +40,10 @@ func newCertificateAuthoritiesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Returns X.509 details of the active Certificate Authority (CA)",
 		Long:  "Returns X.509 details of the active Certificate Authority (CA)",
 		Example: `  # List all certificate-authorities
-  jamf-cli certificate-authorities list
+  jamf-cli pro certificate-authorities list
 
   # List certificate-authorities and extract IDs
-  jamf-cli certificate-authorities list --field id`,
+  jamf-cli pro certificate-authorities list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -80,13 +80,13 @@ func newCertificateAuthoritiesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Returns X.509 details of Certificate Authority (CA) with provided ID",
 		Long:  "Returns X.509 details of Certificate Authority (CA) with provided ID",
 		Example: `  # Get a certificate-authority by ID
-  jamf-cli certificate-authorities get 1
+  jamf-cli pro certificate-authorities get 1
 
   # Get a certificate-authority by name
-  jamf-cli certificate-authorities get --name "Example"
+  jamf-cli pro certificate-authorities get --name "Example"
 
   # Get a certificate-authority and output as YAML
-  jamf-cli certificate-authorities get 1 -o yaml`,
+  jamf-cli pro certificate-authorities get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_account_groups.go
+++ b/internal/commands/pro/generated/classic_account_groups.go
@@ -42,10 +42,10 @@ func newClassicAccountGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all account-groups",
 		Example: `  # List all account-groups
-  jamf-cli classic-account-groups list
+  jamf-cli pro classic-account-groups list
 
   # List account-groups and extract IDs
-  jamf-cli classic-account-groups list --field id`,
+  jamf-cli pro classic-account-groups list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/accounts", nil)
@@ -90,10 +90,10 @@ func newClassicAccountGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a account_group by ID",
 		Example: `  # Get a account_group by ID
-  jamf-cli classic-account-groups get 1
+  jamf-cli pro classic-account-groups get 1
 
   # Get a account_group and output as YAML
-  jamf-cli classic-account-groups get 1 -o yaml`,
+  jamf-cli pro classic-account-groups get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -150,7 +150,7 @@ func newClassicAccountGroupsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a account_group",
 		Long:  "Create a new account_group. Reads XML body from stdin.",
 		Example: `  # Create a account_group from XML
-  cat account_group.xml | jamf-cli classic-account-groups create`,
+  cat account_group.xml | jamf-cli pro classic-account-groups create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -182,7 +182,7 @@ func newClassicAccountGroupsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a account_group",
 		Long:  "Update an existing account_group by ID. Reads XML body from stdin.",
 		Example: `  # Update a account_group from XML
-  cat account_group.xml | jamf-cli classic-account-groups update 1`,
+  cat account_group.xml | jamf-cli pro classic-account-groups update 1`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -220,10 +220,10 @@ func newClassicAccountGroupsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete <id>",
 		Short: "Delete a account_group",
 		Example: `  # Delete a account_group (with confirmation)
-  jamf-cli classic-account-groups delete 1
+  jamf-cli pro classic-account-groups delete 1
 
   # Delete without confirmation prompt
-  jamf-cli classic-account-groups delete 1 --yes`,
+  jamf-cli pro classic-account-groups delete 1 --yes`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_account_users.go
+++ b/internal/commands/pro/generated/classic_account_users.go
@@ -42,10 +42,10 @@ func newClassicAccountUsersListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all account-users",
 		Example: `  # List all account-users
-  jamf-cli classic-account-users list
+  jamf-cli pro classic-account-users list
 
   # List account-users and extract IDs
-  jamf-cli classic-account-users list --field id`,
+  jamf-cli pro classic-account-users list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/accounts", nil)
@@ -90,10 +90,10 @@ func newClassicAccountUsersGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a account_user by ID",
 		Example: `  # Get a account_user by ID
-  jamf-cli classic-account-users get 1
+  jamf-cli pro classic-account-users get 1
 
   # Get a account_user and output as YAML
-  jamf-cli classic-account-users get 1 -o yaml`,
+  jamf-cli pro classic-account-users get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -150,7 +150,7 @@ func newClassicAccountUsersCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a account_user",
 		Long:  "Create a new account_user. Reads XML body from stdin.",
 		Example: `  # Create a account_user from XML
-  cat account_user.xml | jamf-cli classic-account-users create`,
+  cat account_user.xml | jamf-cli pro classic-account-users create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -182,7 +182,7 @@ func newClassicAccountUsersUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a account_user",
 		Long:  "Update an existing account_user by ID. Reads XML body from stdin.",
 		Example: `  # Update a account_user from XML
-  cat account_user.xml | jamf-cli classic-account-users update 1`,
+  cat account_user.xml | jamf-cli pro classic-account-users update 1`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -220,10 +220,10 @@ func newClassicAccountUsersDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete <id>",
 		Short: "Delete a account_user",
 		Example: `  # Delete a account_user (with confirmation)
-  jamf-cli classic-account-users delete 1
+  jamf-cli pro classic-account-users delete 1
 
   # Delete without confirmation prompt
-  jamf-cli classic-account-users delete 1 --yes`,
+  jamf-cli pro classic-account-users delete 1 --yes`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_accounts.go
+++ b/internal/commands/pro/generated/classic_accounts.go
@@ -29,10 +29,10 @@ func newClassicAccountsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all accounts",
 		Example: `  # List all accounts
-  jamf-cli classic-accounts list
+  jamf-cli pro classic-accounts list
 
   # List accounts and extract IDs
-  jamf-cli classic-accounts list --field id`,
+  jamf-cli pro classic-accounts list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/accounts", nil)

--- a/internal/commands/pro/generated/classic_advanced_computer_searches.go
+++ b/internal/commands/pro/generated/classic_advanced_computer_searches.go
@@ -45,10 +45,10 @@ func newClassicAdvancedComputerSearchesListCmd(ctx *registry.CLIContext) *cobra.
 		Use:   "list",
 		Short: "List all advancedcomputersearches",
 		Example: `  # List all advancedcomputersearches
-  jamf-cli classic-advanced-computer-searches list
+  jamf-cli pro classic-advanced-computer-searches list
 
   # List advancedcomputersearches and extract IDs
-  jamf-cli classic-advanced-computer-searches list --field id`,
+  jamf-cli pro classic-advanced-computer-searches list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/advancedcomputersearches", nil)
@@ -98,13 +98,13 @@ func newClassicAdvancedComputerSearchesGetCmd(ctx *registry.CLIContext) *cobra.C
 		Use:   "get [<id>]",
 		Short: "Get a advanced_computer_search by ID",
 		Example: `  # Get a advanced_computer_search by ID
-  jamf-cli classic-advanced-computer-searches get 1
+  jamf-cli pro classic-advanced-computer-searches get 1
 
   # Get a advanced_computer_search by name
-  jamf-cli classic-advanced-computer-searches get --name "Example"
+  jamf-cli pro classic-advanced-computer-searches get --name "Example"
 
   # Get a advanced_computer_search and output as YAML
-  jamf-cli classic-advanced-computer-searches get 1 -o yaml`,
+  jamf-cli pro classic-advanced-computer-searches get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicAdvancedComputerSearchesCreateCmd(ctx *registry.CLIContext) *cobr
 		Short: "Create a advanced_computer_search",
 		Long:  "Create a new advanced_computer_search. Reads XML body from stdin.",
 		Example: `  # Create a advanced_computer_search from XML
-  cat advanced_computer_search.xml | jamf-cli classic-advanced-computer-searches create`,
+  cat advanced_computer_search.xml | jamf-cli pro classic-advanced-computer-searches create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicAdvancedComputerSearchesUpdateCmd(ctx *registry.CLIContext) *cobr
 		Short: "Update a advanced_computer_search",
 		Long:  "Update an existing advanced_computer_search by ID. Reads XML body from stdin.",
 		Example: `  # Update a advanced_computer_search from XML
-  cat advanced_computer_search.xml | jamf-cli classic-advanced-computer-searches update 1`,
+  cat advanced_computer_search.xml | jamf-cli pro classic-advanced-computer-searches update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicAdvancedComputerSearchesDeleteCmd(ctx *registry.CLIContext) *cobr
 		Use:   "delete [<id>]",
 		Short: "Delete a advanced_computer_search",
 		Example: `  # Delete a advanced_computer_search (with confirmation)
-  jamf-cli classic-advanced-computer-searches delete 1
+  jamf-cli pro classic-advanced-computer-searches delete 1
 
   # Delete by name
-  jamf-cli classic-advanced-computer-searches delete --name "Example" --yes
+  jamf-cli pro classic-advanced-computer-searches delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-advanced-computer-searches delete 1 --yes`,
+  jamf-cli pro classic-advanced-computer-searches delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a advanced_computer_search from an XML file
-  jamf-cli classic-advanced-computer-searches apply --from-file advanced_computer_search.xml
+  jamf-cli pro classic-advanced-computer-searches apply --from-file advanced_computer_search.xml
 
   # Apply from stdin
-  cat advanced_computer_search.xml | jamf-cli classic-advanced-computer-searches apply
+  cat advanced_computer_search.xml | jamf-cli pro classic-advanced-computer-searches apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-advanced-computer-searches apply --from-file advanced_computer_search.xml --yes`,
+  jamf-cli pro classic-advanced-computer-searches apply --from-file advanced_computer_search.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_allowed_file_extensions.go
+++ b/internal/commands/pro/generated/classic_allowed_file_extensions.go
@@ -40,10 +40,10 @@ func newClassicAllowedFileExtensionsListCmd(ctx *registry.CLIContext) *cobra.Com
 		Use:   "list",
 		Short: "List all allowedfileextensions",
 		Example: `  # List all allowedfileextensions
-  jamf-cli classic-allowed-file-extensions list
+  jamf-cli pro classic-allowed-file-extensions list
 
   # List allowedfileextensions and extract IDs
-  jamf-cli classic-allowed-file-extensions list --field id`,
+  jamf-cli pro classic-allowed-file-extensions list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/allowedfileextensions", nil)
@@ -93,10 +93,10 @@ func newClassicAllowedFileExtensionsGetCmd(ctx *registry.CLIContext) *cobra.Comm
 		Use:   "get [<id>]",
 		Short: "Get a allowed_file_extension by ID",
 		Example: `  # Get a allowed_file_extension by ID
-  jamf-cli classic-allowed-file-extensions get 1
+  jamf-cli pro classic-allowed-file-extensions get 1
 
   # Get a allowed_file_extension and output as YAML
-  jamf-cli classic-allowed-file-extensions get 1 -o yaml`,
+  jamf-cli pro classic-allowed-file-extensions get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -153,7 +153,7 @@ func newClassicAllowedFileExtensionsCreateCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Create a allowed_file_extension",
 		Long:  "Create a new allowed_file_extension. Reads XML body from stdin.",
 		Example: `  # Create a allowed_file_extension from XML
-  cat allowed_file_extension.xml | jamf-cli classic-allowed-file-extensions create`,
+  cat allowed_file_extension.xml | jamf-cli pro classic-allowed-file-extensions create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -188,10 +188,10 @@ func newClassicAllowedFileExtensionsDeleteCmd(ctx *registry.CLIContext) *cobra.C
 		Use:   "delete <id>",
 		Short: "Delete a allowed_file_extension",
 		Example: `  # Delete a allowed_file_extension (with confirmation)
-  jamf-cli classic-allowed-file-extensions delete 1
+  jamf-cli pro classic-allowed-file-extensions delete 1
 
   # Delete without confirmation prompt
-  jamf-cli classic-allowed-file-extensions delete 1 --yes`,
+  jamf-cli pro classic-allowed-file-extensions delete 1 --yes`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_classes.go
+++ b/internal/commands/pro/generated/classic_classes.go
@@ -45,10 +45,10 @@ func newClassicClassesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all classes",
 		Example: `  # List all classes
-  jamf-cli classic-classes list
+  jamf-cli pro classic-classes list
 
   # List classes and extract IDs
-  jamf-cli classic-classes list --field id`,
+  jamf-cli pro classic-classes list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/classes", nil)
@@ -98,13 +98,13 @@ func newClassicClassesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a class by ID",
 		Example: `  # Get a class by ID
-  jamf-cli classic-classes get 1
+  jamf-cli pro classic-classes get 1
 
   # Get a class by name
-  jamf-cli classic-classes get --name "Example"
+  jamf-cli pro classic-classes get --name "Example"
 
   # Get a class and output as YAML
-  jamf-cli classic-classes get 1 -o yaml`,
+  jamf-cli pro classic-classes get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicClassesCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a class",
 		Long:  "Create a new class. Reads XML body from stdin.",
 		Example: `  # Create a class from XML
-  cat class.xml | jamf-cli classic-classes create`,
+  cat class.xml | jamf-cli pro classic-classes create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicClassesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a class",
 		Long:  "Update an existing class by ID. Reads XML body from stdin.",
 		Example: `  # Update a class from XML
-  cat class.xml | jamf-cli classic-classes update 1`,
+  cat class.xml | jamf-cli pro classic-classes update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicClassesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete [<id>]",
 		Short: "Delete a class",
 		Example: `  # Delete a class (with confirmation)
-  jamf-cli classic-classes delete 1
+  jamf-cli pro classic-classes delete 1
 
   # Delete by name
-  jamf-cli classic-classes delete --name "Example" --yes
+  jamf-cli pro classic-classes delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-classes delete 1 --yes`,
+  jamf-cli pro classic-classes delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a class from an XML file
-  jamf-cli classic-classes apply --from-file class.xml
+  jamf-cli pro classic-classes apply --from-file class.xml
 
   # Apply from stdin
-  cat class.xml | jamf-cli classic-classes apply
+  cat class.xml | jamf-cli pro classic-classes apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-classes apply --from-file class.xml --yes`,
+  jamf-cli pro classic-classes apply --from-file class.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_computer_commands.go
+++ b/internal/commands/pro/generated/classic_computer_commands.go
@@ -29,10 +29,10 @@ func newClassicComputerCommandsListCmd(ctx *registry.CLIContext) *cobra.Command 
 		Use:   "list",
 		Short: "List all computercommands",
 		Example: `  # List all computercommands
-  jamf-cli classic-computer-commands list
+  jamf-cli pro classic-computer-commands list
 
   # List computercommands and extract IDs
-  jamf-cli classic-computer-commands list --field id`,
+  jamf-cli pro classic-computer-commands list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/computercommands", nil)

--- a/internal/commands/pro/generated/classic_computer_configs.go
+++ b/internal/commands/pro/generated/classic_computer_configs.go
@@ -45,10 +45,10 @@ func newClassicComputerConfigsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all computerconfigurations",
 		Example: `  # List all computerconfigurations
-  jamf-cli classic-computer-configs list
+  jamf-cli pro classic-computer-configs list
 
   # List computerconfigurations and extract IDs
-  jamf-cli classic-computer-configs list --field id`,
+  jamf-cli pro classic-computer-configs list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/computerconfigurations", nil)
@@ -98,13 +98,13 @@ func newClassicComputerConfigsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a computer_configuration by ID",
 		Example: `  # Get a computer_configuration by ID
-  jamf-cli classic-computer-configs get 1
+  jamf-cli pro classic-computer-configs get 1
 
   # Get a computer_configuration by name
-  jamf-cli classic-computer-configs get --name "Example"
+  jamf-cli pro classic-computer-configs get --name "Example"
 
   # Get a computer_configuration and output as YAML
-  jamf-cli classic-computer-configs get 1 -o yaml`,
+  jamf-cli pro classic-computer-configs get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicComputerConfigsCreateCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Create a computer_configuration",
 		Long:  "Create a new computer_configuration. Reads XML body from stdin.",
 		Example: `  # Create a computer_configuration from XML
-  cat computer_configuration.xml | jamf-cli classic-computer-configs create`,
+  cat computer_configuration.xml | jamf-cli pro classic-computer-configs create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicComputerConfigsUpdateCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Update a computer_configuration",
 		Long:  "Update an existing computer_configuration by ID. Reads XML body from stdin.",
 		Example: `  # Update a computer_configuration from XML
-  cat computer_configuration.xml | jamf-cli classic-computer-configs update 1`,
+  cat computer_configuration.xml | jamf-cli pro classic-computer-configs update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicComputerConfigsDeleteCmd(ctx *registry.CLIContext) *cobra.Command
 		Use:   "delete [<id>]",
 		Short: "Delete a computer_configuration",
 		Example: `  # Delete a computer_configuration (with confirmation)
-  jamf-cli classic-computer-configs delete 1
+  jamf-cli pro classic-computer-configs delete 1
 
   # Delete by name
-  jamf-cli classic-computer-configs delete --name "Example" --yes
+  jamf-cli pro classic-computer-configs delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-computer-configs delete 1 --yes`,
+  jamf-cli pro classic-computer-configs delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a computer_configuration from an XML file
-  jamf-cli classic-computer-configs apply --from-file computer_configuration.xml
+  jamf-cli pro classic-computer-configs apply --from-file computer_configuration.xml
 
   # Apply from stdin
-  cat computer_configuration.xml | jamf-cli classic-computer-configs apply
+  cat computer_configuration.xml | jamf-cli pro classic-computer-configs apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-computer-configs apply --from-file computer_configuration.xml --yes`,
+  jamf-cli pro classic-computer-configs apply --from-file computer_configuration.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_computer_ext_attrs.go
+++ b/internal/commands/pro/generated/classic_computer_ext_attrs.go
@@ -45,10 +45,10 @@ func newClassicComputerExtAttrsListCmd(ctx *registry.CLIContext) *cobra.Command 
 		Use:   "list",
 		Short: "List all computerextensionattributes",
 		Example: `  # List all computerextensionattributes
-  jamf-cli classic-computer-ext-attrs list
+  jamf-cli pro classic-computer-ext-attrs list
 
   # List computerextensionattributes and extract IDs
-  jamf-cli classic-computer-ext-attrs list --field id`,
+  jamf-cli pro classic-computer-ext-attrs list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/computerextensionattributes", nil)
@@ -98,13 +98,13 @@ func newClassicComputerExtAttrsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a computer_extension_attribute by ID",
 		Example: `  # Get a computer_extension_attribute by ID
-  jamf-cli classic-computer-ext-attrs get 1
+  jamf-cli pro classic-computer-ext-attrs get 1
 
   # Get a computer_extension_attribute by name
-  jamf-cli classic-computer-ext-attrs get --name "Example"
+  jamf-cli pro classic-computer-ext-attrs get --name "Example"
 
   # Get a computer_extension_attribute and output as YAML
-  jamf-cli classic-computer-ext-attrs get 1 -o yaml`,
+  jamf-cli pro classic-computer-ext-attrs get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicComputerExtAttrsCreateCmd(ctx *registry.CLIContext) *cobra.Comman
 		Short: "Create a computer_extension_attribute",
 		Long:  "Create a new computer_extension_attribute. Reads XML body from stdin.",
 		Example: `  # Create a computer_extension_attribute from XML
-  cat computer_extension_attribute.xml | jamf-cli classic-computer-ext-attrs create`,
+  cat computer_extension_attribute.xml | jamf-cli pro classic-computer-ext-attrs create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicComputerExtAttrsUpdateCmd(ctx *registry.CLIContext) *cobra.Comman
 		Short: "Update a computer_extension_attribute",
 		Long:  "Update an existing computer_extension_attribute by ID. Reads XML body from stdin.",
 		Example: `  # Update a computer_extension_attribute from XML
-  cat computer_extension_attribute.xml | jamf-cli classic-computer-ext-attrs update 1`,
+  cat computer_extension_attribute.xml | jamf-cli pro classic-computer-ext-attrs update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicComputerExtAttrsDeleteCmd(ctx *registry.CLIContext) *cobra.Comman
 		Use:   "delete [<id>]",
 		Short: "Delete a computer_extension_attribute",
 		Example: `  # Delete a computer_extension_attribute (with confirmation)
-  jamf-cli classic-computer-ext-attrs delete 1
+  jamf-cli pro classic-computer-ext-attrs delete 1
 
   # Delete by name
-  jamf-cli classic-computer-ext-attrs delete --name "Example" --yes
+  jamf-cli pro classic-computer-ext-attrs delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-computer-ext-attrs delete 1 --yes`,
+  jamf-cli pro classic-computer-ext-attrs delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a computer_extension_attribute from an XML file
-  jamf-cli classic-computer-ext-attrs apply --from-file computer_extension_attribute.xml
+  jamf-cli pro classic-computer-ext-attrs apply --from-file computer_extension_attribute.xml
 
   # Apply from stdin
-  cat computer_extension_attribute.xml | jamf-cli classic-computer-ext-attrs apply
+  cat computer_extension_attribute.xml | jamf-cli pro classic-computer-ext-attrs apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-computer-ext-attrs apply --from-file computer_extension_attribute.xml --yes`,
+  jamf-cli pro classic-computer-ext-attrs apply --from-file computer_extension_attribute.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_computer_history.go
+++ b/internal/commands/pro/generated/classic_computer_history.go
@@ -38,13 +38,13 @@ func newClassicComputerHistoryGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a computer_history by ID",
 		Example: `  # Get a computer_history by ID
-  jamf-cli classic-computer-history get 1
+  jamf-cli pro classic-computer-history get 1
 
   # Get a computer_history by name
-  jamf-cli classic-computer-history get --name "Example"
+  jamf-cli pro classic-computer-history get --name "Example"
 
   # Get a computer_history and output as YAML
-  jamf-cli classic-computer-history get 1 -o yaml`,
+  jamf-cli pro classic-computer-history get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_computer_invitations.go
+++ b/internal/commands/pro/generated/classic_computer_invitations.go
@@ -40,10 +40,10 @@ func newClassicComputerInvitationsListCmd(ctx *registry.CLIContext) *cobra.Comma
 		Use:   "list",
 		Short: "List all computerinvitations",
 		Example: `  # List all computerinvitations
-  jamf-cli classic-computer-invitations list
+  jamf-cli pro classic-computer-invitations list
 
   # List computerinvitations and extract IDs
-  jamf-cli classic-computer-invitations list --field id`,
+  jamf-cli pro classic-computer-invitations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/computerinvitations", nil)
@@ -94,13 +94,13 @@ func newClassicComputerInvitationsGetCmd(ctx *registry.CLIContext) *cobra.Comman
 		Use:   "get [<id>]",
 		Short: "Get a computer_invitation by ID",
 		Example: `  # Get a computer_invitation by ID
-  jamf-cli classic-computer-invitations get 1
+  jamf-cli pro classic-computer-invitations get 1
 
   # Get a computer_invitation by name
-  jamf-cli classic-computer-invitations get --name "Example"
+  jamf-cli pro classic-computer-invitations get --name "Example"
 
   # Get a computer_invitation and output as YAML
-  jamf-cli classic-computer-invitations get 1 -o yaml`,
+  jamf-cli pro classic-computer-invitations get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -160,7 +160,7 @@ func newClassicComputerInvitationsCreateCmd(ctx *registry.CLIContext) *cobra.Com
 		Short: "Create a computer_invitation",
 		Long:  "Create a new computer_invitation. Reads XML body from stdin.",
 		Example: `  # Create a computer_invitation from XML
-  cat computer_invitation.xml | jamf-cli classic-computer-invitations create`,
+  cat computer_invitation.xml | jamf-cli pro classic-computer-invitations create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -196,13 +196,13 @@ func newClassicComputerInvitationsDeleteCmd(ctx *registry.CLIContext) *cobra.Com
 		Use:   "delete [<id>]",
 		Short: "Delete a computer_invitation",
 		Example: `  # Delete a computer_invitation (with confirmation)
-  jamf-cli classic-computer-invitations delete 1
+  jamf-cli pro classic-computer-invitations delete 1
 
   # Delete by name
-  jamf-cli classic-computer-invitations delete --name "Example" --yes
+  jamf-cli pro classic-computer-invitations delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-computer-invitations delete 1 --yes`,
+  jamf-cli pro classic-computer-invitations delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_directory_bindings.go
+++ b/internal/commands/pro/generated/classic_directory_bindings.go
@@ -45,10 +45,10 @@ func newClassicDirectoryBindingsListCmd(ctx *registry.CLIContext) *cobra.Command
 		Use:   "list",
 		Short: "List all directorybindings",
 		Example: `  # List all directorybindings
-  jamf-cli classic-directory-bindings list
+  jamf-cli pro classic-directory-bindings list
 
   # List directorybindings and extract IDs
-  jamf-cli classic-directory-bindings list --field id`,
+  jamf-cli pro classic-directory-bindings list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/directorybindings", nil)
@@ -98,13 +98,13 @@ func newClassicDirectoryBindingsGetCmd(ctx *registry.CLIContext) *cobra.Command 
 		Use:   "get [<id>]",
 		Short: "Get a directory_binding by ID",
 		Example: `  # Get a directory_binding by ID
-  jamf-cli classic-directory-bindings get 1
+  jamf-cli pro classic-directory-bindings get 1
 
   # Get a directory_binding by name
-  jamf-cli classic-directory-bindings get --name "Example"
+  jamf-cli pro classic-directory-bindings get --name "Example"
 
   # Get a directory_binding and output as YAML
-  jamf-cli classic-directory-bindings get 1 -o yaml`,
+  jamf-cli pro classic-directory-bindings get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicDirectoryBindingsCreateCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Create a directory_binding",
 		Long:  "Create a new directory_binding. Reads XML body from stdin.",
 		Example: `  # Create a directory_binding from XML
-  cat directory_binding.xml | jamf-cli classic-directory-bindings create`,
+  cat directory_binding.xml | jamf-cli pro classic-directory-bindings create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicDirectoryBindingsUpdateCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Update a directory_binding",
 		Long:  "Update an existing directory_binding by ID. Reads XML body from stdin.",
 		Example: `  # Update a directory_binding from XML
-  cat directory_binding.xml | jamf-cli classic-directory-bindings update 1`,
+  cat directory_binding.xml | jamf-cli pro classic-directory-bindings update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicDirectoryBindingsDeleteCmd(ctx *registry.CLIContext) *cobra.Comma
 		Use:   "delete [<id>]",
 		Short: "Delete a directory_binding",
 		Example: `  # Delete a directory_binding (with confirmation)
-  jamf-cli classic-directory-bindings delete 1
+  jamf-cli pro classic-directory-bindings delete 1
 
   # Delete by name
-  jamf-cli classic-directory-bindings delete --name "Example" --yes
+  jamf-cli pro classic-directory-bindings delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-directory-bindings delete 1 --yes`,
+  jamf-cli pro classic-directory-bindings delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a directory_binding from an XML file
-  jamf-cli classic-directory-bindings apply --from-file directory_binding.xml
+  jamf-cli pro classic-directory-bindings apply --from-file directory_binding.xml
 
   # Apply from stdin
-  cat directory_binding.xml | jamf-cli classic-directory-bindings apply
+  cat directory_binding.xml | jamf-cli pro classic-directory-bindings apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-directory-bindings apply --from-file directory_binding.xml --yes`,
+  jamf-cli pro classic-directory-bindings apply --from-file directory_binding.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_disk_encryption_configs.go
+++ b/internal/commands/pro/generated/classic_disk_encryption_configs.go
@@ -45,10 +45,10 @@ func newClassicDiskEncryptionConfigsListCmd(ctx *registry.CLIContext) *cobra.Com
 		Use:   "list",
 		Short: "List all diskencryptionconfigurations",
 		Example: `  # List all diskencryptionconfigurations
-  jamf-cli classic-disk-encryption-configs list
+  jamf-cli pro classic-disk-encryption-configs list
 
   # List diskencryptionconfigurations and extract IDs
-  jamf-cli classic-disk-encryption-configs list --field id`,
+  jamf-cli pro classic-disk-encryption-configs list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/diskencryptionconfigurations", nil)
@@ -98,13 +98,13 @@ func newClassicDiskEncryptionConfigsGetCmd(ctx *registry.CLIContext) *cobra.Comm
 		Use:   "get [<id>]",
 		Short: "Get a disk_encryption_configuration by ID",
 		Example: `  # Get a disk_encryption_configuration by ID
-  jamf-cli classic-disk-encryption-configs get 1
+  jamf-cli pro classic-disk-encryption-configs get 1
 
   # Get a disk_encryption_configuration by name
-  jamf-cli classic-disk-encryption-configs get --name "Example"
+  jamf-cli pro classic-disk-encryption-configs get --name "Example"
 
   # Get a disk_encryption_configuration and output as YAML
-  jamf-cli classic-disk-encryption-configs get 1 -o yaml`,
+  jamf-cli pro classic-disk-encryption-configs get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicDiskEncryptionConfigsCreateCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Create a disk_encryption_configuration",
 		Long:  "Create a new disk_encryption_configuration. Reads XML body from stdin.",
 		Example: `  # Create a disk_encryption_configuration from XML
-  cat disk_encryption_configuration.xml | jamf-cli classic-disk-encryption-configs create`,
+  cat disk_encryption_configuration.xml | jamf-cli pro classic-disk-encryption-configs create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicDiskEncryptionConfigsUpdateCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Update a disk_encryption_configuration",
 		Long:  "Update an existing disk_encryption_configuration by ID. Reads XML body from stdin.",
 		Example: `  # Update a disk_encryption_configuration from XML
-  cat disk_encryption_configuration.xml | jamf-cli classic-disk-encryption-configs update 1`,
+  cat disk_encryption_configuration.xml | jamf-cli pro classic-disk-encryption-configs update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicDiskEncryptionConfigsDeleteCmd(ctx *registry.CLIContext) *cobra.C
 		Use:   "delete [<id>]",
 		Short: "Delete a disk_encryption_configuration",
 		Example: `  # Delete a disk_encryption_configuration (with confirmation)
-  jamf-cli classic-disk-encryption-configs delete 1
+  jamf-cli pro classic-disk-encryption-configs delete 1
 
   # Delete by name
-  jamf-cli classic-disk-encryption-configs delete --name "Example" --yes
+  jamf-cli pro classic-disk-encryption-configs delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-disk-encryption-configs delete 1 --yes`,
+  jamf-cli pro classic-disk-encryption-configs delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a disk_encryption_configuration from an XML file
-  jamf-cli classic-disk-encryption-configs apply --from-file disk_encryption_configuration.xml
+  jamf-cli pro classic-disk-encryption-configs apply --from-file disk_encryption_configuration.xml
 
   # Apply from stdin
-  cat disk_encryption_configuration.xml | jamf-cli classic-disk-encryption-configs apply
+  cat disk_encryption_configuration.xml | jamf-cli pro classic-disk-encryption-configs apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-disk-encryption-configs apply --from-file disk_encryption_configuration.xml --yes`,
+  jamf-cli pro classic-disk-encryption-configs apply --from-file disk_encryption_configuration.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_distribution_points.go
+++ b/internal/commands/pro/generated/classic_distribution_points.go
@@ -45,10 +45,10 @@ func newClassicDistributionPointsListCmd(ctx *registry.CLIContext) *cobra.Comman
 		Use:   "list",
 		Short: "List all distributionpoints",
 		Example: `  # List all distributionpoints
-  jamf-cli classic-distribution-points list
+  jamf-cli pro classic-distribution-points list
 
   # List distributionpoints and extract IDs
-  jamf-cli classic-distribution-points list --field id`,
+  jamf-cli pro classic-distribution-points list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/distributionpoints", nil)
@@ -98,13 +98,13 @@ func newClassicDistributionPointsGetCmd(ctx *registry.CLIContext) *cobra.Command
 		Use:   "get [<id>]",
 		Short: "Get a distribution_point by ID",
 		Example: `  # Get a distribution_point by ID
-  jamf-cli classic-distribution-points get 1
+  jamf-cli pro classic-distribution-points get 1
 
   # Get a distribution_point by name
-  jamf-cli classic-distribution-points get --name "Example"
+  jamf-cli pro classic-distribution-points get --name "Example"
 
   # Get a distribution_point and output as YAML
-  jamf-cli classic-distribution-points get 1 -o yaml`,
+  jamf-cli pro classic-distribution-points get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicDistributionPointsCreateCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Create a distribution_point",
 		Long:  "Create a new distribution_point. Reads XML body from stdin.",
 		Example: `  # Create a distribution_point from XML
-  cat distribution_point.xml | jamf-cli classic-distribution-points create`,
+  cat distribution_point.xml | jamf-cli pro classic-distribution-points create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicDistributionPointsUpdateCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Update a distribution_point",
 		Long:  "Update an existing distribution_point by ID. Reads XML body from stdin.",
 		Example: `  # Update a distribution_point from XML
-  cat distribution_point.xml | jamf-cli classic-distribution-points update 1`,
+  cat distribution_point.xml | jamf-cli pro classic-distribution-points update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicDistributionPointsDeleteCmd(ctx *registry.CLIContext) *cobra.Comm
 		Use:   "delete [<id>]",
 		Short: "Delete a distribution_point",
 		Example: `  # Delete a distribution_point (with confirmation)
-  jamf-cli classic-distribution-points delete 1
+  jamf-cli pro classic-distribution-points delete 1
 
   # Delete by name
-  jamf-cli classic-distribution-points delete --name "Example" --yes
+  jamf-cli pro classic-distribution-points delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-distribution-points delete 1 --yes`,
+  jamf-cli pro classic-distribution-points delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a distribution_point from an XML file
-  jamf-cli classic-distribution-points apply --from-file distribution_point.xml
+  jamf-cli pro classic-distribution-points apply --from-file distribution_point.xml
 
   # Apply from stdin
-  cat distribution_point.xml | jamf-cli classic-distribution-points apply
+  cat distribution_point.xml | jamf-cli pro classic-distribution-points apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-distribution-points apply --from-file distribution_point.xml --yes`,
+  jamf-cli pro classic-distribution-points apply --from-file distribution_point.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_dock_items.go
+++ b/internal/commands/pro/generated/classic_dock_items.go
@@ -45,10 +45,10 @@ func newClassicDockItemsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all dockitems",
 		Example: `  # List all dockitems
-  jamf-cli classic-dock-items list
+  jamf-cli pro classic-dock-items list
 
   # List dockitems and extract IDs
-  jamf-cli classic-dock-items list --field id`,
+  jamf-cli pro classic-dock-items list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/dockitems", nil)
@@ -98,13 +98,13 @@ func newClassicDockItemsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a dock_item by ID",
 		Example: `  # Get a dock_item by ID
-  jamf-cli classic-dock-items get 1
+  jamf-cli pro classic-dock-items get 1
 
   # Get a dock_item by name
-  jamf-cli classic-dock-items get --name "Example"
+  jamf-cli pro classic-dock-items get --name "Example"
 
   # Get a dock_item and output as YAML
-  jamf-cli classic-dock-items get 1 -o yaml`,
+  jamf-cli pro classic-dock-items get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicDockItemsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a dock_item",
 		Long:  "Create a new dock_item. Reads XML body from stdin.",
 		Example: `  # Create a dock_item from XML
-  cat dock_item.xml | jamf-cli classic-dock-items create`,
+  cat dock_item.xml | jamf-cli pro classic-dock-items create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicDockItemsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a dock_item",
 		Long:  "Update an existing dock_item by ID. Reads XML body from stdin.",
 		Example: `  # Update a dock_item from XML
-  cat dock_item.xml | jamf-cli classic-dock-items update 1`,
+  cat dock_item.xml | jamf-cli pro classic-dock-items update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicDockItemsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete [<id>]",
 		Short: "Delete a dock_item",
 		Example: `  # Delete a dock_item (with confirmation)
-  jamf-cli classic-dock-items delete 1
+  jamf-cli pro classic-dock-items delete 1
 
   # Delete by name
-  jamf-cli classic-dock-items delete --name "Example" --yes
+  jamf-cli pro classic-dock-items delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-dock-items delete 1 --yes`,
+  jamf-cli pro classic-dock-items delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a dock_item from an XML file
-  jamf-cli classic-dock-items apply --from-file dock_item.xml
+  jamf-cli pro classic-dock-items apply --from-file dock_item.xml
 
   # Apply from stdin
-  cat dock_item.xml | jamf-cli classic-dock-items apply
+  cat dock_item.xml | jamf-cli pro classic-dock-items apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-dock-items apply --from-file dock_item.xml --yes`,
+  jamf-cli pro classic-dock-items apply --from-file dock_item.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_gsx_connection.go
+++ b/internal/commands/pro/generated/classic_gsx_connection.go
@@ -35,10 +35,10 @@ func newClassicGsxConnectionGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get <id>",
 		Short: "Get a gsx_connection by ID",
 		Example: `  # Get a gsx_connection by ID
-  jamf-cli classic-gsx-connection get 1
+  jamf-cli pro classic-gsx-connection get 1
 
   # Get a gsx_connection and output as YAML
-  jamf-cli classic-gsx-connection get 1 -o yaml`,
+  jamf-cli pro classic-gsx-connection get 1 -o yaml`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -85,7 +85,7 @@ func newClassicGsxConnectionUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a gsx_connection",
 		Long:  "Update an existing gsx_connection by ID. Reads XML body from stdin.",
 		Example: `  # Update a gsx_connection from XML
-  cat gsx_connection.xml | jamf-cli classic-gsx-connection update 1`,
+  cat gsx_connection.xml | jamf-cli pro classic-gsx-connection update 1`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_ibeacons.go
+++ b/internal/commands/pro/generated/classic_ibeacons.go
@@ -45,10 +45,10 @@ func newClassicIbeaconsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all ibeacons",
 		Example: `  # List all ibeacons
-  jamf-cli classic-ibeacons list
+  jamf-cli pro classic-ibeacons list
 
   # List ibeacons and extract IDs
-  jamf-cli classic-ibeacons list --field id`,
+  jamf-cli pro classic-ibeacons list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/ibeacons", nil)
@@ -98,13 +98,13 @@ func newClassicIbeaconsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a ibeacon by ID",
 		Example: `  # Get a ibeacon by ID
-  jamf-cli classic-ibeacons get 1
+  jamf-cli pro classic-ibeacons get 1
 
   # Get a ibeacon by name
-  jamf-cli classic-ibeacons get --name "Example"
+  jamf-cli pro classic-ibeacons get --name "Example"
 
   # Get a ibeacon and output as YAML
-  jamf-cli classic-ibeacons get 1 -o yaml`,
+  jamf-cli pro classic-ibeacons get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicIbeaconsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a ibeacon",
 		Long:  "Create a new ibeacon. Reads XML body from stdin.",
 		Example: `  # Create a ibeacon from XML
-  cat ibeacon.xml | jamf-cli classic-ibeacons create`,
+  cat ibeacon.xml | jamf-cli pro classic-ibeacons create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicIbeaconsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a ibeacon",
 		Long:  "Update an existing ibeacon by ID. Reads XML body from stdin.",
 		Example: `  # Update a ibeacon from XML
-  cat ibeacon.xml | jamf-cli classic-ibeacons update 1`,
+  cat ibeacon.xml | jamf-cli pro classic-ibeacons update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicIbeaconsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete [<id>]",
 		Short: "Delete a ibeacon",
 		Example: `  # Delete a ibeacon (with confirmation)
-  jamf-cli classic-ibeacons delete 1
+  jamf-cli pro classic-ibeacons delete 1
 
   # Delete by name
-  jamf-cli classic-ibeacons delete --name "Example" --yes
+  jamf-cli pro classic-ibeacons delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-ibeacons delete 1 --yes`,
+  jamf-cli pro classic-ibeacons delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a ibeacon from an XML file
-  jamf-cli classic-ibeacons apply --from-file ibeacon.xml
+  jamf-cli pro classic-ibeacons apply --from-file ibeacon.xml
 
   # Apply from stdin
-  cat ibeacon.xml | jamf-cli classic-ibeacons apply
+  cat ibeacon.xml | jamf-cli pro classic-ibeacons apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-ibeacons apply --from-file ibeacon.xml --yes`,
+  jamf-cli pro classic-ibeacons apply --from-file ibeacon.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_jwt_configs.go
+++ b/internal/commands/pro/generated/classic_jwt_configs.go
@@ -42,10 +42,10 @@ func newClassicJwtConfigsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all jsonwebtokenconfigurations",
 		Example: `  # List all jsonwebtokenconfigurations
-  jamf-cli classic-jwt-configs list
+  jamf-cli pro classic-jwt-configs list
 
   # List jsonwebtokenconfigurations and extract IDs
-  jamf-cli classic-jwt-configs list --field id`,
+  jamf-cli pro classic-jwt-configs list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/jsonwebtokenconfigurations", nil)
@@ -92,10 +92,10 @@ func newClassicJwtConfigsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get <id>",
 		Short: "Get a json_web_token_configuration by ID",
 		Example: `  # Get a json_web_token_configuration by ID
-  jamf-cli classic-jwt-configs get 1
+  jamf-cli pro classic-jwt-configs get 1
 
   # Get a json_web_token_configuration and output as YAML
-  jamf-cli classic-jwt-configs get 1 -o yaml`,
+  jamf-cli pro classic-jwt-configs get 1 -o yaml`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -141,7 +141,7 @@ func newClassicJwtConfigsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a json_web_token_configuration",
 		Long:  "Create a new json_web_token_configuration. Reads XML body from stdin.",
 		Example: `  # Create a json_web_token_configuration from XML
-  cat json_web_token_configuration.xml | jamf-cli classic-jwt-configs create`,
+  cat json_web_token_configuration.xml | jamf-cli pro classic-jwt-configs create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -173,7 +173,7 @@ func newClassicJwtConfigsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a json_web_token_configuration",
 		Long:  "Update an existing json_web_token_configuration by ID. Reads XML body from stdin.",
 		Example: `  # Update a json_web_token_configuration from XML
-  cat json_web_token_configuration.xml | jamf-cli classic-jwt-configs update 1`,
+  cat json_web_token_configuration.xml | jamf-cli pro classic-jwt-configs update 1`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -211,10 +211,10 @@ func newClassicJwtConfigsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete <id>",
 		Short: "Delete a json_web_token_configuration",
 		Example: `  # Delete a json_web_token_configuration (with confirmation)
-  jamf-cli classic-jwt-configs delete 1
+  jamf-cli pro classic-jwt-configs delete 1
 
   # Delete without confirmation prompt
-  jamf-cli classic-jwt-configs delete 1 --yes`,
+  jamf-cli pro classic-jwt-configs delete 1 --yes`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_ldaps.go
+++ b/internal/commands/pro/generated/classic_ldaps.go
@@ -35,13 +35,13 @@ func newClassicLdapsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get mappings for OnPrem Ldap configuration with given id.",
 		Long:  "Get mappings for OnPrem Ldap configuration with given id.",
 		Example: `  # Get a classic-ldap by ID
-  jamf-cli classic-ldaps get 1
+  jamf-cli pro classic-ldaps get 1
 
   # Get a classic-ldap by name
-  jamf-cli classic-ldaps get --name "Example"
+  jamf-cli pro classic-ldaps get --name "Example"
 
   # Get a classic-ldap and output as YAML
-  jamf-cli classic-ldaps get 1 -o yaml`,
+  jamf-cli pro classic-ldaps get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_licensed_software.go
+++ b/internal/commands/pro/generated/classic_licensed_software.go
@@ -45,10 +45,10 @@ func newClassicLicensedSoftwareListCmd(ctx *registry.CLIContext) *cobra.Command 
 		Use:   "list",
 		Short: "List all licensedsoftware",
 		Example: `  # List all licensedsoftware
-  jamf-cli classic-licensed-software list
+  jamf-cli pro classic-licensed-software list
 
   # List licensedsoftware and extract IDs
-  jamf-cli classic-licensed-software list --field id`,
+  jamf-cli pro classic-licensed-software list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/licensedsoftware", nil)
@@ -98,13 +98,13 @@ func newClassicLicensedSoftwareGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a licensed_software by ID",
 		Example: `  # Get a licensed_software by ID
-  jamf-cli classic-licensed-software get 1
+  jamf-cli pro classic-licensed-software get 1
 
   # Get a licensed_software by name
-  jamf-cli classic-licensed-software get --name "Example"
+  jamf-cli pro classic-licensed-software get --name "Example"
 
   # Get a licensed_software and output as YAML
-  jamf-cli classic-licensed-software get 1 -o yaml`,
+  jamf-cli pro classic-licensed-software get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicLicensedSoftwareCreateCmd(ctx *registry.CLIContext) *cobra.Comman
 		Short: "Create a licensed_software",
 		Long:  "Create a new licensed_software. Reads XML body from stdin.",
 		Example: `  # Create a licensed_software from XML
-  cat licensed_software.xml | jamf-cli classic-licensed-software create`,
+  cat licensed_software.xml | jamf-cli pro classic-licensed-software create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicLicensedSoftwareUpdateCmd(ctx *registry.CLIContext) *cobra.Comman
 		Short: "Update a licensed_software",
 		Long:  "Update an existing licensed_software by ID. Reads XML body from stdin.",
 		Example: `  # Update a licensed_software from XML
-  cat licensed_software.xml | jamf-cli classic-licensed-software update 1`,
+  cat licensed_software.xml | jamf-cli pro classic-licensed-software update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicLicensedSoftwareDeleteCmd(ctx *registry.CLIContext) *cobra.Comman
 		Use:   "delete [<id>]",
 		Short: "Delete a licensed_software",
 		Example: `  # Delete a licensed_software (with confirmation)
-  jamf-cli classic-licensed-software delete 1
+  jamf-cli pro classic-licensed-software delete 1
 
   # Delete by name
-  jamf-cli classic-licensed-software delete --name "Example" --yes
+  jamf-cli pro classic-licensed-software delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-licensed-software delete 1 --yes`,
+  jamf-cli pro classic-licensed-software delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a licensed_software from an XML file
-  jamf-cli classic-licensed-software apply --from-file licensed_software.xml
+  jamf-cli pro classic-licensed-software apply --from-file licensed_software.xml
 
   # Apply from stdin
-  cat licensed_software.xml | jamf-cli classic-licensed-software apply
+  cat licensed_software.xml | jamf-cli pro classic-licensed-software apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-licensed-software apply --from-file licensed_software.xml --yes`,
+  jamf-cli pro classic-licensed-software apply --from-file licensed_software.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_mac_apps.go
+++ b/internal/commands/pro/generated/classic_mac_apps.go
@@ -51,10 +51,10 @@ func newClassicMacAppsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all macapplications",
 		Example: `  # List all macapplications
-  jamf-cli classic-mac-apps list
+  jamf-cli pro classic-mac-apps list
 
   # List macapplications and extract IDs
-  jamf-cli classic-mac-apps list --field id`,
+  jamf-cli pro classic-mac-apps list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/macapplications", nil)
@@ -104,13 +104,13 @@ func newClassicMacAppsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a mac_application by ID",
 		Example: `  # Get a mac_application by ID
-  jamf-cli classic-mac-apps get 1
+  jamf-cli pro classic-mac-apps get 1
 
   # Get a mac_application by name
-  jamf-cli classic-mac-apps get --name "Example"
+  jamf-cli pro classic-mac-apps get --name "Example"
 
   # Get a mac_application and output as YAML
-  jamf-cli classic-mac-apps get 1 -o yaml`,
+  jamf-cli pro classic-mac-apps get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -170,7 +170,7 @@ func newClassicMacAppsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a mac_application",
 		Long:  "Create a new mac_application. Reads XML body from stdin.",
 		Example: `  # Create a mac_application from XML
-  cat mac_application.xml | jamf-cli classic-mac-apps create`,
+  cat mac_application.xml | jamf-cli pro classic-mac-apps create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -219,7 +219,7 @@ func newClassicMacAppsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a mac_application",
 		Long:  "Update an existing mac_application by ID. Reads XML body from stdin.",
 		Example: `  # Update a mac_application from XML
-  cat mac_application.xml | jamf-cli classic-mac-apps update 1`,
+  cat mac_application.xml | jamf-cli pro classic-mac-apps update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -317,13 +317,13 @@ func newClassicMacAppsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete [<id>]",
 		Short: "Delete a mac_application",
 		Example: `  # Delete a mac_application (with confirmation)
-  jamf-cli classic-mac-apps delete 1
+  jamf-cli pro classic-mac-apps delete 1
 
   # Delete by name
-  jamf-cli classic-mac-apps delete --name "Example" --yes
+  jamf-cli pro classic-mac-apps delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-mac-apps delete 1 --yes`,
+  jamf-cli pro classic-mac-apps delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -408,13 +408,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a mac_application from an XML file
-  jamf-cli classic-mac-apps apply --from-file mac_application.xml
+  jamf-cli pro classic-mac-apps apply --from-file mac_application.xml
 
   # Apply from stdin
-  cat mac_application.xml | jamf-cli classic-mac-apps apply
+  cat mac_application.xml | jamf-cli pro classic-mac-apps apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-mac-apps apply --from-file mac_application.xml --yes`,
+  jamf-cli pro classic-mac-apps apply --from-file mac_application.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_macos_config_profiles.go
+++ b/internal/commands/pro/generated/classic_macos_config_profiles.go
@@ -51,10 +51,10 @@ func newClassicMacosConfigProfilesListCmd(ctx *registry.CLIContext) *cobra.Comma
 		Use:   "list",
 		Short: "List all osxconfigurationprofiles",
 		Example: `  # List all osxconfigurationprofiles
-  jamf-cli classic-macos-config-profiles list
+  jamf-cli pro classic-macos-config-profiles list
 
   # List osxconfigurationprofiles and extract IDs
-  jamf-cli classic-macos-config-profiles list --field id`,
+  jamf-cli pro classic-macos-config-profiles list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/osxconfigurationprofiles", nil)
@@ -104,13 +104,13 @@ func newClassicMacosConfigProfilesGetCmd(ctx *registry.CLIContext) *cobra.Comman
 		Use:   "get [<id>]",
 		Short: "Get a os_x_configuration_profile by ID",
 		Example: `  # Get a os_x_configuration_profile by ID
-  jamf-cli classic-macos-config-profiles get 1
+  jamf-cli pro classic-macos-config-profiles get 1
 
   # Get a os_x_configuration_profile by name
-  jamf-cli classic-macos-config-profiles get --name "Example"
+  jamf-cli pro classic-macos-config-profiles get --name "Example"
 
   # Get a os_x_configuration_profile and output as YAML
-  jamf-cli classic-macos-config-profiles get 1 -o yaml`,
+  jamf-cli pro classic-macos-config-profiles get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -170,7 +170,7 @@ func newClassicMacosConfigProfilesCreateCmd(ctx *registry.CLIContext) *cobra.Com
 		Short: "Create a os_x_configuration_profile",
 		Long:  "Create a new os_x_configuration_profile. Reads XML body from stdin.",
 		Example: `  # Create a os_x_configuration_profile from XML
-  cat os_x_configuration_profile.xml | jamf-cli classic-macos-config-profiles create`,
+  cat os_x_configuration_profile.xml | jamf-cli pro classic-macos-config-profiles create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -219,7 +219,7 @@ func newClassicMacosConfigProfilesUpdateCmd(ctx *registry.CLIContext) *cobra.Com
 		Short: "Update a os_x_configuration_profile",
 		Long:  "Update an existing os_x_configuration_profile by ID. Reads XML body from stdin.",
 		Example: `  # Update a os_x_configuration_profile from XML
-  cat os_x_configuration_profile.xml | jamf-cli classic-macos-config-profiles update 1`,
+  cat os_x_configuration_profile.xml | jamf-cli pro classic-macos-config-profiles update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -298,13 +298,13 @@ func newClassicMacosConfigProfilesDeleteCmd(ctx *registry.CLIContext) *cobra.Com
 		Use:   "delete [<id>]",
 		Short: "Delete a os_x_configuration_profile",
 		Example: `  # Delete a os_x_configuration_profile (with confirmation)
-  jamf-cli classic-macos-config-profiles delete 1
+  jamf-cli pro classic-macos-config-profiles delete 1
 
   # Delete by name
-  jamf-cli classic-macos-config-profiles delete --name "Example" --yes
+  jamf-cli pro classic-macos-config-profiles delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-macos-config-profiles delete 1 --yes`,
+  jamf-cli pro classic-macos-config-profiles delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -388,13 +388,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a os_x_configuration_profile from an XML file
-  jamf-cli classic-macos-config-profiles apply --from-file os_x_configuration_profile.xml
+  jamf-cli pro classic-macos-config-profiles apply --from-file os_x_configuration_profile.xml
 
   # Apply from stdin
-  cat os_x_configuration_profile.xml | jamf-cli classic-macos-config-profiles apply
+  cat os_x_configuration_profile.xml | jamf-cli pro classic-macos-config-profiles apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-macos-config-profiles apply --from-file os_x_configuration_profile.xml --yes`,
+  jamf-cli pro classic-macos-config-profiles apply --from-file os_x_configuration_profile.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_mobile_apps.go
+++ b/internal/commands/pro/generated/classic_mobile_apps.go
@@ -51,10 +51,10 @@ func newClassicMobileAppsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all mobiledeviceapplications",
 		Example: `  # List all mobiledeviceapplications
-  jamf-cli classic-mobile-apps list
+  jamf-cli pro classic-mobile-apps list
 
   # List mobiledeviceapplications and extract IDs
-  jamf-cli classic-mobile-apps list --field id`,
+  jamf-cli pro classic-mobile-apps list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/mobiledeviceapplications", nil)
@@ -104,13 +104,13 @@ func newClassicMobileAppsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a mobile_device_application by ID",
 		Example: `  # Get a mobile_device_application by ID
-  jamf-cli classic-mobile-apps get 1
+  jamf-cli pro classic-mobile-apps get 1
 
   # Get a mobile_device_application by name
-  jamf-cli classic-mobile-apps get --name "Example"
+  jamf-cli pro classic-mobile-apps get --name "Example"
 
   # Get a mobile_device_application and output as YAML
-  jamf-cli classic-mobile-apps get 1 -o yaml`,
+  jamf-cli pro classic-mobile-apps get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -170,7 +170,7 @@ func newClassicMobileAppsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a mobile_device_application",
 		Long:  "Create a new mobile_device_application. Reads XML body from stdin.",
 		Example: `  # Create a mobile_device_application from XML
-  cat mobile_device_application.xml | jamf-cli classic-mobile-apps create`,
+  cat mobile_device_application.xml | jamf-cli pro classic-mobile-apps create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -219,7 +219,7 @@ func newClassicMobileAppsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a mobile_device_application",
 		Long:  "Update an existing mobile_device_application by ID. Reads XML body from stdin.",
 		Example: `  # Update a mobile_device_application from XML
-  cat mobile_device_application.xml | jamf-cli classic-mobile-apps update 1`,
+  cat mobile_device_application.xml | jamf-cli pro classic-mobile-apps update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -317,13 +317,13 @@ func newClassicMobileAppsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete [<id>]",
 		Short: "Delete a mobile_device_application",
 		Example: `  # Delete a mobile_device_application (with confirmation)
-  jamf-cli classic-mobile-apps delete 1
+  jamf-cli pro classic-mobile-apps delete 1
 
   # Delete by name
-  jamf-cli classic-mobile-apps delete --name "Example" --yes
+  jamf-cli pro classic-mobile-apps delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-mobile-apps delete 1 --yes`,
+  jamf-cli pro classic-mobile-apps delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -408,13 +408,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a mobile_device_application from an XML file
-  jamf-cli classic-mobile-apps apply --from-file mobile_device_application.xml
+  jamf-cli pro classic-mobile-apps apply --from-file mobile_device_application.xml
 
   # Apply from stdin
-  cat mobile_device_application.xml | jamf-cli classic-mobile-apps apply
+  cat mobile_device_application.xml | jamf-cli pro classic-mobile-apps apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-mobile-apps apply --from-file mobile_device_application.xml --yes`,
+  jamf-cli pro classic-mobile-apps apply --from-file mobile_device_application.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_mobile_commands.go
+++ b/internal/commands/pro/generated/classic_mobile_commands.go
@@ -29,10 +29,10 @@ func newClassicMobileCommandsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all mobiledevicecommands",
 		Example: `  # List all mobiledevicecommands
-  jamf-cli classic-mobile-commands list
+  jamf-cli pro classic-mobile-commands list
 
   # List mobiledevicecommands and extract IDs
-  jamf-cli classic-mobile-commands list --field id`,
+  jamf-cli pro classic-mobile-commands list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/mobiledevicecommands", nil)

--- a/internal/commands/pro/generated/classic_mobile_config_profiles.go
+++ b/internal/commands/pro/generated/classic_mobile_config_profiles.go
@@ -51,10 +51,10 @@ func newClassicMobileConfigProfilesListCmd(ctx *registry.CLIContext) *cobra.Comm
 		Use:   "list",
 		Short: "List all mobiledeviceconfigurationprofiles",
 		Example: `  # List all mobiledeviceconfigurationprofiles
-  jamf-cli classic-mobile-config-profiles list
+  jamf-cli pro classic-mobile-config-profiles list
 
   # List mobiledeviceconfigurationprofiles and extract IDs
-  jamf-cli classic-mobile-config-profiles list --field id`,
+  jamf-cli pro classic-mobile-config-profiles list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/mobiledeviceconfigurationprofiles", nil)
@@ -104,13 +104,13 @@ func newClassicMobileConfigProfilesGetCmd(ctx *registry.CLIContext) *cobra.Comma
 		Use:   "get [<id>]",
 		Short: "Get a configuration_profile by ID",
 		Example: `  # Get a configuration_profile by ID
-  jamf-cli classic-mobile-config-profiles get 1
+  jamf-cli pro classic-mobile-config-profiles get 1
 
   # Get a configuration_profile by name
-  jamf-cli classic-mobile-config-profiles get --name "Example"
+  jamf-cli pro classic-mobile-config-profiles get --name "Example"
 
   # Get a configuration_profile and output as YAML
-  jamf-cli classic-mobile-config-profiles get 1 -o yaml`,
+  jamf-cli pro classic-mobile-config-profiles get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -170,7 +170,7 @@ func newClassicMobileConfigProfilesCreateCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Create a configuration_profile",
 		Long:  "Create a new configuration_profile. Reads XML body from stdin.",
 		Example: `  # Create a configuration_profile from XML
-  cat configuration_profile.xml | jamf-cli classic-mobile-config-profiles create`,
+  cat configuration_profile.xml | jamf-cli pro classic-mobile-config-profiles create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -219,7 +219,7 @@ func newClassicMobileConfigProfilesUpdateCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Update a configuration_profile",
 		Long:  "Update an existing configuration_profile by ID. Reads XML body from stdin.",
 		Example: `  # Update a configuration_profile from XML
-  cat configuration_profile.xml | jamf-cli classic-mobile-config-profiles update 1`,
+  cat configuration_profile.xml | jamf-cli pro classic-mobile-config-profiles update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -298,13 +298,13 @@ func newClassicMobileConfigProfilesDeleteCmd(ctx *registry.CLIContext) *cobra.Co
 		Use:   "delete [<id>]",
 		Short: "Delete a configuration_profile",
 		Example: `  # Delete a configuration_profile (with confirmation)
-  jamf-cli classic-mobile-config-profiles delete 1
+  jamf-cli pro classic-mobile-config-profiles delete 1
 
   # Delete by name
-  jamf-cli classic-mobile-config-profiles delete --name "Example" --yes
+  jamf-cli pro classic-mobile-config-profiles delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-mobile-config-profiles delete 1 --yes`,
+  jamf-cli pro classic-mobile-config-profiles delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -388,13 +388,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a configuration_profile from an XML file
-  jamf-cli classic-mobile-config-profiles apply --from-file configuration_profile.xml
+  jamf-cli pro classic-mobile-config-profiles apply --from-file configuration_profile.xml
 
   # Apply from stdin
-  cat configuration_profile.xml | jamf-cli classic-mobile-config-profiles apply
+  cat configuration_profile.xml | jamf-cli pro classic-mobile-config-profiles apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-mobile-config-profiles apply --from-file configuration_profile.xml --yes`,
+  jamf-cli pro classic-mobile-config-profiles apply --from-file configuration_profile.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_mobile_history.go
+++ b/internal/commands/pro/generated/classic_mobile_history.go
@@ -38,13 +38,13 @@ func newClassicMobileHistoryGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a mobile_device_history by ID",
 		Example: `  # Get a mobile_device_history by ID
-  jamf-cli classic-mobile-history get 1
+  jamf-cli pro classic-mobile-history get 1
 
   # Get a mobile_device_history by name
-  jamf-cli classic-mobile-history get --name "Example"
+  jamf-cli pro classic-mobile-history get --name "Example"
 
   # Get a mobile_device_history and output as YAML
-  jamf-cli classic-mobile-history get 1 -o yaml`,
+  jamf-cli pro classic-mobile-history get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_mobile_invitations.go
+++ b/internal/commands/pro/generated/classic_mobile_invitations.go
@@ -40,10 +40,10 @@ func newClassicMobileInvitationsListCmd(ctx *registry.CLIContext) *cobra.Command
 		Use:   "list",
 		Short: "List all mobiledeviceinvitations",
 		Example: `  # List all mobiledeviceinvitations
-  jamf-cli classic-mobile-invitations list
+  jamf-cli pro classic-mobile-invitations list
 
   # List mobiledeviceinvitations and extract IDs
-  jamf-cli classic-mobile-invitations list --field id`,
+  jamf-cli pro classic-mobile-invitations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/mobiledeviceinvitations", nil)
@@ -93,10 +93,10 @@ func newClassicMobileInvitationsGetCmd(ctx *registry.CLIContext) *cobra.Command 
 		Use:   "get [<id>]",
 		Short: "Get a mobile_device_invitation by ID",
 		Example: `  # Get a mobile_device_invitation by ID
-  jamf-cli classic-mobile-invitations get 1
+  jamf-cli pro classic-mobile-invitations get 1
 
   # Get a mobile_device_invitation and output as YAML
-  jamf-cli classic-mobile-invitations get 1 -o yaml`,
+  jamf-cli pro classic-mobile-invitations get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -153,7 +153,7 @@ func newClassicMobileInvitationsCreateCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Create a mobile_device_invitation",
 		Long:  "Create a new mobile_device_invitation. Reads XML body from stdin.",
 		Example: `  # Create a mobile_device_invitation from XML
-  cat mobile_device_invitation.xml | jamf-cli classic-mobile-invitations create`,
+  cat mobile_device_invitation.xml | jamf-cli pro classic-mobile-invitations create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -188,10 +188,10 @@ func newClassicMobileInvitationsDeleteCmd(ctx *registry.CLIContext) *cobra.Comma
 		Use:   "delete <id>",
 		Short: "Delete a mobile_device_invitation",
 		Example: `  # Delete a mobile_device_invitation (with confirmation)
-  jamf-cli classic-mobile-invitations delete 1
+  jamf-cli pro classic-mobile-invitations delete 1
 
   # Delete without confirmation prompt
-  jamf-cli classic-mobile-invitations delete 1 --yes`,
+  jamf-cli pro classic-mobile-invitations delete 1 --yes`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_mobile_provisioning_profiles.go
+++ b/internal/commands/pro/generated/classic_mobile_provisioning_profiles.go
@@ -45,10 +45,10 @@ func newClassicMobileProvisioningProfilesListCmd(ctx *registry.CLIContext) *cobr
 		Use:   "list",
 		Short: "List all mobiledeviceprovisioningprofiles",
 		Example: `  # List all mobiledeviceprovisioningprofiles
-  jamf-cli classic-mobile-provisioning-profiles list
+  jamf-cli pro classic-mobile-provisioning-profiles list
 
   # List mobiledeviceprovisioningprofiles and extract IDs
-  jamf-cli classic-mobile-provisioning-profiles list --field id`,
+  jamf-cli pro classic-mobile-provisioning-profiles list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/mobiledeviceprovisioningprofiles", nil)
@@ -98,13 +98,13 @@ func newClassicMobileProvisioningProfilesGetCmd(ctx *registry.CLIContext) *cobra
 		Use:   "get [<id>]",
 		Short: "Get a mobile_device_provisioning_profile by ID",
 		Example: `  # Get a mobile_device_provisioning_profile by ID
-  jamf-cli classic-mobile-provisioning-profiles get 1
+  jamf-cli pro classic-mobile-provisioning-profiles get 1
 
   # Get a mobile_device_provisioning_profile by name
-  jamf-cli classic-mobile-provisioning-profiles get --name "Example"
+  jamf-cli pro classic-mobile-provisioning-profiles get --name "Example"
 
   # Get a mobile_device_provisioning_profile and output as YAML
-  jamf-cli classic-mobile-provisioning-profiles get 1 -o yaml`,
+  jamf-cli pro classic-mobile-provisioning-profiles get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicMobileProvisioningProfilesCreateCmd(ctx *registry.CLIContext) *co
 		Short: "Create a mobile_device_provisioning_profile",
 		Long:  "Create a new mobile_device_provisioning_profile. Reads XML body from stdin.",
 		Example: `  # Create a mobile_device_provisioning_profile from XML
-  cat mobile_device_provisioning_profile.xml | jamf-cli classic-mobile-provisioning-profiles create`,
+  cat mobile_device_provisioning_profile.xml | jamf-cli pro classic-mobile-provisioning-profiles create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicMobileProvisioningProfilesUpdateCmd(ctx *registry.CLIContext) *co
 		Short: "Update a mobile_device_provisioning_profile",
 		Long:  "Update an existing mobile_device_provisioning_profile by ID. Reads XML body from stdin.",
 		Example: `  # Update a mobile_device_provisioning_profile from XML
-  cat mobile_device_provisioning_profile.xml | jamf-cli classic-mobile-provisioning-profiles update 1`,
+  cat mobile_device_provisioning_profile.xml | jamf-cli pro classic-mobile-provisioning-profiles update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicMobileProvisioningProfilesDeleteCmd(ctx *registry.CLIContext) *co
 		Use:   "delete [<id>]",
 		Short: "Delete a mobile_device_provisioning_profile",
 		Example: `  # Delete a mobile_device_provisioning_profile (with confirmation)
-  jamf-cli classic-mobile-provisioning-profiles delete 1
+  jamf-cli pro classic-mobile-provisioning-profiles delete 1
 
   # Delete by name
-  jamf-cli classic-mobile-provisioning-profiles delete --name "Example" --yes
+  jamf-cli pro classic-mobile-provisioning-profiles delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-mobile-provisioning-profiles delete 1 --yes`,
+  jamf-cli pro classic-mobile-provisioning-profiles delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a mobile_device_provisioning_profile from an XML file
-  jamf-cli classic-mobile-provisioning-profiles apply --from-file mobile_device_provisioning_profile.xml
+  jamf-cli pro classic-mobile-provisioning-profiles apply --from-file mobile_device_provisioning_profile.xml
 
   # Apply from stdin
-  cat mobile_device_provisioning_profile.xml | jamf-cli classic-mobile-provisioning-profiles apply
+  cat mobile_device_provisioning_profile.xml | jamf-cli pro classic-mobile-provisioning-profiles apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-mobile-provisioning-profiles apply --from-file mobile_device_provisioning_profile.xml --yes`,
+  jamf-cli pro classic-mobile-provisioning-profiles apply --from-file mobile_device_provisioning_profile.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_network_segments.go
+++ b/internal/commands/pro/generated/classic_network_segments.go
@@ -45,10 +45,10 @@ func newClassicNetworkSegmentsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all networksegments",
 		Example: `  # List all networksegments
-  jamf-cli classic-network-segments list
+  jamf-cli pro classic-network-segments list
 
   # List networksegments and extract IDs
-  jamf-cli classic-network-segments list --field id`,
+  jamf-cli pro classic-network-segments list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/networksegments", nil)
@@ -98,13 +98,13 @@ func newClassicNetworkSegmentsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a network_segment by ID",
 		Example: `  # Get a network_segment by ID
-  jamf-cli classic-network-segments get 1
+  jamf-cli pro classic-network-segments get 1
 
   # Get a network_segment by name
-  jamf-cli classic-network-segments get --name "Example"
+  jamf-cli pro classic-network-segments get --name "Example"
 
   # Get a network_segment and output as YAML
-  jamf-cli classic-network-segments get 1 -o yaml`,
+  jamf-cli pro classic-network-segments get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicNetworkSegmentsCreateCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Create a network_segment",
 		Long:  "Create a new network_segment. Reads XML body from stdin.",
 		Example: `  # Create a network_segment from XML
-  cat network_segment.xml | jamf-cli classic-network-segments create`,
+  cat network_segment.xml | jamf-cli pro classic-network-segments create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicNetworkSegmentsUpdateCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Update a network_segment",
 		Long:  "Update an existing network_segment by ID. Reads XML body from stdin.",
 		Example: `  # Update a network_segment from XML
-  cat network_segment.xml | jamf-cli classic-network-segments update 1`,
+  cat network_segment.xml | jamf-cli pro classic-network-segments update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicNetworkSegmentsDeleteCmd(ctx *registry.CLIContext) *cobra.Command
 		Use:   "delete [<id>]",
 		Short: "Delete a network_segment",
 		Example: `  # Delete a network_segment (with confirmation)
-  jamf-cli classic-network-segments delete 1
+  jamf-cli pro classic-network-segments delete 1
 
   # Delete by name
-  jamf-cli classic-network-segments delete --name "Example" --yes
+  jamf-cli pro classic-network-segments delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-network-segments delete 1 --yes`,
+  jamf-cli pro classic-network-segments delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a network_segment from an XML file
-  jamf-cli classic-network-segments apply --from-file network_segment.xml
+  jamf-cli pro classic-network-segments apply --from-file network_segment.xml
 
   # Apply from stdin
-  cat network_segment.xml | jamf-cli classic-network-segments apply
+  cat network_segment.xml | jamf-cli pro classic-network-segments apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-network-segments apply --from-file network_segment.xml --yes`,
+  jamf-cli pro classic-network-segments apply --from-file network_segment.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_packages.go
+++ b/internal/commands/pro/generated/classic_packages.go
@@ -45,10 +45,10 @@ func newClassicPackagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all packages",
 		Example: `  # List all packages
-  jamf-cli classic-packages list
+  jamf-cli pro classic-packages list
 
   # List packages and extract IDs
-  jamf-cli classic-packages list --field id`,
+  jamf-cli pro classic-packages list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/packages", nil)
@@ -98,13 +98,13 @@ func newClassicPackagesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a package by ID",
 		Example: `  # Get a package by ID
-  jamf-cli classic-packages get 1
+  jamf-cli pro classic-packages get 1
 
   # Get a package by name
-  jamf-cli classic-packages get --name "Example"
+  jamf-cli pro classic-packages get --name "Example"
 
   # Get a package and output as YAML
-  jamf-cli classic-packages get 1 -o yaml`,
+  jamf-cli pro classic-packages get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicPackagesCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a package",
 		Long:  "Create a new package. Reads XML body from stdin.",
 		Example: `  # Create a package from XML
-  cat package.xml | jamf-cli classic-packages create`,
+  cat package.xml | jamf-cli pro classic-packages create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicPackagesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a package",
 		Long:  "Update an existing package by ID. Reads XML body from stdin.",
 		Example: `  # Update a package from XML
-  cat package.xml | jamf-cli classic-packages update 1`,
+  cat package.xml | jamf-cli pro classic-packages update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicPackagesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete [<id>]",
 		Short: "Delete a package",
 		Example: `  # Delete a package (with confirmation)
-  jamf-cli classic-packages delete 1
+  jamf-cli pro classic-packages delete 1
 
   # Delete by name
-  jamf-cli classic-packages delete --name "Example" --yes
+  jamf-cli pro classic-packages delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-packages delete 1 --yes`,
+  jamf-cli pro classic-packages delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a package from an XML file
-  jamf-cli classic-packages apply --from-file package.xml
+  jamf-cli pro classic-packages apply --from-file package.xml
 
   # Apply from stdin
-  cat package.xml | jamf-cli classic-packages apply
+  cat package.xml | jamf-cli pro classic-packages apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-packages apply --from-file package.xml --yes`,
+  jamf-cli pro classic-packages apply --from-file package.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_patch_available_titles.go
+++ b/internal/commands/pro/generated/classic_patch_available_titles.go
@@ -32,10 +32,10 @@ func newClassicPatchAvailableTitlesGetCmd(ctx *registry.CLIContext) *cobra.Comma
 		Use:   "get <id>",
 		Short: "Get a patch_available_title by ID",
 		Example: `  # Get a patch_available_title by ID
-  jamf-cli classic-patch-available-titles get 1
+  jamf-cli pro classic-patch-available-titles get 1
 
   # Get a patch_available_title and output as YAML
-  jamf-cli classic-patch-available-titles get 1 -o yaml`,
+  jamf-cli pro classic-patch-available-titles get 1 -o yaml`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_patch_external_sources.go
+++ b/internal/commands/pro/generated/classic_patch_external_sources.go
@@ -45,10 +45,10 @@ func newClassicPatchExternalSourcesListCmd(ctx *registry.CLIContext) *cobra.Comm
 		Use:   "list",
 		Short: "List all patchexternalsources",
 		Example: `  # List all patchexternalsources
-  jamf-cli classic-patch-external-sources list
+  jamf-cli pro classic-patch-external-sources list
 
   # List patchexternalsources and extract IDs
-  jamf-cli classic-patch-external-sources list --field id`,
+  jamf-cli pro classic-patch-external-sources list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/patchexternalsources", nil)
@@ -98,13 +98,13 @@ func newClassicPatchExternalSourcesGetCmd(ctx *registry.CLIContext) *cobra.Comma
 		Use:   "get [<id>]",
 		Short: "Get a patch_external_source by ID",
 		Example: `  # Get a patch_external_source by ID
-  jamf-cli classic-patch-external-sources get 1
+  jamf-cli pro classic-patch-external-sources get 1
 
   # Get a patch_external_source by name
-  jamf-cli classic-patch-external-sources get --name "Example"
+  jamf-cli pro classic-patch-external-sources get --name "Example"
 
   # Get a patch_external_source and output as YAML
-  jamf-cli classic-patch-external-sources get 1 -o yaml`,
+  jamf-cli pro classic-patch-external-sources get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicPatchExternalSourcesCreateCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Create a patch_external_source",
 		Long:  "Create a new patch_external_source. Reads XML body from stdin.",
 		Example: `  # Create a patch_external_source from XML
-  cat patch_external_source.xml | jamf-cli classic-patch-external-sources create`,
+  cat patch_external_source.xml | jamf-cli pro classic-patch-external-sources create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicPatchExternalSourcesUpdateCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Update a patch_external_source",
 		Long:  "Update an existing patch_external_source by ID. Reads XML body from stdin.",
 		Example: `  # Update a patch_external_source from XML
-  cat patch_external_source.xml | jamf-cli classic-patch-external-sources update 1`,
+  cat patch_external_source.xml | jamf-cli pro classic-patch-external-sources update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicPatchExternalSourcesDeleteCmd(ctx *registry.CLIContext) *cobra.Co
 		Use:   "delete [<id>]",
 		Short: "Delete a patch_external_source",
 		Example: `  # Delete a patch_external_source (with confirmation)
-  jamf-cli classic-patch-external-sources delete 1
+  jamf-cli pro classic-patch-external-sources delete 1
 
   # Delete by name
-  jamf-cli classic-patch-external-sources delete --name "Example" --yes
+  jamf-cli pro classic-patch-external-sources delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-patch-external-sources delete 1 --yes`,
+  jamf-cli pro classic-patch-external-sources delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a patch_external_source from an XML file
-  jamf-cli classic-patch-external-sources apply --from-file patch_external_source.xml
+  jamf-cli pro classic-patch-external-sources apply --from-file patch_external_source.xml
 
   # Apply from stdin
-  cat patch_external_source.xml | jamf-cli classic-patch-external-sources apply
+  cat patch_external_source.xml | jamf-cli pro classic-patch-external-sources apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-patch-external-sources apply --from-file patch_external_source.xml --yes`,
+  jamf-cli pro classic-patch-external-sources apply --from-file patch_external_source.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_patch_internal_sources.go
+++ b/internal/commands/pro/generated/classic_patch_internal_sources.go
@@ -33,10 +33,10 @@ func newClassicPatchInternalSourcesListCmd(ctx *registry.CLIContext) *cobra.Comm
 		Use:   "list",
 		Short: "List all patchinternalsources",
 		Example: `  # List all patchinternalsources
-  jamf-cli classic-patch-internal-sources list
+  jamf-cli pro classic-patch-internal-sources list
 
   # List patchinternalsources and extract IDs
-  jamf-cli classic-patch-internal-sources list --field id`,
+  jamf-cli pro classic-patch-internal-sources list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/patchinternalsources", nil)
@@ -86,13 +86,13 @@ func newClassicPatchInternalSourcesGetCmd(ctx *registry.CLIContext) *cobra.Comma
 		Use:   "get [<id>]",
 		Short: "Get a patch_internal_source by ID",
 		Example: `  # Get a patch_internal_source by ID
-  jamf-cli classic-patch-internal-sources get 1
+  jamf-cli pro classic-patch-internal-sources get 1
 
   # Get a patch_internal_source by name
-  jamf-cli classic-patch-internal-sources get --name "Example"
+  jamf-cli pro classic-patch-internal-sources get --name "Example"
 
   # Get a patch_internal_source and output as YAML
-  jamf-cli classic-patch-internal-sources get 1 -o yaml`,
+  jamf-cli pro classic-patch-internal-sources get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_patch_policies.go
+++ b/internal/commands/pro/generated/classic_patch_policies.go
@@ -42,10 +42,10 @@ func newClassicPatchPoliciesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all patchpolicies",
 		Example: `  # List all patchpolicies
-  jamf-cli classic-patch-policies list
+  jamf-cli pro classic-patch-policies list
 
   # List patchpolicies and extract IDs
-  jamf-cli classic-patch-policies list --field id`,
+  jamf-cli pro classic-patch-policies list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/patchpolicies", nil)
@@ -92,10 +92,10 @@ func newClassicPatchPoliciesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get <id>",
 		Short: "Get a patch_policy by ID",
 		Example: `  # Get a patch_policy by ID
-  jamf-cli classic-patch-policies get 1
+  jamf-cli pro classic-patch-policies get 1
 
   # Get a patch_policy and output as YAML
-  jamf-cli classic-patch-policies get 1 -o yaml`,
+  jamf-cli pro classic-patch-policies get 1 -o yaml`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -141,7 +141,7 @@ func newClassicPatchPoliciesCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a patch_policy",
 		Long:  "Create a new patch_policy. Reads XML body from stdin.",
 		Example: `  # Create a patch_policy from XML
-  cat patch_policy.xml | jamf-cli classic-patch-policies create`,
+  cat patch_policy.xml | jamf-cli pro classic-patch-policies create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -173,7 +173,7 @@ func newClassicPatchPoliciesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a patch_policy",
 		Long:  "Update an existing patch_policy by ID. Reads XML body from stdin.",
 		Example: `  # Update a patch_policy from XML
-  cat patch_policy.xml | jamf-cli classic-patch-policies update 1`,
+  cat patch_policy.xml | jamf-cli pro classic-patch-policies update 1`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -211,10 +211,10 @@ func newClassicPatchPoliciesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete <id>",
 		Short: "Delete a patch_policy",
 		Example: `  # Delete a patch_policy (with confirmation)
-  jamf-cli classic-patch-policies delete 1
+  jamf-cli pro classic-patch-policies delete 1
 
   # Delete without confirmation prompt
-  jamf-cli classic-patch-policies delete 1 --yes`,
+  jamf-cli pro classic-patch-policies delete 1 --yes`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_patch_reports.go
+++ b/internal/commands/pro/generated/classic_patch_reports.go
@@ -32,10 +32,10 @@ func newClassicPatchReportsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get <id>",
 		Short: "Get a patch_report by ID",
 		Example: `  # Get a patch_report by ID
-  jamf-cli classic-patch-reports get 1
+  jamf-cli pro classic-patch-reports get 1
 
   # Get a patch_report and output as YAML
-  jamf-cli classic-patch-reports get 1 -o yaml`,
+  jamf-cli pro classic-patch-reports get 1 -o yaml`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_patch_titles.go
+++ b/internal/commands/pro/generated/classic_patch_titles.go
@@ -45,10 +45,10 @@ func newClassicPatchTitlesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all patchsoftwaretitles",
 		Example: `  # List all patchsoftwaretitles
-  jamf-cli classic-patch-titles list
+  jamf-cli pro classic-patch-titles list
 
   # List patchsoftwaretitles and extract IDs
-  jamf-cli classic-patch-titles list --field id`,
+  jamf-cli pro classic-patch-titles list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/patchsoftwaretitles", nil)
@@ -98,13 +98,13 @@ func newClassicPatchTitlesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a patch_software_title by ID",
 		Example: `  # Get a patch_software_title by ID
-  jamf-cli classic-patch-titles get 1
+  jamf-cli pro classic-patch-titles get 1
 
   # Get a patch_software_title by name
-  jamf-cli classic-patch-titles get --name "Example"
+  jamf-cli pro classic-patch-titles get --name "Example"
 
   # Get a patch_software_title and output as YAML
-  jamf-cli classic-patch-titles get 1 -o yaml`,
+  jamf-cli pro classic-patch-titles get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicPatchTitlesCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a patch_software_title",
 		Long:  "Create a new patch_software_title. Reads XML body from stdin.",
 		Example: `  # Create a patch_software_title from XML
-  cat patch_software_title.xml | jamf-cli classic-patch-titles create`,
+  cat patch_software_title.xml | jamf-cli pro classic-patch-titles create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicPatchTitlesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a patch_software_title",
 		Long:  "Update an existing patch_software_title by ID. Reads XML body from stdin.",
 		Example: `  # Update a patch_software_title from XML
-  cat patch_software_title.xml | jamf-cli classic-patch-titles update 1`,
+  cat patch_software_title.xml | jamf-cli pro classic-patch-titles update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicPatchTitlesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete [<id>]",
 		Short: "Delete a patch_software_title",
 		Example: `  # Delete a patch_software_title (with confirmation)
-  jamf-cli classic-patch-titles delete 1
+  jamf-cli pro classic-patch-titles delete 1
 
   # Delete by name
-  jamf-cli classic-patch-titles delete --name "Example" --yes
+  jamf-cli pro classic-patch-titles delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-patch-titles delete 1 --yes`,
+  jamf-cli pro classic-patch-titles delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a patch_software_title from an XML file
-  jamf-cli classic-patch-titles apply --from-file patch_software_title.xml
+  jamf-cli pro classic-patch-titles apply --from-file patch_software_title.xml
 
   # Apply from stdin
-  cat patch_software_title.xml | jamf-cli classic-patch-titles apply
+  cat patch_software_title.xml | jamf-cli pro classic-patch-titles apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-patch-titles apply --from-file patch_software_title.xml --yes`,
+  jamf-cli pro classic-patch-titles apply --from-file patch_software_title.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_policies.go
+++ b/internal/commands/pro/generated/classic_policies.go
@@ -51,10 +51,10 @@ func newClassicPoliciesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all policies",
 		Example: `  # List all policies
-  jamf-cli classic-policies list
+  jamf-cli pro classic-policies list
 
   # List policies and extract IDs
-  jamf-cli classic-policies list --field id`,
+  jamf-cli pro classic-policies list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/policies", nil)
@@ -104,13 +104,13 @@ func newClassicPoliciesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a policy by ID",
 		Example: `  # Get a policy by ID
-  jamf-cli classic-policies get 1
+  jamf-cli pro classic-policies get 1
 
   # Get a policy by name
-  jamf-cli classic-policies get --name "Example"
+  jamf-cli pro classic-policies get --name "Example"
 
   # Get a policy and output as YAML
-  jamf-cli classic-policies get 1 -o yaml`,
+  jamf-cli pro classic-policies get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -167,7 +167,7 @@ func newClassicPoliciesCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a policy",
 		Long:  "Create a new policy. Reads XML body from stdin.",
 		Example: `  # Create a policy from XML
-  cat policy.xml | jamf-cli classic-policies create`,
+  cat policy.xml | jamf-cli pro classic-policies create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -200,7 +200,7 @@ func newClassicPoliciesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a policy",
 		Long:  "Update an existing policy by ID. Reads XML body from stdin.",
 		Example: `  # Update a policy from XML
-  cat policy.xml | jamf-cli classic-policies update 1`,
+  cat policy.xml | jamf-cli pro classic-policies update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -248,13 +248,13 @@ func newClassicPoliciesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete [<id>]",
 		Short: "Delete a policy",
 		Example: `  # Delete a policy (with confirmation)
-  jamf-cli classic-policies delete 1
+  jamf-cli pro classic-policies delete 1
 
   # Delete by name
-  jamf-cli classic-policies delete --name "Example" --yes
+  jamf-cli pro classic-policies delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-policies delete 1 --yes`,
+  jamf-cli pro classic-policies delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -337,13 +337,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a policy from an XML file
-  jamf-cli classic-policies apply --from-file policy.xml
+  jamf-cli pro classic-policies apply --from-file policy.xml
 
   # Apply from stdin
-  cat policy.xml | jamf-cli classic-policies apply
+  cat policy.xml | jamf-cli pro classic-policies apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-policies apply --from-file policy.xml --yes`,
+  jamf-cli pro classic-policies apply --from-file policy.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_printers.go
+++ b/internal/commands/pro/generated/classic_printers.go
@@ -45,10 +45,10 @@ func newClassicPrintersListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all printers",
 		Example: `  # List all printers
-  jamf-cli classic-printers list
+  jamf-cli pro classic-printers list
 
   # List printers and extract IDs
-  jamf-cli classic-printers list --field id`,
+  jamf-cli pro classic-printers list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/printers", nil)
@@ -98,13 +98,13 @@ func newClassicPrintersGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a printer by ID",
 		Example: `  # Get a printer by ID
-  jamf-cli classic-printers get 1
+  jamf-cli pro classic-printers get 1
 
   # Get a printer by name
-  jamf-cli classic-printers get --name "Example"
+  jamf-cli pro classic-printers get --name "Example"
 
   # Get a printer and output as YAML
-  jamf-cli classic-printers get 1 -o yaml`,
+  jamf-cli pro classic-printers get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicPrintersCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a printer",
 		Long:  "Create a new printer. Reads XML body from stdin.",
 		Example: `  # Create a printer from XML
-  cat printer.xml | jamf-cli classic-printers create`,
+  cat printer.xml | jamf-cli pro classic-printers create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicPrintersUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a printer",
 		Long:  "Update an existing printer by ID. Reads XML body from stdin.",
 		Example: `  # Update a printer from XML
-  cat printer.xml | jamf-cli classic-printers update 1`,
+  cat printer.xml | jamf-cli pro classic-printers update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicPrintersDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete [<id>]",
 		Short: "Delete a printer",
 		Example: `  # Delete a printer (with confirmation)
-  jamf-cli classic-printers delete 1
+  jamf-cli pro classic-printers delete 1
 
   # Delete by name
-  jamf-cli classic-printers delete --name "Example" --yes
+  jamf-cli pro classic-printers delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-printers delete 1 --yes`,
+  jamf-cli pro classic-printers delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a printer from an XML file
-  jamf-cli classic-printers apply --from-file printer.xml
+  jamf-cli pro classic-printers apply --from-file printer.xml
 
   # Apply from stdin
-  cat printer.xml | jamf-cli classic-printers apply
+  cat printer.xml | jamf-cli pro classic-printers apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-printers apply --from-file printer.xml --yes`,
+  jamf-cli pro classic-printers apply --from-file printer.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_removable_mac_addresses.go
+++ b/internal/commands/pro/generated/classic_removable_mac_addresses.go
@@ -45,10 +45,10 @@ func newClassicRemovableMacAddressesListCmd(ctx *registry.CLIContext) *cobra.Com
 		Use:   "list",
 		Short: "List all removablemacaddresses",
 		Example: `  # List all removablemacaddresses
-  jamf-cli classic-removable-mac-addresses list
+  jamf-cli pro classic-removable-mac-addresses list
 
   # List removablemacaddresses and extract IDs
-  jamf-cli classic-removable-mac-addresses list --field id`,
+  jamf-cli pro classic-removable-mac-addresses list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/removablemacaddresses", nil)
@@ -98,13 +98,13 @@ func newClassicRemovableMacAddressesGetCmd(ctx *registry.CLIContext) *cobra.Comm
 		Use:   "get [<id>]",
 		Short: "Get a removable_mac_address by ID",
 		Example: `  # Get a removable_mac_address by ID
-  jamf-cli classic-removable-mac-addresses get 1
+  jamf-cli pro classic-removable-mac-addresses get 1
 
   # Get a removable_mac_address by name
-  jamf-cli classic-removable-mac-addresses get --name "Example"
+  jamf-cli pro classic-removable-mac-addresses get --name "Example"
 
   # Get a removable_mac_address and output as YAML
-  jamf-cli classic-removable-mac-addresses get 1 -o yaml`,
+  jamf-cli pro classic-removable-mac-addresses get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicRemovableMacAddressesCreateCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Create a removable_mac_address",
 		Long:  "Create a new removable_mac_address. Reads XML body from stdin.",
 		Example: `  # Create a removable_mac_address from XML
-  cat removable_mac_address.xml | jamf-cli classic-removable-mac-addresses create`,
+  cat removable_mac_address.xml | jamf-cli pro classic-removable-mac-addresses create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicRemovableMacAddressesUpdateCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Update a removable_mac_address",
 		Long:  "Update an existing removable_mac_address by ID. Reads XML body from stdin.",
 		Example: `  # Update a removable_mac_address from XML
-  cat removable_mac_address.xml | jamf-cli classic-removable-mac-addresses update 1`,
+  cat removable_mac_address.xml | jamf-cli pro classic-removable-mac-addresses update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicRemovableMacAddressesDeleteCmd(ctx *registry.CLIContext) *cobra.C
 		Use:   "delete [<id>]",
 		Short: "Delete a removable_mac_address",
 		Example: `  # Delete a removable_mac_address (with confirmation)
-  jamf-cli classic-removable-mac-addresses delete 1
+  jamf-cli pro classic-removable-mac-addresses delete 1
 
   # Delete by name
-  jamf-cli classic-removable-mac-addresses delete --name "Example" --yes
+  jamf-cli pro classic-removable-mac-addresses delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-removable-mac-addresses delete 1 --yes`,
+  jamf-cli pro classic-removable-mac-addresses delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a removable_mac_address from an XML file
-  jamf-cli classic-removable-mac-addresses apply --from-file removable_mac_address.xml
+  jamf-cli pro classic-removable-mac-addresses apply --from-file removable_mac_address.xml
 
   # Apply from stdin
-  cat removable_mac_address.xml | jamf-cli classic-removable-mac-addresses apply
+  cat removable_mac_address.xml | jamf-cli pro classic-removable-mac-addresses apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-removable-mac-addresses apply --from-file removable_mac_address.xml --yes`,
+  jamf-cli pro classic-removable-mac-addresses apply --from-file removable_mac_address.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_restricted_software.go
+++ b/internal/commands/pro/generated/classic_restricted_software.go
@@ -51,10 +51,10 @@ func newClassicRestrictedSoftwareListCmd(ctx *registry.CLIContext) *cobra.Comman
 		Use:   "list",
 		Short: "List all restrictedsoftware",
 		Example: `  # List all restrictedsoftware
-  jamf-cli classic-restricted-software list
+  jamf-cli pro classic-restricted-software list
 
   # List restrictedsoftware and extract IDs
-  jamf-cli classic-restricted-software list --field id`,
+  jamf-cli pro classic-restricted-software list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/restrictedsoftware", nil)
@@ -104,13 +104,13 @@ func newClassicRestrictedSoftwareGetCmd(ctx *registry.CLIContext) *cobra.Command
 		Use:   "get [<id>]",
 		Short: "Get a restricted_software by ID",
 		Example: `  # Get a restricted_software by ID
-  jamf-cli classic-restricted-software get 1
+  jamf-cli pro classic-restricted-software get 1
 
   # Get a restricted_software by name
-  jamf-cli classic-restricted-software get --name "Example"
+  jamf-cli pro classic-restricted-software get --name "Example"
 
   # Get a restricted_software and output as YAML
-  jamf-cli classic-restricted-software get 1 -o yaml`,
+  jamf-cli pro classic-restricted-software get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -167,7 +167,7 @@ func newClassicRestrictedSoftwareCreateCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Create a restricted_software",
 		Long:  "Create a new restricted_software. Reads XML body from stdin.",
 		Example: `  # Create a restricted_software from XML
-  cat restricted_software.xml | jamf-cli classic-restricted-software create`,
+  cat restricted_software.xml | jamf-cli pro classic-restricted-software create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -200,7 +200,7 @@ func newClassicRestrictedSoftwareUpdateCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Update a restricted_software",
 		Long:  "Update an existing restricted_software by ID. Reads XML body from stdin.",
 		Example: `  # Update a restricted_software from XML
-  cat restricted_software.xml | jamf-cli classic-restricted-software update 1`,
+  cat restricted_software.xml | jamf-cli pro classic-restricted-software update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -248,13 +248,13 @@ func newClassicRestrictedSoftwareDeleteCmd(ctx *registry.CLIContext) *cobra.Comm
 		Use:   "delete [<id>]",
 		Short: "Delete a restricted_software",
 		Example: `  # Delete a restricted_software (with confirmation)
-  jamf-cli classic-restricted-software delete 1
+  jamf-cli pro classic-restricted-software delete 1
 
   # Delete by name
-  jamf-cli classic-restricted-software delete --name "Example" --yes
+  jamf-cli pro classic-restricted-software delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-restricted-software delete 1 --yes`,
+  jamf-cli pro classic-restricted-software delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -337,13 +337,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a restricted_software from an XML file
-  jamf-cli classic-restricted-software apply --from-file restricted_software.xml
+  jamf-cli pro classic-restricted-software apply --from-file restricted_software.xml
 
   # Apply from stdin
-  cat restricted_software.xml | jamf-cli classic-restricted-software apply
+  cat restricted_software.xml | jamf-cli pro classic-restricted-software apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-restricted-software apply --from-file restricted_software.xml --yes`,
+  jamf-cli pro classic-restricted-software apply --from-file restricted_software.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_smtp_server.go
+++ b/internal/commands/pro/generated/classic_smtp_server.go
@@ -35,10 +35,10 @@ func newClassicSmtpServerGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get <id>",
 		Short: "Get a smtp_server by ID",
 		Example: `  # Get a smtp_server by ID
-  jamf-cli classic-smtp-server get 1
+  jamf-cli pro classic-smtp-server get 1
 
   # Get a smtp_server and output as YAML
-  jamf-cli classic-smtp-server get 1 -o yaml`,
+  jamf-cli pro classic-smtp-server get 1 -o yaml`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -85,7 +85,7 @@ func newClassicSmtpServerUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a smtp_server",
 		Long:  "Update an existing smtp_server by ID. Reads XML body from stdin.",
 		Example: `  # Update a smtp_server from XML
-  cat smtp_server.xml | jamf-cli classic-smtp-server update 1`,
+  cat smtp_server.xml | jamf-cli pro classic-smtp-server update 1`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_software_update_servers.go
+++ b/internal/commands/pro/generated/classic_software_update_servers.go
@@ -45,10 +45,10 @@ func newClassicSoftwareUpdateServersListCmd(ctx *registry.CLIContext) *cobra.Com
 		Use:   "list",
 		Short: "List all softwareupdateservers",
 		Example: `  # List all softwareupdateservers
-  jamf-cli classic-software-update-servers list
+  jamf-cli pro classic-software-update-servers list
 
   # List softwareupdateservers and extract IDs
-  jamf-cli classic-software-update-servers list --field id`,
+  jamf-cli pro classic-software-update-servers list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/softwareupdateservers", nil)
@@ -98,13 +98,13 @@ func newClassicSoftwareUpdateServersGetCmd(ctx *registry.CLIContext) *cobra.Comm
 		Use:   "get [<id>]",
 		Short: "Get a software_update_server by ID",
 		Example: `  # Get a software_update_server by ID
-  jamf-cli classic-software-update-servers get 1
+  jamf-cli pro classic-software-update-servers get 1
 
   # Get a software_update_server by name
-  jamf-cli classic-software-update-servers get --name "Example"
+  jamf-cli pro classic-software-update-servers get --name "Example"
 
   # Get a software_update_server and output as YAML
-  jamf-cli classic-software-update-servers get 1 -o yaml`,
+  jamf-cli pro classic-software-update-servers get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicSoftwareUpdateServersCreateCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Create a software_update_server",
 		Long:  "Create a new software_update_server. Reads XML body from stdin.",
 		Example: `  # Create a software_update_server from XML
-  cat software_update_server.xml | jamf-cli classic-software-update-servers create`,
+  cat software_update_server.xml | jamf-cli pro classic-software-update-servers create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicSoftwareUpdateServersUpdateCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Update a software_update_server",
 		Long:  "Update an existing software_update_server by ID. Reads XML body from stdin.",
 		Example: `  # Update a software_update_server from XML
-  cat software_update_server.xml | jamf-cli classic-software-update-servers update 1`,
+  cat software_update_server.xml | jamf-cli pro classic-software-update-servers update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicSoftwareUpdateServersDeleteCmd(ctx *registry.CLIContext) *cobra.C
 		Use:   "delete [<id>]",
 		Short: "Delete a software_update_server",
 		Example: `  # Delete a software_update_server (with confirmation)
-  jamf-cli classic-software-update-servers delete 1
+  jamf-cli pro classic-software-update-servers delete 1
 
   # Delete by name
-  jamf-cli classic-software-update-servers delete --name "Example" --yes
+  jamf-cli pro classic-software-update-servers delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-software-update-servers delete 1 --yes`,
+  jamf-cli pro classic-software-update-servers delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a software_update_server from an XML file
-  jamf-cli classic-software-update-servers apply --from-file software_update_server.xml
+  jamf-cli pro classic-software-update-servers apply --from-file software_update_server.xml
 
   # Apply from stdin
-  cat software_update_server.xml | jamf-cli classic-software-update-servers apply
+  cat software_update_server.xml | jamf-cli pro classic-software-update-servers apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-software-update-servers apply --from-file software_update_server.xml --yes`,
+  jamf-cli pro classic-software-update-servers apply --from-file software_update_server.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_user_ext_attrs.go
+++ b/internal/commands/pro/generated/classic_user_ext_attrs.go
@@ -45,10 +45,10 @@ func newClassicUserExtAttrsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all userextensionattributes",
 		Example: `  # List all userextensionattributes
-  jamf-cli classic-user-ext-attrs list
+  jamf-cli pro classic-user-ext-attrs list
 
   # List userextensionattributes and extract IDs
-  jamf-cli classic-user-ext-attrs list --field id`,
+  jamf-cli pro classic-user-ext-attrs list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/userextensionattributes", nil)
@@ -98,13 +98,13 @@ func newClassicUserExtAttrsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a user_extension_attribute by ID",
 		Example: `  # Get a user_extension_attribute by ID
-  jamf-cli classic-user-ext-attrs get 1
+  jamf-cli pro classic-user-ext-attrs get 1
 
   # Get a user_extension_attribute by name
-  jamf-cli classic-user-ext-attrs get --name "Example"
+  jamf-cli pro classic-user-ext-attrs get --name "Example"
 
   # Get a user_extension_attribute and output as YAML
-  jamf-cli classic-user-ext-attrs get 1 -o yaml`,
+  jamf-cli pro classic-user-ext-attrs get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicUserExtAttrsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a user_extension_attribute",
 		Long:  "Create a new user_extension_attribute. Reads XML body from stdin.",
 		Example: `  # Create a user_extension_attribute from XML
-  cat user_extension_attribute.xml | jamf-cli classic-user-ext-attrs create`,
+  cat user_extension_attribute.xml | jamf-cli pro classic-user-ext-attrs create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicUserExtAttrsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a user_extension_attribute",
 		Long:  "Update an existing user_extension_attribute by ID. Reads XML body from stdin.",
 		Example: `  # Update a user_extension_attribute from XML
-  cat user_extension_attribute.xml | jamf-cli classic-user-ext-attrs update 1`,
+  cat user_extension_attribute.xml | jamf-cli pro classic-user-ext-attrs update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicUserExtAttrsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete [<id>]",
 		Short: "Delete a user_extension_attribute",
 		Example: `  # Delete a user_extension_attribute (with confirmation)
-  jamf-cli classic-user-ext-attrs delete 1
+  jamf-cli pro classic-user-ext-attrs delete 1
 
   # Delete by name
-  jamf-cli classic-user-ext-attrs delete --name "Example" --yes
+  jamf-cli pro classic-user-ext-attrs delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-user-ext-attrs delete 1 --yes`,
+  jamf-cli pro classic-user-ext-attrs delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a user_extension_attribute from an XML file
-  jamf-cli classic-user-ext-attrs apply --from-file user_extension_attribute.xml
+  jamf-cli pro classic-user-ext-attrs apply --from-file user_extension_attribute.xml
 
   # Apply from stdin
-  cat user_extension_attribute.xml | jamf-cli classic-user-ext-attrs apply
+  cat user_extension_attribute.xml | jamf-cli pro classic-user-ext-attrs apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-user-ext-attrs apply --from-file user_extension_attribute.xml --yes`,
+  jamf-cli pro classic-user-ext-attrs apply --from-file user_extension_attribute.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_vpp_accounts.go
+++ b/internal/commands/pro/generated/classic_vpp_accounts.go
@@ -42,10 +42,10 @@ func newClassicVppAccountsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all vppaccounts",
 		Example: `  # List all vppaccounts
-  jamf-cli classic-vpp-accounts list
+  jamf-cli pro classic-vpp-accounts list
 
   # List vppaccounts and extract IDs
-  jamf-cli classic-vpp-accounts list --field id`,
+  jamf-cli pro classic-vpp-accounts list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/vppaccounts", nil)
@@ -92,10 +92,10 @@ func newClassicVppAccountsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get <id>",
 		Short: "Get a vpp_account by ID",
 		Example: `  # Get a vpp_account by ID
-  jamf-cli classic-vpp-accounts get 1
+  jamf-cli pro classic-vpp-accounts get 1
 
   # Get a vpp_account and output as YAML
-  jamf-cli classic-vpp-accounts get 1 -o yaml`,
+  jamf-cli pro classic-vpp-accounts get 1 -o yaml`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -141,7 +141,7 @@ func newClassicVppAccountsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a vpp_account",
 		Long:  "Create a new vpp_account. Reads XML body from stdin.",
 		Example: `  # Create a vpp_account from XML
-  cat vpp_account.xml | jamf-cli classic-vpp-accounts create`,
+  cat vpp_account.xml | jamf-cli pro classic-vpp-accounts create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -173,7 +173,7 @@ func newClassicVppAccountsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a vpp_account",
 		Long:  "Update an existing vpp_account by ID. Reads XML body from stdin.",
 		Example: `  # Update a vpp_account from XML
-  cat vpp_account.xml | jamf-cli classic-vpp-accounts update 1`,
+  cat vpp_account.xml | jamf-cli pro classic-vpp-accounts update 1`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -211,10 +211,10 @@ func newClassicVppAccountsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete <id>",
 		Short: "Delete a vpp_account",
 		Example: `  # Delete a vpp_account (with confirmation)
-  jamf-cli classic-vpp-accounts delete 1
+  jamf-cli pro classic-vpp-accounts delete 1
 
   # Delete without confirmation prompt
-  jamf-cli classic-vpp-accounts delete 1 --yes`,
+  jamf-cli pro classic-vpp-accounts delete 1 --yes`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_vpp_assignments.go
+++ b/internal/commands/pro/generated/classic_vpp_assignments.go
@@ -42,10 +42,10 @@ func newClassicVppAssignmentsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all vppassignments",
 		Example: `  # List all vppassignments
-  jamf-cli classic-vpp-assignments list
+  jamf-cli pro classic-vpp-assignments list
 
   # List vppassignments and extract IDs
-  jamf-cli classic-vpp-assignments list --field id`,
+  jamf-cli pro classic-vpp-assignments list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/vppassignments", nil)
@@ -92,10 +92,10 @@ func newClassicVppAssignmentsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get <id>",
 		Short: "Get a vpp_assignment by ID",
 		Example: `  # Get a vpp_assignment by ID
-  jamf-cli classic-vpp-assignments get 1
+  jamf-cli pro classic-vpp-assignments get 1
 
   # Get a vpp_assignment and output as YAML
-  jamf-cli classic-vpp-assignments get 1 -o yaml`,
+  jamf-cli pro classic-vpp-assignments get 1 -o yaml`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -141,7 +141,7 @@ func newClassicVppAssignmentsCreateCmd(ctx *registry.CLIContext) *cobra.Command 
 		Short: "Create a vpp_assignment",
 		Long:  "Create a new vpp_assignment. Reads XML body from stdin.",
 		Example: `  # Create a vpp_assignment from XML
-  cat vpp_assignment.xml | jamf-cli classic-vpp-assignments create`,
+  cat vpp_assignment.xml | jamf-cli pro classic-vpp-assignments create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -173,7 +173,7 @@ func newClassicVppAssignmentsUpdateCmd(ctx *registry.CLIContext) *cobra.Command 
 		Short: "Update a vpp_assignment",
 		Long:  "Update an existing vpp_assignment by ID. Reads XML body from stdin.",
 		Example: `  # Update a vpp_assignment from XML
-  cat vpp_assignment.xml | jamf-cli classic-vpp-assignments update 1`,
+  cat vpp_assignment.xml | jamf-cli pro classic-vpp-assignments update 1`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -211,10 +211,10 @@ func newClassicVppAssignmentsDeleteCmd(ctx *registry.CLIContext) *cobra.Command 
 		Use:   "delete <id>",
 		Short: "Delete a vpp_assignment",
 		Example: `  # Delete a vpp_assignment (with confirmation)
-  jamf-cli classic-vpp-assignments delete 1
+  jamf-cli pro classic-vpp-assignments delete 1
 
   # Delete without confirmation prompt
-  jamf-cli classic-vpp-assignments delete 1 --yes`,
+  jamf-cli pro classic-vpp-assignments delete 1 --yes`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_vpp_invitations.go
+++ b/internal/commands/pro/generated/classic_vpp_invitations.go
@@ -40,10 +40,10 @@ func newClassicVppInvitationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all vppinvitations",
 		Example: `  # List all vppinvitations
-  jamf-cli classic-vpp-invitations list
+  jamf-cli pro classic-vpp-invitations list
 
   # List vppinvitations and extract IDs
-  jamf-cli classic-vpp-invitations list --field id`,
+  jamf-cli pro classic-vpp-invitations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/vppinvitations", nil)
@@ -90,10 +90,10 @@ func newClassicVppInvitationsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get <id>",
 		Short: "Get a vpp_invitation by ID",
 		Example: `  # Get a vpp_invitation by ID
-  jamf-cli classic-vpp-invitations get 1
+  jamf-cli pro classic-vpp-invitations get 1
 
   # Get a vpp_invitation and output as YAML
-  jamf-cli classic-vpp-invitations get 1 -o yaml`,
+  jamf-cli pro classic-vpp-invitations get 1 -o yaml`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -139,7 +139,7 @@ func newClassicVppInvitationsCreateCmd(ctx *registry.CLIContext) *cobra.Command 
 		Short: "Create a vpp_invitation",
 		Long:  "Create a new vpp_invitation. Reads XML body from stdin.",
 		Example: `  # Create a vpp_invitation from XML
-  cat vpp_invitation.xml | jamf-cli classic-vpp-invitations create`,
+  cat vpp_invitation.xml | jamf-cli pro classic-vpp-invitations create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -174,10 +174,10 @@ func newClassicVppInvitationsDeleteCmd(ctx *registry.CLIContext) *cobra.Command 
 		Use:   "delete <id>",
 		Short: "Delete a vpp_invitation",
 		Example: `  # Delete a vpp_invitation (with confirmation)
-  jamf-cli classic-vpp-invitations delete 1
+  jamf-cli pro classic-vpp-invitations delete 1
 
   # Delete without confirmation prompt
-  jamf-cli classic-vpp-invitations delete 1 --yes`,
+  jamf-cli pro classic-vpp-invitations delete 1 --yes`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/classic_webhooks.go
+++ b/internal/commands/pro/generated/classic_webhooks.go
@@ -45,10 +45,10 @@ func newClassicWebhooksListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "list",
 		Short: "List all webhooks",
 		Example: `  # List all webhooks
-  jamf-cli classic-webhooks list
+  jamf-cli pro classic-webhooks list
 
   # List webhooks and extract IDs
-  jamf-cli classic-webhooks list --field id`,
+  jamf-cli pro classic-webhooks list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			resp, err := ctx.Client.Do(reqCtx, "GET", "/JSSResource/webhooks", nil)
@@ -98,13 +98,13 @@ func newClassicWebhooksGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "get [<id>]",
 		Short: "Get a webhook by ID",
 		Example: `  # Get a webhook by ID
-  jamf-cli classic-webhooks get 1
+  jamf-cli pro classic-webhooks get 1
 
   # Get a webhook by name
-  jamf-cli classic-webhooks get --name "Example"
+  jamf-cli pro classic-webhooks get --name "Example"
 
   # Get a webhook and output as YAML
-  jamf-cli classic-webhooks get 1 -o yaml`,
+  jamf-cli pro classic-webhooks get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -161,7 +161,7 @@ func newClassicWebhooksCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a webhook",
 		Long:  "Create a new webhook. Reads XML body from stdin.",
 		Example: `  # Create a webhook from XML
-  cat webhook.xml | jamf-cli classic-webhooks create`,
+  cat webhook.xml | jamf-cli pro classic-webhooks create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -194,7 +194,7 @@ func newClassicWebhooksUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a webhook",
 		Long:  "Update an existing webhook by ID. Reads XML body from stdin.",
 		Example: `  # Update a webhook from XML
-  cat webhook.xml | jamf-cli classic-webhooks update 1`,
+  cat webhook.xml | jamf-cli pro classic-webhooks update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newClassicWebhooksDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Use:   "delete [<id>]",
 		Short: "Delete a webhook",
 		Example: `  # Delete a webhook (with confirmation)
-  jamf-cli classic-webhooks delete 1
+  jamf-cli pro classic-webhooks delete 1
 
   # Delete by name
-  jamf-cli classic-webhooks delete --name "Example" --yes
+  jamf-cli pro classic-webhooks delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli classic-webhooks delete 1 --yes`,
+  jamf-cli pro classic-webhooks delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -331,13 +331,13 @@ The name field in the input XML is used to check if the resource already
 exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a webhook from an XML file
-  jamf-cli classic-webhooks apply --from-file webhook.xml
+  jamf-cli pro classic-webhooks apply --from-file webhook.xml
 
   # Apply from stdin
-  cat webhook.xml | jamf-cli classic-webhooks apply
+  cat webhook.xml | jamf-cli pro classic-webhooks apply
 
   # Apply without replacement confirmation
-  jamf-cli classic-webhooks apply --from-file webhook.xml --yes`,
+  jamf-cli pro classic-webhooks apply --from-file webhook.xml --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/client_check_in.go
+++ b/internal/commands/pro/generated/client_check_in.go
@@ -40,10 +40,10 @@ func newClientCheckInGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Client Check-In settings",
 		Long:  "Gets 'Client Check-In' object.",
 		Example: `  # Get client-check-in
-  jamf-cli client-check-in get
+  jamf-cli pro client-check-in get
 
   # Get client-check-in and output as YAML
-  jamf-cli client-check-in get -o yaml`,
+  jamf-cli pro client-check-in get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -80,10 +80,10 @@ func newClientCheckInUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update Client Check-In object",
 		Long:  "Update Client Check-In object",
 		Example: `  # Update client-check-in
-  jamf-cli client-check-in get -o json | jq '.field = "value"' | jamf-cli client-check-in update
+  jamf-cli pro client-check-in get -o json | jq '.field = "value"' | jamf-cli pro client-check-in update
 
   # Update from a file
-  jamf-cli client-check-in update --from-file client-check-in.json`,
+  jamf-cli pro client-check-in update --from-file client-check-in.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -158,7 +158,7 @@ func newClientCheckInHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Client Check-In history object",
 		Long:  "Gets Client Check-In history object",
 		Example: `  # Get history for a client-check-in
-  jamf-cli client-check-in history 1`,
+  jamf-cli pro client-check-in history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/cloud_azures.go
+++ b/internal/commands/pro/generated/cloud_azures.go
@@ -44,13 +44,13 @@ func newCloudAzuresGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Azure Cloud Identity Provider configuration with given ID.",
 		Long:  "Get Azure Cloud Identity Provider configuration with given ID.",
 		Example: `  # Get a cloud-azure by ID
-  jamf-cli cloud-azures get 1
+  jamf-cli pro cloud-azures get 1
 
   # Get a cloud-azure by name
-  jamf-cli cloud-azures get --name "Example"
+  jamf-cli pro cloud-azures get --name "Example"
 
   # Get a cloud-azure and output as YAML
-  jamf-cli cloud-azures get 1 -o yaml`,
+  jamf-cli pro cloud-azures get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -105,13 +105,13 @@ func newCloudAzuresCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create Azure Cloud Identity Provider configuration",
 		Long:  "Create new Azure Cloud Identity Provider configuration with unique display name.",
 		Example: `  # Show the JSON template for creating a cloud-azure
-  jamf-cli cloud-azures create --scaffold
+  jamf-cli pro cloud-azures create --scaffold
 
   # Create a cloud-azure from JSON
-  echo '{"name":"Example"}' | jamf-cli cloud-azures create
+  echo '{"name":"Example"}' | jamf-cli pro cloud-azures create
 
   # Get a cloud-azure, modify it, and create a copy
-  jamf-cli cloud-azures get 1 -o json | jq '.name = "Copy"' | jamf-cli cloud-azures create`,
+  jamf-cli pro cloud-azures get 1 -o json | jq '.name = "Copy"' | jamf-cli pro cloud-azures create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -175,13 +175,13 @@ func newCloudAzuresUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update Azure Cloud Identity Provider configuration",
 		Long:  "Update Azure Cloud Identity Provider configuration. Cannot be used for partial updates, all content body must be sent.",
 		Example: `  # Update a cloud-azure from JSON
-  echo '{"name":"Updated"}' | jamf-cli cloud-azures update 1
+  echo '{"name":"Updated"}' | jamf-cli pro cloud-azures update 1
 
   # Update by name
-  jamf-cli cloud-azures get --name "Example" -o json | jq '.field = "value"' | jamf-cli cloud-azures update --name "Example"
+  jamf-cli pro cloud-azures get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro cloud-azures update --name "Example"
 
   # Get a cloud-azure, modify, and update
-  jamf-cli cloud-azures get 1 -o json | jq '.name = "New Name"' | jamf-cli cloud-azures update 1`,
+  jamf-cli pro cloud-azures get 1 -o json | jq '.name = "New Name"' | jamf-cli pro cloud-azures update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -263,13 +263,13 @@ func newCloudAzuresDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete Cloud Identity Provider configuration.",
 		Long:  "Delete Cloud Identity Provider configuration.",
 		Example: `  # Delete a cloud-azure (with confirmation)
-  jamf-cli cloud-azures delete 1
+  jamf-cli pro cloud-azures delete 1
 
   # Delete by name
-  jamf-cli cloud-azures delete --name "Example" --yes
+  jamf-cli pro cloud-azures delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli cloud-azures delete 1 --yes`,
+  jamf-cli pro cloud-azures delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -381,19 +381,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a cloud-azure from a JSON file
-  jamf-cli cloud-azures apply --from-file cloud-azure.json
+  jamf-cli pro cloud-azures apply --from-file cloud-azure.json
 
   # Apply a cloud-azure from a YAML file
-  jamf-cli cloud-azures apply --from-file cloud-azure.yaml
+  jamf-cli pro cloud-azures apply --from-file cloud-azure.yaml
 
   # Apply from stdin
-  cat cloud-azure.json | jamf-cli cloud-azures apply
+  cat cloud-azure.json | jamf-cli pro cloud-azures apply
 
   # Apply without replacement confirmation
-  jamf-cli cloud-azures apply --from-file cloud-azure.json --yes
+  jamf-cli pro cloud-azures apply --from-file cloud-azure.json --yes
 
   # Preview what would happen
-  jamf-cli cloud-azures apply --from-file cloud-azure.json --dry-run`,
+  jamf-cli pro cloud-azures apply --from-file cloud-azure.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/cloud_distribution_points.go
+++ b/internal/commands/pro/generated/cloud_distribution_points.go
@@ -51,13 +51,13 @@ func newCloudDistributionPointsCreateCmd(ctx *registry.CLIContext) *cobra.Comman
 		Short: "Create cloud distribution point",
 		Long:  "Creates cloud distribution point. This operation is triggered when the content delivery network (CDN) settings change, specifically when the network type is updated from \"None\" to any other supported type. Upon successful creation,the API returns the updated details of the cloud distribution point.",
 		Example: `  # Show the JSON template for creating a cloud-distribution-point
-  jamf-cli cloud-distribution-points create --scaffold
+  jamf-cli pro cloud-distribution-points create --scaffold
 
   # Create a cloud-distribution-point from JSON
-  echo '{"name":"Example"}' | jamf-cli cloud-distribution-points create
+  echo '{"name":"Example"}' | jamf-cli pro cloud-distribution-points create
 
   # Get a cloud-distribution-point, modify it, and create a copy
-  jamf-cli cloud-distribution-points get 1 -o json | jq '.name = "Copy"' | jamf-cli cloud-distribution-points create`,
+  jamf-cli pro cloud-distribution-points get 1 -o json | jq '.name = "Copy"' | jamf-cli pro cloud-distribution-points create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -133,10 +133,10 @@ func newCloudDistributionPointsDeleteCmd(ctx *registry.CLIContext) *cobra.Comman
 		Short: "Delete cloud distribution point.",
 		Long:  "The cloud distribution point and inventory details to be deleted.",
 		Example: `  # Delete a cloud-distribution-point (with confirmation)
-  jamf-cli cloud-distribution-points delete 1
+  jamf-cli pro cloud-distribution-points delete 1
 
   # Delete without confirmation prompt
-  jamf-cli cloud-distribution-points delete 1 --yes`,
+  jamf-cli pro cloud-distribution-points delete 1 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -215,7 +215,7 @@ func newCloudDistributionPointsHistoryCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Get cloud distribution point history details",
 		Long:  "Get cloud distribution point history details",
 		Example: `  # Get history for a cloud-distribution-point
-  jamf-cli cloud-distribution-points history 1`,
+  jamf-cli pro cloud-distribution-points history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -433,10 +433,10 @@ func newCloudDistributionPointsPatchCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Update specific fields on a cloud distribution point",
 		Long:  "Update specific fields on a cloud distribution point, then return the updated cloud distribution point details object.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  cdnType                                      string\n  directory                                    string\n  downloadUrl                                  string\n  expirationSeconds                            integer\n  keyPairId                                    string\n  master                                       boolean\n  password                                     string\n  privateKey                                   string\n  requireSignedUrls                            boolean\n  secondaryAuthRequired                        boolean\n  secondaryAuthStatusCode                      integer\n  secondaryAuthTimeToLive                      integer\n  uploadUrl                                    string\n  username                                     string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field
-  jamf-cli cloud-distribution-points patch --set field=value
+  jamf-cli pro cloud-distribution-points patch --set field=value
 
   # Update using JSON
-  jamf-cli cloud-distribution-points get -o json | jq '.field = "value"' | jamf-cli cloud-distribution-points patch`,
+  jamf-cli pro cloud-distribution-points get -o json | jq '.field = "value"' | jamf-cli pro cloud-distribution-points patch`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/cloud_id_p_configurations.go
+++ b/internal/commands/pro/generated/cloud_id_p_configurations.go
@@ -45,10 +45,10 @@ func newCloudIdPConfigurationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get information about all Cloud Identity Providers configurations.",
 		Long:  "Returns basic informations about all configured Cloud Identity Provider.",
 		Example: `  # List all cloud-id-p-configurations
-  jamf-cli cloud-id-p-configurations list
+  jamf-cli pro cloud-id-p-configurations list
 
   # List cloud-id-p-configurations and extract IDs
-  jamf-cli cloud-id-p-configurations list --field id`,
+  jamf-cli pro cloud-id-p-configurations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -167,13 +167,13 @@ func newCloudIdPConfigurationsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Cloud Identity Provider configuration with given ID.",
 		Long:  "Get Cloud Identity Provider configuration with given ID.",
 		Example: `  # Get a cloud-id-p-configuration by ID
-  jamf-cli cloud-id-p-configurations get 1
+  jamf-cli pro cloud-id-p-configurations get 1
 
   # Get a cloud-id-p-configuration by name
-  jamf-cli cloud-id-p-configurations get --name "Example"
+  jamf-cli pro cloud-id-p-configurations get --name "Example"
 
   # Get a cloud-id-p-configuration and output as YAML
-  jamf-cli cloud-id-p-configurations get 1 -o yaml`,
+  jamf-cli pro cloud-id-p-configurations get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -235,7 +235,7 @@ func newCloudIdPConfigurationsExportCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Export Cloud Identity Providers collection",
 		Long:  "Export Cloud Identity Providers collection",
 		Example: `  # Export cloud-id-p-configurations to CSV
-  jamf-cli cloud-id-p-configurations export --out-file cloud-id-p-configurations.csv`,
+  jamf-cli pro cloud-id-p-configurations export --out-file cloud-id-p-configurations.csv`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			reqCtx = registry.WithAccept(reqCtx, "*/*")

--- a/internal/commands/pro/generated/cloud_id_p_histories.go
+++ b/internal/commands/pro/generated/cloud_id_p_histories.go
@@ -45,7 +45,7 @@ func newCloudIdPHistoriesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Cloud Identity Provider history",
 		Long:  "Gets specified Cloud Identity Provider object history",
 		Example: `  # Get history for a cloud-id-p-history
-  jamf-cli cloud-id-p-histories history 1`,
+  jamf-cli pro cloud-id-p-histories history 1`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/cloud_informations.go
+++ b/internal/commands/pro/generated/cloud_informations.go
@@ -31,10 +31,10 @@ func newCloudInformationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve information related to cloud setup.",
 		Long:  "Retrieve information related to cloud setup. Retrieves information related to cloud setup. Provides details about cloud instance configuration.",
 		Example: `  # List all cloud-informations
-  jamf-cli cloud-informations list
+  jamf-cli pro cloud-informations list
 
   # List cloud-informations and extract IDs
-  jamf-cli cloud-informations list --field id`,
+  jamf-cli pro cloud-informations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/cloud_ldaps.go
+++ b/internal/commands/pro/generated/cloud_ldaps.go
@@ -44,13 +44,13 @@ func newCloudLdapsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Cloud Identity Provider configuration with given id.",
 		Long:  "Get Cloud Identity Provider configuration with given id.",
 		Example: `  # Get a cloud-ldap by ID
-  jamf-cli cloud-ldaps get 1
+  jamf-cli pro cloud-ldaps get 1
 
   # Get a cloud-ldap by name
-  jamf-cli cloud-ldaps get --name "Example"
+  jamf-cli pro cloud-ldaps get --name "Example"
 
   # Get a cloud-ldap and output as YAML
-  jamf-cli cloud-ldaps get 1 -o yaml`,
+  jamf-cli pro cloud-ldaps get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -105,13 +105,13 @@ func newCloudLdapsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create Cloud Identity Provider configuration",
 		Long:  "Create new Cloud Identity Provider configuration with unique display name. If mappings not provided, then defaults will be generated instead.",
 		Example: `  # Show the JSON template for creating a cloud-ldap
-  jamf-cli cloud-ldaps create --scaffold
+  jamf-cli pro cloud-ldaps create --scaffold
 
   # Create a cloud-ldap from JSON
-  echo '{"name":"Example"}' | jamf-cli cloud-ldaps create
+  echo '{"name":"Example"}' | jamf-cli pro cloud-ldaps create
 
   # Get a cloud-ldap, modify it, and create a copy
-  jamf-cli cloud-ldaps get 1 -o json | jq '.name = "Copy"' | jamf-cli cloud-ldaps create`,
+  jamf-cli pro cloud-ldaps get 1 -o json | jq '.name = "Copy"' | jamf-cli pro cloud-ldaps create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -176,13 +176,13 @@ func newCloudLdapsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update Cloud Identity Provider configuration",
 		Long:  "Update Cloud Identity Provider configuration. Cannot be used for partial updates, all content body must be sent.",
 		Example: `  # Update a cloud-ldap from JSON
-  echo '{"name":"Updated"}' | jamf-cli cloud-ldaps update 1
+  echo '{"name":"Updated"}' | jamf-cli pro cloud-ldaps update 1
 
   # Update by name
-  jamf-cli cloud-ldaps get --name "Example" -o json | jq '.field = "value"' | jamf-cli cloud-ldaps update --name "Example"
+  jamf-cli pro cloud-ldaps get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro cloud-ldaps update --name "Example"
 
   # Get a cloud-ldap, modify, and update
-  jamf-cli cloud-ldaps get 1 -o json | jq '.name = "New Name"' | jamf-cli cloud-ldaps update 1`,
+  jamf-cli pro cloud-ldaps get 1 -o json | jq '.name = "New Name"' | jamf-cli pro cloud-ldaps update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -265,13 +265,13 @@ func newCloudLdapsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete Cloud Identity Provider configuration.",
 		Long:  "Delete Cloud Identity Provider configuration.",
 		Example: `  # Delete a cloud-ldap (with confirmation)
-  jamf-cli cloud-ldaps delete 1
+  jamf-cli pro cloud-ldaps delete 1
 
   # Delete by name
-  jamf-cli cloud-ldaps delete --name "Example" --yes
+  jamf-cli pro cloud-ldaps delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli cloud-ldaps delete 1 --yes`,
+  jamf-cli pro cloud-ldaps delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -383,19 +383,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a cloud-ldap from a JSON file
-  jamf-cli cloud-ldaps apply --from-file cloud-ldap.json
+  jamf-cli pro cloud-ldaps apply --from-file cloud-ldap.json
 
   # Apply a cloud-ldap from a YAML file
-  jamf-cli cloud-ldaps apply --from-file cloud-ldap.yaml
+  jamf-cli pro cloud-ldaps apply --from-file cloud-ldap.yaml
 
   # Apply from stdin
-  cat cloud-ldap.json | jamf-cli cloud-ldaps apply
+  cat cloud-ldap.json | jamf-cli pro cloud-ldaps apply
 
   # Apply without replacement confirmation
-  jamf-cli cloud-ldaps apply --from-file cloud-ldap.json --yes
+  jamf-cli pro cloud-ldaps apply --from-file cloud-ldap.json --yes
 
   # Preview what would happen
-  jamf-cli cloud-ldaps apply --from-file cloud-ldap.json --dry-run`,
+  jamf-cli pro cloud-ldaps apply --from-file cloud-ldap.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/computer_extension_attributes.go
+++ b/internal/commands/pro/generated/computer_extension_attributes.go
@@ -59,10 +59,10 @@ func newComputerExtensionAttributesListCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Retrieve Computer Extension Attributes.",
 		Long:  "Retrieves All Computer Extension Attributes Configuration.",
 		Example: `  # List all computer-extension-attributes
-  jamf-cli computer-extension-attributes list
+  jamf-cli pro computer-extension-attributes list
 
   # List computer-extension-attributes and extract IDs
-  jamf-cli computer-extension-attributes list --field id`,
+  jamf-cli pro computer-extension-attributes list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -185,13 +185,13 @@ func newComputerExtensionAttributesGetCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Get specified Computer Extension Attribute object.",
 		Long:  "Gets specified Computer Extension Attribute object.",
 		Example: `  # Get a computer-extension-attribute by ID
-  jamf-cli computer-extension-attributes get 1
+  jamf-cli pro computer-extension-attributes get 1
 
   # Get a computer-extension-attribute by name
-  jamf-cli computer-extension-attributes get --name "Example"
+  jamf-cli pro computer-extension-attributes get --name "Example"
 
   # Get a computer-extension-attribute and output as YAML
-  jamf-cli computer-extension-attributes get 1 -o yaml`,
+  jamf-cli pro computer-extension-attributes get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -247,13 +247,13 @@ func newComputerExtensionAttributesCreateCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Create Computer Extension Attribute.",
 		Long:  "Create Computer Extension Attribute to collect extra inventory information.",
 		Example: `  # Show the JSON template for creating a computer-extension-attribute
-  jamf-cli computer-extension-attributes create --scaffold
+  jamf-cli pro computer-extension-attributes create --scaffold
 
   # Create a computer-extension-attribute from JSON
-  echo '{"name":"Example"}' | jamf-cli computer-extension-attributes create
+  echo '{"name":"Example"}' | jamf-cli pro computer-extension-attributes create
 
   # Get a computer-extension-attribute, modify it, and create a copy
-  jamf-cli computer-extension-attributes get 1 -o json | jq '.name = "Copy"' | jamf-cli computer-extension-attributes create`,
+  jamf-cli pro computer-extension-attributes get 1 -o json | jq '.name = "Copy"' | jamf-cli pro computer-extension-attributes create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -342,13 +342,13 @@ func newComputerExtensionAttributesUpdateCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Update specified Computer Extension Attribute object.",
 		Long:  "Update specified Computer Extension Attribute object.",
 		Example: `  # Update a computer-extension-attribute from JSON
-  echo '{"name":"Updated"}' | jamf-cli computer-extension-attributes update 1
+  echo '{"name":"Updated"}' | jamf-cli pro computer-extension-attributes update 1
 
   # Update by name
-  jamf-cli computer-extension-attributes get --name "Example" -o json | jq '.field = "value"' | jamf-cli computer-extension-attributes update --name "Example"
+  jamf-cli pro computer-extension-attributes get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro computer-extension-attributes update --name "Example"
 
   # Get a computer-extension-attribute, modify, and update
-  jamf-cli computer-extension-attributes get 1 -o json | jq '.name = "New Name"' | jamf-cli computer-extension-attributes update 1`,
+  jamf-cli pro computer-extension-attributes get 1 -o json | jq '.name = "New Name"' | jamf-cli pro computer-extension-attributes update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -454,13 +454,13 @@ func newComputerExtensionAttributesDeleteCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Remove specified Computer Extension Attribute.",
 		Long:  "ID of the Computer Extension Attribute to be deleted.",
 		Example: `  # Delete a computer-extension-attribute (with confirmation)
-  jamf-cli computer-extension-attributes delete 1
+  jamf-cli pro computer-extension-attributes delete 1
 
   # Delete by name
-  jamf-cli computer-extension-attributes delete --name "Example" --yes
+  jamf-cli pro computer-extension-attributes delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli computer-extension-attributes delete 1 --yes`,
+  jamf-cli pro computer-extension-attributes delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -568,7 +568,7 @@ func newComputerExtensionAttributesDeleteMultipleCmd(ctx *registry.CLIContext) *
 		Short: "Delete multiple Computer Extension Attribute at once.",
 		Long:  "IDs of the Computer Extension Attribute to be deleted.",
 		Example: `  # Delete multiple computer-extension-attributes by IDs
-  jamf-cli computer-extension-attributes delete-multiple --ids 1,2,3 --yes`,
+  jamf-cli pro computer-extension-attributes delete-multiple --ids 1,2,3 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -668,10 +668,10 @@ func newComputerExtensionAttributesHistoryCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Get specified Computer Extension Attribute History object",
 		Long:  "Get specified Computer Extension Attribute history object",
 		Example: `  # Get history for a computer-extension-attribute by ID
-  jamf-cli computer-extension-attributes history 1
+  jamf-cli pro computer-extension-attributes history 1
 
   # Get history by name
-  jamf-cli computer-extension-attributes history --name "Example"`,
+  jamf-cli pro computer-extension-attributes history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -1082,19 +1082,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a computer-extension-attribute from a JSON file
-  jamf-cli computer-extension-attributes apply --from-file computer-extension-attribute.json
+  jamf-cli pro computer-extension-attributes apply --from-file computer-extension-attribute.json
 
   # Apply a computer-extension-attribute from a YAML file
-  jamf-cli computer-extension-attributes apply --from-file computer-extension-attribute.yaml
+  jamf-cli pro computer-extension-attributes apply --from-file computer-extension-attribute.yaml
 
   # Apply from stdin
-  cat computer-extension-attribute.json | jamf-cli computer-extension-attributes apply
+  cat computer-extension-attribute.json | jamf-cli pro computer-extension-attributes apply
 
   # Apply without replacement confirmation
-  jamf-cli computer-extension-attributes apply --from-file computer-extension-attribute.json --yes
+  jamf-cli pro computer-extension-attributes apply --from-file computer-extension-attribute.json --yes
 
   # Preview what would happen
-  jamf-cli computer-extension-attributes apply --from-file computer-extension-attribute.json --dry-run`,
+  jamf-cli pro computer-extension-attributes apply --from-file computer-extension-attribute.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/computer_groups.go
+++ b/internal/commands/pro/generated/computer_groups.go
@@ -31,10 +31,10 @@ func newComputerGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Returns the list of all computer groups",
 		Long:  "Use it to get the list of all computer groups.",
 		Example: `  # List all computer-groups
-  jamf-cli computer-groups list
+  jamf-cli pro computer-groups list
 
   # List computer-groups and extract IDs
-  jamf-cli computer-groups list --field id`,
+  jamf-cli pro computer-groups list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/computer_inventory_collection_settings.go
+++ b/internal/commands/pro/generated/computer_inventory_collection_settings.go
@@ -41,10 +41,10 @@ func newComputerInventoryCollectionSettingsListCmd(ctx *registry.CLIContext) *co
 		Short: "Returns computer inventory settings",
 		Long:  "Returns computer inventory settings",
 		Example: `  # List all computer-inventory-collection-settings
-  jamf-cli computer-inventory-collection-settings list
+  jamf-cli pro computer-inventory-collection-settings list
 
   # List computer-inventory-collection-settings and extract IDs
-  jamf-cli computer-inventory-collection-settings list --field id`,
+  jamf-cli pro computer-inventory-collection-settings list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -81,13 +81,13 @@ func newComputerInventoryCollectionSettingsCreateCmd(ctx *registry.CLIContext) *
 		Short: "Create Computer Inventory Collection Settings Custom Path",
 		Long:  "Creates a custom search path to use when collecting applications.",
 		Example: `  # Show the JSON template for creating a computer-inventory-collection-setting
-  jamf-cli computer-inventory-collection-settings create --scaffold
+  jamf-cli pro computer-inventory-collection-settings create --scaffold
 
   # Create a computer-inventory-collection-setting from JSON
-  echo '{"name":"Example"}' | jamf-cli computer-inventory-collection-settings create
+  echo '{"name":"Example"}' | jamf-cli pro computer-inventory-collection-settings create
 
   # Get a computer-inventory-collection-setting, modify it, and create a copy
-  jamf-cli computer-inventory-collection-settings get 1 -o json | jq '.name = "Copy"' | jamf-cli computer-inventory-collection-settings create`,
+  jamf-cli pro computer-inventory-collection-settings get 1 -o json | jq '.name = "Copy"' | jamf-cli pro computer-inventory-collection-settings create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -152,13 +152,13 @@ func newComputerInventoryCollectionSettingsDeleteCmd(ctx *registry.CLIContext) *
 		Short: "Delete Custom Path from Computer Inventory Collection Settings",
 		Long:  "Delete Custom Path from Computer Inventory Collection Settings",
 		Example: `  # Delete a computer-inventory-collection-setting (with confirmation)
-  jamf-cli computer-inventory-collection-settings delete 1
+  jamf-cli pro computer-inventory-collection-settings delete 1
 
   # Delete by name
-  jamf-cli computer-inventory-collection-settings delete --name "Example" --yes
+  jamf-cli pro computer-inventory-collection-settings delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli computer-inventory-collection-settings delete 1 --yes`,
+  jamf-cli pro computer-inventory-collection-settings delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -265,10 +265,10 @@ func newComputerInventoryCollectionSettingsPatchCmd(ctx *registry.CLIContext) *c
 		Short: "Update computer inventory settings",
 		Long:  "Update computer inventory settings\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  computerInventoryCollectionPreferences.allowChangingUserAndLocation boolean\n  computerInventoryCollectionPreferences.calculateSizes boolean\n  computerInventoryCollectionPreferences.collectSyncedMobileDeviceInfo boolean\n  computerInventoryCollectionPreferences.collectUnmanagedCertificates boolean\n  computerInventoryCollectionPreferences.includeAccounts boolean\n  computerInventoryCollectionPreferences.includeHiddenAccounts boolean\n  computerInventoryCollectionPreferences.includePackages boolean\n  computerInventoryCollectionPreferences.includePrinters boolean\n  computerInventoryCollectionPreferences.includeServices boolean\n  computerInventoryCollectionPreferences.includeSoftwareId boolean\n  computerInventoryCollectionPreferences.includeSoftwareUpdates boolean\n  computerInventoryCollectionPreferences.monitorApplicationUsage boolean\n  computerInventoryCollectionPreferences.monitorBeacons boolean\n  computerInventoryCollectionPreferences.updateLdapInfoOnComputerInventorySubmissions boolean\n  computerInventoryCollectionPreferences.useUnixUserPaths boolean\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field
-  jamf-cli computer-inventory-collection-settings patch --set field=value
+  jamf-cli pro computer-inventory-collection-settings patch --set field=value
 
   # Update using JSON
-  jamf-cli computer-inventory-collection-settings get -o json | jq '.field = "value"' | jamf-cli computer-inventory-collection-settings patch`,
+  jamf-cli pro computer-inventory-collection-settings get -o json | jq '.field = "value"' | jamf-cli pro computer-inventory-collection-settings patch`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/computer_prestage_scopes.go
+++ b/internal/commands/pro/generated/computer_prestage_scopes.go
@@ -42,10 +42,10 @@ func newComputerPrestageScopesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get all device Scope for all Computer Prestages",
 		Long:  "Get all device scope for all computer prestages",
 		Example: `  # List all computer-prestage-scopes
-  jamf-cli computer-prestage-scopes list
+  jamf-cli pro computer-prestage-scopes list
 
   # List computer-prestage-scopes and extract IDs
-  jamf-cli computer-prestage-scopes list --field id`,
+  jamf-cli pro computer-prestage-scopes list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -85,7 +85,7 @@ func newComputerPrestageScopesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra
 		Short: "Remove device Scope for a specific Computer Prestage",
 		Long:  "Remove device scope for a specific computer prestage",
 		Example: `  # Delete multiple computer-prestage-scopes by IDs
-  jamf-cli computer-prestage-scopes delete-multiple --ids 1,2,3 --yes`,
+  jamf-cli pro computer-prestage-scopes delete-multiple --ids 1,2,3 --yes`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/computer_prestages.go
+++ b/internal/commands/pro/generated/computer_prestages.go
@@ -50,10 +50,10 @@ func newComputerPrestagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get sorted and paged Computer Prestages",
 		Long:  "Gets sorted and paged computer prestages",
 		Example: `  # List all computer-prestages
-  jamf-cli computer-prestages list
+  jamf-cli pro computer-prestages list
 
   # List computer-prestages and extract IDs
-  jamf-cli computer-prestages list --field id`,
+  jamf-cli pro computer-prestages list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -172,13 +172,13 @@ func newComputerPrestagesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve a Computer Prestage with the supplied id",
 		Long:  "Retrieves a Computer Prestage with the supplied id",
 		Example: `  # Get a computer-prestage by ID
-  jamf-cli computer-prestages get 1
+  jamf-cli pro computer-prestages get 1
 
   # Get a computer-prestage by name
-  jamf-cli computer-prestages get --name "Example"
+  jamf-cli pro computer-prestages get --name "Example"
 
   # Get a computer-prestage and output as YAML
-  jamf-cli computer-prestages get 1 -o yaml`,
+  jamf-cli pro computer-prestages get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -233,13 +233,13 @@ func newComputerPrestagesCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a Computer Prestage",
 		Long:  "Create a computer prestage",
 		Example: `  # Show the JSON template for creating a computer-prestage
-  jamf-cli computer-prestages create --scaffold
+  jamf-cli pro computer-prestages create --scaffold
 
   # Create a computer-prestage from JSON
-  echo '{"name":"Example"}' | jamf-cli computer-prestages create
+  echo '{"name":"Example"}' | jamf-cli pro computer-prestages create
 
   # Get a computer-prestage, modify it, and create a copy
-  jamf-cli computer-prestages get 1 -o json | jq '.name = "Copy"' | jamf-cli computer-prestages create`,
+  jamf-cli pro computer-prestages get 1 -o json | jq '.name = "Copy"' | jamf-cli pro computer-prestages create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -344,13 +344,13 @@ func newComputerPrestagesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a Computer Prestage",
 		Long:  "Updates a Computer Prestage",
 		Example: `  # Update a computer-prestage from JSON
-  echo '{"name":"Updated"}' | jamf-cli computer-prestages update 1
+  echo '{"name":"Updated"}' | jamf-cli pro computer-prestages update 1
 
   # Update by name
-  jamf-cli computer-prestages get --name "Example" -o json | jq '.field = "value"' | jamf-cli computer-prestages update --name "Example"
+  jamf-cli pro computer-prestages get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro computer-prestages update --name "Example"
 
   # Get a computer-prestage, modify, and update
-  jamf-cli computer-prestages get 1 -o json | jq '.name = "New Name"' | jamf-cli computer-prestages update 1`,
+  jamf-cli pro computer-prestages get 1 -o json | jq '.name = "New Name"' | jamf-cli pro computer-prestages update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -484,13 +484,13 @@ func newComputerPrestagesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete a Computer Prestage with the supplied id",
 		Long:  "Deletes a Computer Prestage with the supplied id",
 		Example: `  # Delete a computer-prestage (with confirmation)
-  jamf-cli computer-prestages delete 1
+  jamf-cli pro computer-prestages delete 1
 
   # Delete by name
-  jamf-cli computer-prestages delete --name "Example" --yes
+  jamf-cli pro computer-prestages delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli computer-prestages delete 1 --yes`,
+  jamf-cli pro computer-prestages delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -602,19 +602,19 @@ The displayName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a computer-prestage from a JSON file
-  jamf-cli computer-prestages apply --from-file computer-prestage.json
+  jamf-cli pro computer-prestages apply --from-file computer-prestage.json
 
   # Apply a computer-prestage from a YAML file
-  jamf-cli computer-prestages apply --from-file computer-prestage.yaml
+  jamf-cli pro computer-prestages apply --from-file computer-prestage.yaml
 
   # Apply from stdin
-  cat computer-prestage.json | jamf-cli computer-prestages apply
+  cat computer-prestage.json | jamf-cli pro computer-prestages apply
 
   # Apply without replacement confirmation
-  jamf-cli computer-prestages apply --from-file computer-prestage.json --yes
+  jamf-cli pro computer-prestages apply --from-file computer-prestage.json --yes
 
   # Preview what would happen
-  jamf-cli computer-prestages apply --from-file computer-prestage.json --dry-run`,
+  jamf-cli pro computer-prestages apply --from-file computer-prestage.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/computers.go
+++ b/internal/commands/pro/generated/computers.go
@@ -43,10 +43,10 @@ func newComputersListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Return a list of Computers",
 		Long:  "Returns a list of computers.",
 		Example: `  # List all computers
-  jamf-cli computers list
+  jamf-cli pro computers list
 
   # List computers and extract IDs
-  jamf-cli computers list --field id`,
+  jamf-cli pro computers list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/computers_inventory.go
+++ b/internal/commands/pro/generated/computers_inventory.go
@@ -60,10 +60,10 @@ func newComputersInventoryListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Return paginated Computer Inventory records",
 		Long:  "Return paginated Computer Inventory records",
 		Example: `  # List all computers-inventory
-  jamf-cli computers-inventory list
+  jamf-cli pro computers-inventory list
 
   # List computers-inventory and extract IDs
-  jamf-cli computers-inventory list --field id`,
+  jamf-cli pro computers-inventory list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -207,13 +207,13 @@ func newComputersInventoryGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Return General section of a Computer",
 		Long:  "Return General section of a Computer",
 		Example: `  # Get a computers-inventory by ID
-  jamf-cli computers-inventory get 1
+  jamf-cli pro computers-inventory get 1
 
   # Get a computers-inventory by name
-  jamf-cli computers-inventory get --name "Example"
+  jamf-cli pro computers-inventory get --name "Example"
 
   # Get a computers-inventory and output as YAML
-  jamf-cli computers-inventory get 1 -o yaml`,
+  jamf-cli pro computers-inventory get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -292,13 +292,13 @@ func newComputersInventoryCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create Computer Inventory record",
 		Long:  "Creates Computer Inventory record",
 		Example: `  # Show the JSON template for creating a computers-inventory
-  jamf-cli computers-inventory create --scaffold
+  jamf-cli pro computers-inventory create --scaffold
 
   # Create a computers-inventory from JSON
-  echo '{"name":"Example"}' | jamf-cli computers-inventory create
+  echo '{"name":"Example"}' | jamf-cli pro computers-inventory create
 
   # Get a computers-inventory, modify it, and create a copy
-  jamf-cli computers-inventory get 1 -o json | jq '.name = "Copy"' | jamf-cli computers-inventory create`,
+  jamf-cli pro computers-inventory get 1 -o json | jq '.name = "Copy"' | jamf-cli pro computers-inventory create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -379,13 +379,13 @@ func newComputersInventoryDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Remove specified Computer record",
 		Long:  "Remove specified Computer record",
 		Example: `  # Delete a computers-inventory (with confirmation)
-  jamf-cli computers-inventory delete 1
+  jamf-cli pro computers-inventory delete 1
 
   # Delete by name
-  jamf-cli computers-inventory delete --name "Example" --yes
+  jamf-cli pro computers-inventory delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli computers-inventory delete 1 --yes`,
+  jamf-cli pro computers-inventory delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -520,22 +520,22 @@ func newComputersInventoryPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update specific fields on a computer",
 		Long:  "Update specific fields on a computer, then return the updated computer object.\n\nIdentify the resource by ID (positional arg), --name, --serial, --udid. Omit ID to use a lookup flag.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  general.assetTag                             string\n  general.barcode1                             string\n  general.barcode2                             string\n  general.lastIpAddress                        string\n  general.managed                              boolean\n  general.name                                 string\n  general.siteId                               string\n  hardware.altMacAddress                       string\n  hardware.altNetworkAdapterType               string\n  hardware.macAddress                          string\n  hardware.networkAdapterType                  string\n  purchasing.appleCareId                       string\n  purchasing.leaseDate                         string\n  purchasing.leased                            boolean\n  purchasing.lifeExpectancy                    integer\n  purchasing.poDate                            string\n  purchasing.poNumber                          string\n  purchasing.purchasePrice                     string\n  purchasing.purchased                         boolean\n  purchasing.purchasingAccount                 string\n  purchasing.purchasingContact                 string\n  purchasing.vendor                            string\n  purchasing.warrantyDate                      string\n  udid                                         string\n  userAndLocation.buildingId                   string\n  userAndLocation.departmentId                 string\n  userAndLocation.email                        string\n  userAndLocation.phone                        string\n  userAndLocation.position                     string\n  userAndLocation.realname                     string\n  userAndLocation.room                         string\n  userAndLocation.username                     string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field by ID
-  jamf-cli computers-inventory patch 1 --set general.managed=true
+  jamf-cli pro computers-inventory patch 1 --set general.managed=true
 
   # Update multiple fields
-  jamf-cli computers-inventory patch 1 --set field1=value1 --set field2=value2
+  jamf-cli pro computers-inventory patch 1 --set field1=value1 --set field2=value2
 
   # Update by name
-  jamf-cli computers-inventory patch --name "Example" --set general.managed=true
+  jamf-cli pro computers-inventory patch --name "Example" --set general.managed=true
 
   # Update by serial
-  jamf-cli computers-inventory patch --serial <value> --set general.managed=true
+  jamf-cli pro computers-inventory patch --serial <value> --set general.managed=true
 
   # Update by udid
-  jamf-cli computers-inventory patch --udid <value> --set general.managed=true
+  jamf-cli pro computers-inventory patch --udid <value> --set general.managed=true
 
   # Patch from a file
-  jamf-cli computers-inventory patch 1 --from-file changes.json`,
+  jamf-cli pro computers-inventory patch 1 --from-file changes.json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -1178,19 +1178,19 @@ The general.name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a computers-inventory from a JSON file
-  jamf-cli computers-inventory apply --from-file computers-inventory.json
+  jamf-cli pro computers-inventory apply --from-file computers-inventory.json
 
   # Apply a computers-inventory from a YAML file
-  jamf-cli computers-inventory apply --from-file computers-inventory.yaml
+  jamf-cli pro computers-inventory apply --from-file computers-inventory.yaml
 
   # Apply from stdin
-  cat computers-inventory.json | jamf-cli computers-inventory apply
+  cat computers-inventory.json | jamf-cli pro computers-inventory apply
 
   # Apply without replacement confirmation
-  jamf-cli computers-inventory apply --from-file computers-inventory.json --yes
+  jamf-cli pro computers-inventory apply --from-file computers-inventory.json --yes
 
   # Preview what would happen
-  jamf-cli computers-inventory apply --from-file computers-inventory.json --dry-run`,
+  jamf-cli pro computers-inventory apply --from-file computers-inventory.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/country_codes.go
+++ b/internal/commands/pro/generated/country_codes.go
@@ -31,10 +31,10 @@ func newCountryCodesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Return a list of Countries and the associated Codes",
 		Long:  "Returns a list of countries and the associated codes that can be use for the App Store locale",
 		Example: `  # List all country-codes
-  jamf-cli country-codes list
+  jamf-cli pro country-codes list
 
   # List country-codes and extract IDs
-  jamf-cli country-codes list --field id`,
+  jamf-cli pro country-codes list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/csas.go
+++ b/internal/commands/pro/generated/csas.go
@@ -40,10 +40,10 @@ func newCsasDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete the CSA token exchange - This will disable Jamf Pro's ability to authenticate with cloud-hosted services",
 		Long:  "Delete the CSA token exchange - This will disable Jamf Pro's ability to authenticate with cloud-hosted services",
 		Example: `  # Delete a csa (with confirmation)
-  jamf-cli csas delete 1
+  jamf-cli pro csas delete 1
 
   # Delete without confirmation prompt
-  jamf-cli csas delete 1 --yes`,
+  jamf-cli pro csas delete 1 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/dashboards.go
+++ b/internal/commands/pro/generated/dashboards.go
@@ -36,10 +36,10 @@ func newDashboardsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get all the dashboard setup information",
 		Long:  "Get all the dashboard information for widgets and setup tasks",
 		Example: `  # List all dashboards
-  jamf-cli dashboards list
+  jamf-cli pro dashboards list
 
   # List dashboards and extract IDs
-  jamf-cli dashboards list --field id`,
+  jamf-cli pro dashboards list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/departments.go
+++ b/internal/commands/pro/generated/departments.go
@@ -54,10 +54,10 @@ func newDepartmentsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Search for Departments",
 		Long:  "Search for Departments",
 		Example: `  # List all departments
-  jamf-cli departments list
+  jamf-cli pro departments list
 
   # List departments and extract IDs
-  jamf-cli departments list --field id`,
+  jamf-cli pro departments list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -180,13 +180,13 @@ func newDepartmentsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Department object",
 		Long:  "Gets specified Department object",
 		Example: `  # Get a department by ID
-  jamf-cli departments get 1
+  jamf-cli pro departments get 1
 
   # Get a department by name
-  jamf-cli departments get --name "Example"
+  jamf-cli pro departments get --name "Example"
 
   # Get a department and output as YAML
-  jamf-cli departments get 1 -o yaml`,
+  jamf-cli pro departments get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -241,13 +241,13 @@ func newDepartmentsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create department record",
 		Long:  "Create department record",
 		Example: `  # Show the JSON template for creating a department
-  jamf-cli departments create --scaffold
+  jamf-cli pro departments create --scaffold
 
   # Create a department from JSON
-  echo '{"name":"Example"}' | jamf-cli departments create
+  echo '{"name":"Example"}' | jamf-cli pro departments create
 
   # Get a department, modify it, and create a copy
-  jamf-cli departments get 1 -o json | jq '.name = "Copy"' | jamf-cli departments create`,
+  jamf-cli pro departments get 1 -o json | jq '.name = "Copy"' | jamf-cli pro departments create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -310,13 +310,13 @@ func newDepartmentsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update specified department object",
 		Long:  "Update specified department object",
 		Example: `  # Update a department from JSON
-  echo '{"name":"Updated"}' | jamf-cli departments update 1
+  echo '{"name":"Updated"}' | jamf-cli pro departments update 1
 
   # Update by name
-  jamf-cli departments get --name "Example" -o json | jq '.field = "value"' | jamf-cli departments update --name "Example"
+  jamf-cli pro departments get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro departments update --name "Example"
 
   # Get a department, modify, and update
-  jamf-cli departments get 1 -o json | jq '.name = "New Name"' | jamf-cli departments update 1`,
+  jamf-cli pro departments get 1 -o json | jq '.name = "New Name"' | jamf-cli pro departments update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -397,13 +397,13 @@ func newDepartmentsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Remove specified department record",
 		Long:  "Removes specified department record",
 		Example: `  # Delete a department (with confirmation)
-  jamf-cli departments delete 1
+  jamf-cli pro departments delete 1
 
   # Delete by name
-  jamf-cli departments delete --name "Example" --yes
+  jamf-cli pro departments delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli departments delete 1 --yes`,
+  jamf-cli pro departments delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -511,7 +511,7 @@ func newDepartmentsDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Deletes all departments by ids passed in body",
 		Long:  "Deletes all departments by ids passed in body",
 		Example: `  # Delete multiple departments by IDs
-  jamf-cli departments delete-multiple --ids 1,2,3 --yes`,
+  jamf-cli pro departments delete-multiple --ids 1,2,3 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -611,10 +611,10 @@ func newDepartmentsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Department history object",
 		Long:  "Gets specified Department history object",
 		Example: `  # Get history for a department by ID
-  jamf-cli departments history 1
+  jamf-cli pro departments history 1
 
   # Get history by name
-  jamf-cli departments history --name "Example"`,
+  jamf-cli pro departments history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -840,19 +840,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a department from a JSON file
-  jamf-cli departments apply --from-file department.json
+  jamf-cli pro departments apply --from-file department.json
 
   # Apply a department from a YAML file
-  jamf-cli departments apply --from-file department.yaml
+  jamf-cli pro departments apply --from-file department.yaml
 
   # Apply from stdin
-  cat department.json | jamf-cli departments apply
+  cat department.json | jamf-cli pro departments apply
 
   # Apply without replacement confirmation
-  jamf-cli departments apply --from-file department.json --yes
+  jamf-cli pro departments apply --from-file department.json --yes
 
   # Preview what would happen
-  jamf-cli departments apply --from-file department.json --dry-run`,
+  jamf-cli pro departments apply --from-file department.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/device_communication_settings.go
+++ b/internal/commands/pro/generated/device_communication_settings.go
@@ -40,10 +40,10 @@ func newDeviceCommunicationSettingsGetCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Retrieves all settings for device communication",
 		Long:  "Retrieves all device communication settings, including automatic renewal of the MDM profile.",
 		Example: `  # Get device-communication-settings
-  jamf-cli device-communication-settings get
+  jamf-cli pro device-communication-settings get
 
   # Get device-communication-settings and output as YAML
-  jamf-cli device-communication-settings get -o yaml`,
+  jamf-cli pro device-communication-settings get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -80,10 +80,10 @@ func newDeviceCommunicationSettingsUpdateCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Update device communication settings",
 		Long:  "Update device communication settings",
 		Example: `  # Update device-communication-settings
-  jamf-cli device-communication-settings get -o json | jq '.field = "value"' | jamf-cli device-communication-settings update
+  jamf-cli pro device-communication-settings get -o json | jq '.field = "value"' | jamf-cli pro device-communication-settings update
 
   # Update from a file
-  jamf-cli device-communication-settings update --from-file device-communication-settings.json`,
+  jamf-cli pro device-communication-settings update --from-file device-communication-settings.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -155,7 +155,7 @@ func newDeviceCommunicationSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Get Device Communication settings history",
 		Long:  "Gets Device Communication settings history",
 		Example: `  # Get history for a device-communication-settings
-  jamf-cli device-communication-settings history 1`,
+  jamf-cli pro device-communication-settings history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/device_compliance_informations.go
+++ b/internal/commands/pro/generated/device_compliance_informations.go
@@ -34,10 +34,10 @@ func newDeviceComplianceInformationsListCmd(ctx *registry.CLIContext) *cobra.Com
 		Short: "Retrieves Status of the Feature Toggle",
 		Long:  "Retrieves Status of the Feature Toggle",
 		Example: `  # List all device-compliance-informations
-  jamf-cli device-compliance-informations list
+  jamf-cli pro device-compliance-informations list
 
   # List device-compliance-informations and extract IDs
-  jamf-cli device-compliance-informations list --field id`,
+  jamf-cli pro device-compliance-informations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -74,13 +74,13 @@ func newDeviceComplianceInformationsGetCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Get compliance information for a single computer device",
 		Long:  "Return basic compliance information for the given computer device",
 		Example: `  # Get a device-compliance-information by ID
-  jamf-cli device-compliance-informations get 1
+  jamf-cli pro device-compliance-informations get 1
 
   # Get a device-compliance-information by name
-  jamf-cli device-compliance-informations get --name "Example"
+  jamf-cli pro device-compliance-informations get --name "Example"
 
   # Get a device-compliance-information and output as YAML
-  jamf-cli device-compliance-informations get 1 -o yaml`,
+  jamf-cli pro device-compliance-informations get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/device_enrollment_instance_sync_states.go
+++ b/internal/commands/pro/generated/device_enrollment_instance_sync_states.go
@@ -34,10 +34,10 @@ func newDeviceEnrollmentInstanceSyncStatesListCmd(ctx *registry.CLIContext) *cob
 		Short: "Get all instance sync states for all Device Enrollment Instances",
 		Long:  "Get all instance sync states for all instances",
 		Example: `  # List all device-enrollment-instance-sync-states
-  jamf-cli device-enrollment-instance-sync-states list
+  jamf-cli pro device-enrollment-instance-sync-states list
 
   # List device-enrollment-instance-sync-states and extract IDs
-  jamf-cli device-enrollment-instance-sync-states list --field id`,
+  jamf-cli pro device-enrollment-instance-sync-states list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/device_enrollment_instances.go
+++ b/internal/commands/pro/generated/device_enrollment_instances.go
@@ -56,10 +56,10 @@ func newDeviceEnrollmentInstancesListCmd(ctx *registry.CLIContext) *cobra.Comman
 		Short: "Read all sorted and paged Device Enrollment instances",
 		Long:  "Search for sorted and paged device enrollment instances",
 		Example: `  # List all device-enrollment-instances
-  jamf-cli device-enrollment-instances list
+  jamf-cli pro device-enrollment-instances list
 
   # List device-enrollment-instances and extract IDs
-  jamf-cli device-enrollment-instances list --field id`,
+  jamf-cli pro device-enrollment-instances list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -178,13 +178,13 @@ func newDeviceEnrollmentInstancesGetCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Retrieve a Device Enrollment Instance with the supplied id",
 		Long:  "Retrieves a Device Enrollment Instance with the supplied id",
 		Example: `  # Get a device-enrollment-instance by ID
-  jamf-cli device-enrollment-instances get 1
+  jamf-cli pro device-enrollment-instances get 1
 
   # Get a device-enrollment-instance by name
-  jamf-cli device-enrollment-instances get --name "Example"
+  jamf-cli pro device-enrollment-instances get --name "Example"
 
   # Get a device-enrollment-instance and output as YAML
-  jamf-cli device-enrollment-instances get 1 -o yaml`,
+  jamf-cli pro device-enrollment-instances get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newDeviceEnrollmentInstancesCreateCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Create a Device Enrollment Instance with the supplied Token",
 		Long:  "Creates a device enrollment instance with the supplied token.",
 		Example: `  # Show the JSON template for creating a device-enrollment-instance
-  jamf-cli device-enrollment-instances create --scaffold
+  jamf-cli pro device-enrollment-instances create --scaffold
 
   # Create a device-enrollment-instance from JSON
-  echo '{"name":"Example"}' | jamf-cli device-enrollment-instances create
+  echo '{"name":"Example"}' | jamf-cli pro device-enrollment-instances create
 
   # Get a device-enrollment-instance, modify it, and create a copy
-  jamf-cli device-enrollment-instances get 1 -o json | jq '.name = "Copy"' | jamf-cli device-enrollment-instances create`,
+  jamf-cli pro device-enrollment-instances get 1 -o json | jq '.name = "Copy"' | jamf-cli pro device-enrollment-instances create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -356,13 +356,13 @@ func newDeviceEnrollmentInstancesUpdateCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Update a Device Enrollment Instance with the supplied id",
 		Long:  "Updates a Device Enrollment Instance with the supplied id",
 		Example: `  # Update a device-enrollment-instance from JSON
-  echo '{"name":"Updated"}' | jamf-cli device-enrollment-instances update 1
+  echo '{"name":"Updated"}' | jamf-cli pro device-enrollment-instances update 1
 
   # Update by name
-  jamf-cli device-enrollment-instances get --name "Example" -o json | jq '.field = "value"' | jamf-cli device-enrollment-instances update --name "Example"
+  jamf-cli pro device-enrollment-instances get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro device-enrollment-instances update --name "Example"
 
   # Get a device-enrollment-instance, modify, and update
-  jamf-cli device-enrollment-instances get 1 -o json | jq '.name = "New Name"' | jamf-cli device-enrollment-instances update 1`,
+  jamf-cli pro device-enrollment-instances get 1 -o json | jq '.name = "New Name"' | jamf-cli pro device-enrollment-instances update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -480,13 +480,13 @@ func newDeviceEnrollmentInstancesDeleteCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Delete a Device Enrollment Instance with the supplied id",
 		Long:  "Deletes a Device Enrollment Instance with the supplied id",
 		Example: `  # Delete a device-enrollment-instance (with confirmation)
-  jamf-cli device-enrollment-instances delete 1
+  jamf-cli pro device-enrollment-instances delete 1
 
   # Delete by name
-  jamf-cli device-enrollment-instances delete --name "Example" --yes
+  jamf-cli pro device-enrollment-instances delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli device-enrollment-instances delete 1 --yes`,
+  jamf-cli pro device-enrollment-instances delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -597,10 +597,10 @@ func newDeviceEnrollmentInstancesHistoryCmd(ctx *registry.CLIContext) *cobra.Com
 		Short: "Get sorted and paged Device Enrollment history objects",
 		Long:  "Gets sorted and paged device enrollment history objects",
 		Example: `  # Get history for a device-enrollment-instance by ID
-  jamf-cli device-enrollment-instances history 1
+  jamf-cli pro device-enrollment-instances history 1
 
   # Get history by name
-  jamf-cli device-enrollment-instances history --name "Example"`,
+  jamf-cli pro device-enrollment-instances history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -1020,19 +1020,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a device-enrollment-instance from a JSON file
-  jamf-cli device-enrollment-instances apply --from-file device-enrollment-instance.json
+  jamf-cli pro device-enrollment-instances apply --from-file device-enrollment-instance.json
 
   # Apply a device-enrollment-instance from a YAML file
-  jamf-cli device-enrollment-instances apply --from-file device-enrollment-instance.yaml
+  jamf-cli pro device-enrollment-instances apply --from-file device-enrollment-instance.yaml
 
   # Apply from stdin
-  cat device-enrollment-instance.json | jamf-cli device-enrollment-instances apply
+  cat device-enrollment-instance.json | jamf-cli pro device-enrollment-instances apply
 
   # Apply without replacement confirmation
-  jamf-cli device-enrollment-instances apply --from-file device-enrollment-instance.json --yes
+  jamf-cli pro device-enrollment-instances apply --from-file device-enrollment-instance.json --yes
 
   # Preview what would happen
-  jamf-cli device-enrollment-instances apply --from-file device-enrollment-instance.json --dry-run`,
+  jamf-cli pro device-enrollment-instances apply --from-file device-enrollment-instance.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/digi_cert_settings.go
+++ b/internal/commands/pro/generated/digi_cert_settings.go
@@ -47,13 +47,13 @@ func newDigiCertSettingsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve DigiCert Trust Lifecycle Manager configuration",
 		Long:  "Retrieve the current configuration of the DigiCert Trust Lifecycle Manager.",
 		Example: `  # Get a digi-cert-setting by ID
-  jamf-cli digi-cert-settings get 1
+  jamf-cli pro digi-cert-settings get 1
 
   # Get a digi-cert-setting by name
-  jamf-cli digi-cert-settings get --name "Example"
+  jamf-cli pro digi-cert-settings get --name "Example"
 
   # Get a digi-cert-setting and output as YAML
-  jamf-cli digi-cert-settings get 1 -o yaml`,
+  jamf-cli pro digi-cert-settings get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -108,13 +108,13 @@ func newDigiCertSettingsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create DigiCert Trust Lifecycle Manager configuration with client authentication via client certificate.",
 		Long:  "Create DigiCert Trust Lifecycle Manager configuration and initialize renewal monitor.",
 		Example: `  # Show the JSON template for creating a digi-cert-setting
-  jamf-cli digi-cert-settings create --scaffold
+  jamf-cli pro digi-cert-settings create --scaffold
 
   # Create a digi-cert-setting from JSON
-  echo '{"name":"Example"}' | jamf-cli digi-cert-settings create
+  echo '{"name":"Example"}' | jamf-cli pro digi-cert-settings create
 
   # Get a digi-cert-setting, modify it, and create a copy
-  jamf-cli digi-cert-settings get 1 -o json | jq '.name = "Copy"' | jamf-cli digi-cert-settings create`,
+  jamf-cli pro digi-cert-settings get 1 -o json | jq '.name = "Copy"' | jamf-cli pro digi-cert-settings create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -181,13 +181,13 @@ func newDigiCertSettingsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete DigiCert Trust Lifecycle Manager configuration",
 		Long:  "Delete the current configuration of the DigiCert Trust Lifecycle Manager.",
 		Example: `  # Delete a digi-cert-setting (with confirmation)
-  jamf-cli digi-cert-settings delete 1
+  jamf-cli pro digi-cert-settings delete 1
 
   # Delete by name
-  jamf-cli digi-cert-settings delete --name "Example" --yes
+  jamf-cli pro digi-cert-settings delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli digi-cert-settings delete 1 --yes`,
+  jamf-cli pro digi-cert-settings delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -357,16 +357,16 @@ func newDigiCertSettingsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update DigiCert Trust Lifecycle Manager configuration",
 		Long:  "Update DigiCert Trust Lifecycle Manager configuration, where the client certificate information must be provided in full or not at all.\n\nIdentify the resource by ID (positional arg), --name, . Omit ID to use a lookup flag.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  caName                                       string\n  clientCert.filename                          string\n  clientCert.password                          string\n  fqdn                                         string\n  revocationEnabled                            boolean\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field by ID
-  jamf-cli digi-cert-settings patch 1 --set general.managed=true
+  jamf-cli pro digi-cert-settings patch 1 --set general.managed=true
 
   # Update multiple fields
-  jamf-cli digi-cert-settings patch 1 --set field1=value1 --set field2=value2
+  jamf-cli pro digi-cert-settings patch 1 --set field1=value1 --set field2=value2
 
   # Update by name
-  jamf-cli digi-cert-settings patch --name "Example" --set general.managed=true
+  jamf-cli pro digi-cert-settings patch --name "Example" --set general.managed=true
 
   # Patch from a file
-  jamf-cli digi-cert-settings patch 1 --from-file changes.json`,
+  jamf-cli pro digi-cert-settings patch 1 --from-file changes.json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -582,19 +582,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a digi-cert-setting from a JSON file
-  jamf-cli digi-cert-settings apply --from-file digi-cert-setting.json
+  jamf-cli pro digi-cert-settings apply --from-file digi-cert-setting.json
 
   # Apply a digi-cert-setting from a YAML file
-  jamf-cli digi-cert-settings apply --from-file digi-cert-setting.yaml
+  jamf-cli pro digi-cert-settings apply --from-file digi-cert-setting.yaml
 
   # Apply from stdin
-  cat digi-cert-setting.json | jamf-cli digi-cert-settings apply
+  cat digi-cert-setting.json | jamf-cli pro digi-cert-settings apply
 
   # Apply without replacement confirmation
-  jamf-cli digi-cert-settings apply --from-file digi-cert-setting.json --yes
+  jamf-cli pro digi-cert-settings apply --from-file digi-cert-setting.json --yes
 
   # Preview what would happen
-  jamf-cli digi-cert-settings apply --from-file digi-cert-setting.json --dry-run`,
+  jamf-cli pro digi-cert-settings apply --from-file digi-cert-setting.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/distribution_points.go
+++ b/internal/commands/pro/generated/distribution_points.go
@@ -55,10 +55,10 @@ func newDistributionPointsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Finds all Distribution Points",
 		Long:  "Finds all Distribution Points",
 		Example: `  # List all distribution-points
-  jamf-cli distribution-points list
+  jamf-cli pro distribution-points list
 
   # List distribution-points and extract IDs
-  jamf-cli distribution-points list --field id`,
+  jamf-cli pro distribution-points list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -181,13 +181,13 @@ func newDistributionPointsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified distribution point",
 		Long:  "Get specified distribution point",
 		Example: `  # Get a distribution-point by ID
-  jamf-cli distribution-points get 1
+  jamf-cli pro distribution-points get 1
 
   # Get a distribution-point by name
-  jamf-cli distribution-points get --name "Example"
+  jamf-cli pro distribution-points get --name "Example"
 
   # Get a distribution-point and output as YAML
-  jamf-cli distribution-points get 1 -o yaml`,
+  jamf-cli pro distribution-points get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newDistributionPointsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create distribution point",
 		Long:  "Create distribution point",
 		Example: `  # Show the JSON template for creating a distribution-point
-  jamf-cli distribution-points create --scaffold
+  jamf-cli pro distribution-points create --scaffold
 
   # Create a distribution-point from JSON
-  echo '{"name":"Example"}' | jamf-cli distribution-points create
+  echo '{"name":"Example"}' | jamf-cli pro distribution-points create
 
   # Get a distribution-point, modify it, and create a copy
-  jamf-cli distribution-points get 1 -o json | jq '.name = "Copy"' | jamf-cli distribution-points create`,
+  jamf-cli pro distribution-points get 1 -o json | jq '.name = "Copy"' | jamf-cli pro distribution-points create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -332,13 +332,13 @@ func newDistributionPointsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update specified distribution point object",
 		Long:  "Update specified distribution point object",
 		Example: `  # Update a distribution-point from JSON
-  echo '{"name":"Updated"}' | jamf-cli distribution-points update 1
+  echo '{"name":"Updated"}' | jamf-cli pro distribution-points update 1
 
   # Update by name
-  jamf-cli distribution-points get --name "Example" -o json | jq '.field = "value"' | jamf-cli distribution-points update --name "Example"
+  jamf-cli pro distribution-points get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro distribution-points update --name "Example"
 
   # Get a distribution-point, modify, and update
-  jamf-cli distribution-points get 1 -o json | jq '.name = "New Name"' | jamf-cli distribution-points update 1`,
+  jamf-cli pro distribution-points get 1 -o json | jq '.name = "New Name"' | jamf-cli pro distribution-points update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -440,13 +440,13 @@ func newDistributionPointsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Remove specified distribution point",
 		Long:  "Removes specified distribution point",
 		Example: `  # Delete a distribution-point (with confirmation)
-  jamf-cli distribution-points delete 1
+  jamf-cli pro distribution-points delete 1
 
   # Delete by name
-  jamf-cli distribution-points delete --name "Example" --yes
+  jamf-cli pro distribution-points delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli distribution-points delete 1 --yes`,
+  jamf-cli pro distribution-points delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -554,7 +554,7 @@ func newDistributionPointsDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.Com
 		Short: "Delete multiple distribution points at once",
 		Long:  "Delete multiple distribution points at once",
 		Example: `  # Delete multiple distribution-points by IDs
-  jamf-cli distribution-points delete-multiple --ids 1,2,3 --yes`,
+  jamf-cli pro distribution-points delete-multiple --ids 1,2,3 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -654,10 +654,10 @@ func newDistributionPointsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified distribution point History object",
 		Long:  "Gets specified distribution point history object",
 		Example: `  # Get history for a distribution-point by ID
-  jamf-cli distribution-points history 1
+  jamf-cli pro distribution-points history 1
 
   # Get history by name
-  jamf-cli distribution-points history --name "Example"`,
+  jamf-cli pro distribution-points history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -879,16 +879,16 @@ func newDistributionPointsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update specified distribution point object",
 		Long:  "Updates the specified object configuration of a File Share Distribution Point in Jamf Pro. ID path parameter is mandatory and other fields can be updated as a whole or with minimal object.\n\nIdentify the resource by ID (positional arg), --name, . Omit ID to use a lookup flag.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  backupDistributionPointId                    string\n  enableLoadBalancing                          boolean\n  fileSharingConnectionType                    string\n  httpsContext                                 string\n  httpsEnabled                                 boolean\n  httpsPassword                                string\n  httpsPort                                    integer\n  httpsSecurityType                            string\n  httpsUsername                                string\n  localPathToShare                             string\n  name                                         string\n  port                                         integer\n  principal                                    boolean\n  readOnlyPassword                             string\n  readOnlyUsername                             string\n  readWritePassword                            string\n  readWriteUsername                            string\n  serverName                                   string\n  shareName                                    string\n  sshPassword                                  string\n  sshUsername                                  string\n  workgroup                                    string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field by ID
-  jamf-cli distribution-points patch 1 --set general.managed=true
+  jamf-cli pro distribution-points patch 1 --set general.managed=true
 
   # Update multiple fields
-  jamf-cli distribution-points patch 1 --set field1=value1 --set field2=value2
+  jamf-cli pro distribution-points patch 1 --set field1=value1 --set field2=value2
 
   # Update by name
-  jamf-cli distribution-points patch --name "Example" --set general.managed=true
+  jamf-cli pro distribution-points patch --name "Example" --set general.managed=true
 
   # Patch from a file
-  jamf-cli distribution-points patch 1 --from-file changes.json`,
+  jamf-cli pro distribution-points patch 1 --from-file changes.json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -1016,19 +1016,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a distribution-point from a JSON file
-  jamf-cli distribution-points apply --from-file distribution-point.json
+  jamf-cli pro distribution-points apply --from-file distribution-point.json
 
   # Apply a distribution-point from a YAML file
-  jamf-cli distribution-points apply --from-file distribution-point.yaml
+  jamf-cli pro distribution-points apply --from-file distribution-point.yaml
 
   # Apply from stdin
-  cat distribution-point.json | jamf-cli distribution-points apply
+  cat distribution-point.json | jamf-cli pro distribution-points apply
 
   # Apply without replacement confirmation
-  jamf-cli distribution-points apply --from-file distribution-point.json --yes
+  jamf-cli pro distribution-points apply --from-file distribution-point.json --yes
 
   # Preview what would happen
-  jamf-cli distribution-points apply --from-file distribution-point.json --dry-run`,
+  jamf-cli pro distribution-points apply --from-file distribution-point.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/dock_items.go
+++ b/internal/commands/pro/generated/dock_items.go
@@ -44,13 +44,13 @@ func newDockItemsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve a full dockItem object",
 		Long:  "Retrieves a full dockItem object",
 		Example: `  # Get a dock-item by ID
-  jamf-cli dock-items get 1
+  jamf-cli pro dock-items get 1
 
   # Get a dock-item by name
-  jamf-cli dock-items get --name "Example"
+  jamf-cli pro dock-items get --name "Example"
 
   # Get a dock-item and output as YAML
-  jamf-cli dock-items get 1 -o yaml`,
+  jamf-cli pro dock-items get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -105,13 +105,13 @@ func newDockItemsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a DockItem",
 		Long:  "Creates a DockItem",
 		Example: `  # Show the JSON template for creating a dock-item
-  jamf-cli dock-items create --scaffold
+  jamf-cli pro dock-items create --scaffold
 
   # Create a dock-item from JSON
-  echo '{"name":"Example"}' | jamf-cli dock-items create
+  echo '{"name":"Example"}' | jamf-cli pro dock-items create
 
   # Get a dock-item, modify it, and create a copy
-  jamf-cli dock-items get 1 -o json | jq '.name = "Copy"' | jamf-cli dock-items create`,
+  jamf-cli pro dock-items get 1 -o json | jq '.name = "Copy"' | jamf-cli pro dock-items create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -176,13 +176,13 @@ func newDockItemsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Replace the dockItem at the id with the supplied information",
 		Long:  "Replaces the dockItem at the id with the supplied information",
 		Example: `  # Update a dock-item from JSON
-  echo '{"name":"Updated"}' | jamf-cli dock-items update 1
+  echo '{"name":"Updated"}' | jamf-cli pro dock-items update 1
 
   # Update by name
-  jamf-cli dock-items get --name "Example" -o json | jq '.field = "value"' | jamf-cli dock-items update --name "Example"
+  jamf-cli pro dock-items get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro dock-items update --name "Example"
 
   # Get a dock-item, modify, and update
-  jamf-cli dock-items get 1 -o json | jq '.name = "New Name"' | jamf-cli dock-items update 1`,
+  jamf-cli pro dock-items get 1 -o json | jq '.name = "New Name"' | jamf-cli pro dock-items update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -265,13 +265,13 @@ func newDockItemsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete a DockItem at the specified id",
 		Long:  "Deletes a dockItem at the specified id",
 		Example: `  # Delete a dock-item (with confirmation)
-  jamf-cli dock-items delete 1
+  jamf-cli pro dock-items delete 1
 
   # Delete by name
-  jamf-cli dock-items delete --name "Example" --yes
+  jamf-cli pro dock-items delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli dock-items delete 1 --yes`,
+  jamf-cli pro dock-items delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -383,19 +383,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a dock-item from a JSON file
-  jamf-cli dock-items apply --from-file dock-item.json
+  jamf-cli pro dock-items apply --from-file dock-item.json
 
   # Apply a dock-item from a YAML file
-  jamf-cli dock-items apply --from-file dock-item.yaml
+  jamf-cli pro dock-items apply --from-file dock-item.yaml
 
   # Apply from stdin
-  cat dock-item.json | jamf-cli dock-items apply
+  cat dock-item.json | jamf-cli pro dock-items apply
 
   # Apply without replacement confirmation
-  jamf-cli dock-items apply --from-file dock-item.json --yes
+  jamf-cli pro dock-items apply --from-file dock-item.json --yes
 
   # Preview what would happen
-  jamf-cli dock-items apply --from-file dock-item.json --dry-run`,
+  jamf-cli pro dock-items apply --from-file dock-item.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/dss_proxies.go
+++ b/internal/commands/pro/generated/dss_proxies.go
@@ -32,10 +32,10 @@ func newDssProxiesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve an existing declaration",
 		Long:  "Retrieves a stored declaration based on the provided declaration id",
 		Example: `  # Get a dss-proxy by ID
-  jamf-cli dss-proxies get 1
+  jamf-cli pro dss-proxies get 1
 
   # Get a dss-proxy and output as YAML
-  jamf-cli dss-proxies get 1 -o yaml`,
+  jamf-cli pro dss-proxies get 1 -o yaml`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/ebooks.go
+++ b/internal/commands/pro/generated/ebooks.go
@@ -43,10 +43,10 @@ func newEbooksListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Ebook object",
 		Long:  "Gets ebook object",
 		Example: `  # List all ebooks
-  jamf-cli ebooks list
+  jamf-cli pro ebooks list
 
   # List ebooks and extract IDs
-  jamf-cli ebooks list --field id`,
+  jamf-cli pro ebooks list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -165,13 +165,13 @@ func newEbooksGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Ebook object",
 		Long:  "Gets specified Ebook object",
 		Example: `  # Get a ebook by ID
-  jamf-cli ebooks get 1
+  jamf-cli pro ebooks get 1
 
   # Get a ebook by name
-  jamf-cli ebooks get --name "Example"
+  jamf-cli pro ebooks get --name "Example"
 
   # Get a ebook and output as YAML
-  jamf-cli ebooks get 1 -o yaml`,
+  jamf-cli pro ebooks get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/enrollment_customization_panels.go
+++ b/internal/commands/pro/generated/enrollment_customization_panels.go
@@ -48,13 +48,13 @@ func newEnrollmentCustomizationPanelsCreateCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Create an LDAP Panel for a single Enrollment Customization",
 		Long:  "Create an LDAP panel for a single enrollment customization. If multiple LDAP access groups are defined with the same name and id, only one will be saved.",
 		Example: `  # Show the JSON template for creating a enrollment-customization-panel
-  jamf-cli enrollment-customization-panels create --scaffold
+  jamf-cli pro enrollment-customization-panels create --scaffold
 
   # Create a enrollment-customization-panel from JSON
-  echo '{"name":"Example"}' | jamf-cli enrollment-customization-panels create
+  echo '{"name":"Example"}' | jamf-cli pro enrollment-customization-panels create
 
   # Get a enrollment-customization-panel, modify it, and create a copy
-  jamf-cli enrollment-customization-panels get 1 -o json | jq '.name = "Copy"' | jamf-cli enrollment-customization-panels create`,
+  jamf-cli pro enrollment-customization-panels get 1 -o json | jq '.name = "Copy"' | jamf-cli pro enrollment-customization-panels create`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -125,10 +125,10 @@ func newEnrollmentCustomizationPanelsUpdateCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Update a single LDAP Panel for a single Enrollment Customization",
 		Long:  "Update a single LDAP panel for a single enrollment customization. If multiple LDAP access groups are defined with the same name and id, only one will be saved.",
 		Example: `  # Update a enrollment-customization-panel from JSON
-  echo '{"name":"Updated"}' | jamf-cli enrollment-customization-panels update 1 2
+  echo '{"name":"Updated"}' | jamf-cli pro enrollment-customization-panels update 1 2
 
   # Get a enrollment-customization-panel, modify, and update
-  jamf-cli enrollment-customization-panels get 1 2 -o json | jq '.name = "New Name"' | jamf-cli enrollment-customization-panels update 1 2`,
+  jamf-cli pro enrollment-customization-panels get 1 2 -o json | jq '.name = "New Name"' | jamf-cli pro enrollment-customization-panels update 1 2`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -201,10 +201,10 @@ func newEnrollmentCustomizationPanelsDeleteCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Delete a single Panel from an Enrollment Customization",
 		Long:  "Delete a single panel from an Enrollment Customization",
 		Example: `  # Delete a enrollment-customization-panel (with confirmation)
-  jamf-cli enrollment-customization-panels delete 1 2
+  jamf-cli pro enrollment-customization-panels delete 1 2
 
   # Delete without confirmation prompt
-  jamf-cli enrollment-customization-panels delete 1 2 --yes`,
+  jamf-cli pro enrollment-customization-panels delete 1 2 --yes`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/enrollment_customizations.go
+++ b/internal/commands/pro/generated/enrollment_customizations.go
@@ -57,10 +57,10 @@ func newEnrollmentCustomizationsListCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Retrieve sorted and paged Enrollment Customizations",
 		Long:  "Retrieves sorted and paged Enrollment Customizations",
 		Example: `  # List all enrollment-customizations
-  jamf-cli enrollment-customizations list
+  jamf-cli pro enrollment-customizations list
 
   # List enrollment-customizations and extract IDs
-  jamf-cli enrollment-customizations list --field id`,
+  jamf-cli pro enrollment-customizations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -179,13 +179,13 @@ func newEnrollmentCustomizationsGetCmd(ctx *registry.CLIContext) *cobra.Command 
 		Short: "Retrieve an Enrollment Customization with the supplied id",
 		Long:  "Retrieves an Enrollment Customization with the supplied id",
 		Example: `  # Get a enrollment-customization by ID
-  jamf-cli enrollment-customizations get 1
+  jamf-cli pro enrollment-customizations get 1
 
   # Get a enrollment-customization by name
-  jamf-cli enrollment-customizations get --name "Example"
+  jamf-cli pro enrollment-customizations get --name "Example"
 
   # Get a enrollment-customization and output as YAML
-  jamf-cli enrollment-customizations get 1 -o yaml`,
+  jamf-cli pro enrollment-customizations get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -240,13 +240,13 @@ func newEnrollmentCustomizationsCreateCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Create an Enrollment Customization",
 		Long:  "Create an enrollment customization",
 		Example: `  # Show the JSON template for creating a enrollment-customization
-  jamf-cli enrollment-customizations create --scaffold
+  jamf-cli pro enrollment-customizations create --scaffold
 
   # Create a enrollment-customization from JSON
-  echo '{"name":"Example"}' | jamf-cli enrollment-customizations create
+  echo '{"name":"Example"}' | jamf-cli pro enrollment-customizations create
 
   # Get a enrollment-customization, modify it, and create a copy
-  jamf-cli enrollment-customizations get 1 -o json | jq '.name = "Copy"' | jamf-cli enrollment-customizations create`,
+  jamf-cli pro enrollment-customizations get 1 -o json | jq '.name = "Copy"' | jamf-cli pro enrollment-customizations create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -312,13 +312,13 @@ func newEnrollmentCustomizationsUpdateCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Update an Enrollment Customization",
 		Long:  "Updates an Enrollment Customization",
 		Example: `  # Update a enrollment-customization from JSON
-  echo '{"name":"Updated"}' | jamf-cli enrollment-customizations update 1
+  echo '{"name":"Updated"}' | jamf-cli pro enrollment-customizations update 1
 
   # Update by name
-  jamf-cli enrollment-customizations get --name "Example" -o json | jq '.field = "value"' | jamf-cli enrollment-customizations update --name "Example"
+  jamf-cli pro enrollment-customizations get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro enrollment-customizations update --name "Example"
 
   # Get a enrollment-customization, modify, and update
-  jamf-cli enrollment-customizations get 1 -o json | jq '.name = "New Name"' | jamf-cli enrollment-customizations update 1`,
+  jamf-cli pro enrollment-customizations get 1 -o json | jq '.name = "New Name"' | jamf-cli pro enrollment-customizations update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -402,13 +402,13 @@ func newEnrollmentCustomizationsDeleteCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Delete an Enrollment Customization with the supplied id",
 		Long:  "Deletes an Enrollment Customization with the supplied id",
 		Example: `  # Delete a enrollment-customization (with confirmation)
-  jamf-cli enrollment-customizations delete 1
+  jamf-cli pro enrollment-customizations delete 1
 
   # Delete by name
-  jamf-cli enrollment-customizations delete --name "Example" --yes
+  jamf-cli pro enrollment-customizations delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli enrollment-customizations delete 1 --yes`,
+  jamf-cli pro enrollment-customizations delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -518,10 +518,10 @@ func newEnrollmentCustomizationsHistoryCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Get sorted and paged Enrollment Customization history objects",
 		Long:  "Gets sorted and paged enrollment customization history objects",
 		Example: `  # Get history for a enrollment-customization by ID
-  jamf-cli enrollment-customizations history 1
+  jamf-cli pro enrollment-customizations history 1
 
   # Get history by name
-  jamf-cli enrollment-customizations history --name "Example"`,
+  jamf-cli pro enrollment-customizations history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -927,19 +927,19 @@ The displayName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a enrollment-customization from a JSON file
-  jamf-cli enrollment-customizations apply --from-file enrollment-customization.json
+  jamf-cli pro enrollment-customizations apply --from-file enrollment-customization.json
 
   # Apply a enrollment-customization from a YAML file
-  jamf-cli enrollment-customizations apply --from-file enrollment-customization.yaml
+  jamf-cli pro enrollment-customizations apply --from-file enrollment-customization.yaml
 
   # Apply from stdin
-  cat enrollment-customization.json | jamf-cli enrollment-customizations apply
+  cat enrollment-customization.json | jamf-cli pro enrollment-customizations apply
 
   # Apply without replacement confirmation
-  jamf-cli enrollment-customizations apply --from-file enrollment-customization.json --yes
+  jamf-cli pro enrollment-customizations apply --from-file enrollment-customization.json --yes
 
   # Preview what would happen
-  jamf-cli enrollment-customizations apply --from-file enrollment-customization.json --dry-run`,
+  jamf-cli pro enrollment-customizations apply --from-file enrollment-customization.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/enrollment_languages.go
+++ b/internal/commands/pro/generated/enrollment_languages.go
@@ -51,10 +51,10 @@ func newEnrollmentLanguagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get an array of the language codes that have Enrollment messaging",
 		Long:  "Returns an array of the language codes that have enrollment messaging currently configured.",
 		Example: `  # List all enrollment-languages
-  jamf-cli enrollment-languages list
+  jamf-cli pro enrollment-languages list
 
   # List enrollment-languages and extract IDs
-  jamf-cli enrollment-languages list --field id`,
+  jamf-cli pro enrollment-languages list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -173,13 +173,13 @@ func newEnrollmentLanguagesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve the Enrollment messaging for a language",
 		Long:  "Retrieves the enrollment messaging for a language.",
 		Example: `  # Get a enrollment-language by ID
-  jamf-cli enrollment-languages get 1
+  jamf-cli pro enrollment-languages get 1
 
   # Get a enrollment-language by name
-  jamf-cli enrollment-languages get --name "Example"
+  jamf-cli pro enrollment-languages get --name "Example"
 
   # Get a enrollment-language and output as YAML
-  jamf-cli enrollment-languages get 1 -o yaml`,
+  jamf-cli pro enrollment-languages get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -235,13 +235,13 @@ func newEnrollmentLanguagesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Edit Enrollment messaging for a language",
 		Long:  "Edit enrollment messaging for a language.",
 		Example: `  # Update a enrollment-language from JSON
-  echo '{"name":"Updated"}' | jamf-cli enrollment-languages update 1
+  echo '{"name":"Updated"}' | jamf-cli pro enrollment-languages update 1
 
   # Update by name
-  jamf-cli enrollment-languages get --name "Example" -o json | jq '.field = "value"' | jamf-cli enrollment-languages update --name "Example"
+  jamf-cli pro enrollment-languages get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro enrollment-languages update --name "Example"
 
   # Get a enrollment-language, modify, and update
-  jamf-cli enrollment-languages get 1 -o json | jq '.name = "New Name"' | jamf-cli enrollment-languages update 1`,
+  jamf-cli pro enrollment-languages get 1 -o json | jq '.name = "New Name"' | jamf-cli pro enrollment-languages update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -361,13 +361,13 @@ func newEnrollmentLanguagesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete the Enrollment messaging for a language",
 		Long:  "Delete the enrollment messaging for a language.",
 		Example: `  # Delete a enrollment-language (with confirmation)
-  jamf-cli enrollment-languages delete 1
+  jamf-cli pro enrollment-languages delete 1
 
   # Delete by name
-  jamf-cli enrollment-languages delete --name "Example" --yes
+  jamf-cli pro enrollment-languages delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli enrollment-languages delete 1 --yes`,
+  jamf-cli pro enrollment-languages delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -475,7 +475,7 @@ func newEnrollmentLanguagesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Delete multiple configured languages from User-Initiated Enrollment settings",
 		Long:  "Delete multiple configured languages from User-Initiated Enrollment settings",
 		Example: `  # Delete multiple enrollment-languages by IDs
-  jamf-cli enrollment-languages delete-multiple --ids 1,2,3 --yes`,
+  jamf-cli pro enrollment-languages delete-multiple --ids 1,2,3 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/enrollment_settings.go
+++ b/internal/commands/pro/generated/enrollment_settings.go
@@ -56,10 +56,10 @@ func newEnrollmentSettingsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve the configured LDAP groups configured for User-Initiated Enrollment.",
 		Long:  "Retrieves the configured LDAP groups configured for User-Initiated Enrollment.",
 		Example: `  # List all enrollment-settings
-  jamf-cli enrollment-settings list
+  jamf-cli pro enrollment-settings list
 
   # List enrollment-settings and extract IDs
-  jamf-cli enrollment-settings list --field id`,
+  jamf-cli pro enrollment-settings list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -182,13 +182,13 @@ func newEnrollmentSettingsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve the configured LDAP groups configured for User-Initiated Enrollment",
 		Long:  "Retrieves the configured LDAP groups configured for User-Initiated Enrollment.",
 		Example: `  # Get a enrollment-setting by ID
-  jamf-cli enrollment-settings get 1
+  jamf-cli pro enrollment-settings get 1
 
   # Get a enrollment-setting by name
-  jamf-cli enrollment-settings get --name "Example"
+  jamf-cli pro enrollment-settings get --name "Example"
 
   # Get a enrollment-setting and output as YAML
-  jamf-cli enrollment-settings get 1 -o yaml`,
+  jamf-cli pro enrollment-settings get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -243,13 +243,13 @@ func newEnrollmentSettingsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Add the configured LDAP group for User-Initiated Enrollment.",
 		Long:  "Add the configured LDAP group for User-Initiated Enrollment.",
 		Example: `  # Show the JSON template for creating a enrollment-setting
-  jamf-cli enrollment-settings create --scaffold
+  jamf-cli pro enrollment-settings create --scaffold
 
   # Create a enrollment-setting from JSON
-  echo '{"name":"Example"}' | jamf-cli enrollment-settings create
+  echo '{"name":"Example"}' | jamf-cli pro enrollment-settings create
 
   # Get a enrollment-setting, modify it, and create a copy
-  jamf-cli enrollment-settings get 1 -o json | jq '.name = "Copy"' | jamf-cli enrollment-settings create`,
+  jamf-cli pro enrollment-settings get 1 -o json | jq '.name = "Copy"' | jamf-cli pro enrollment-settings create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -319,13 +319,13 @@ func newEnrollmentSettingsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Modify the configured LDAP groups configured for User-Initiated Enrollment. Only exiting Access Groups can be updated.",
 		Long:  "Modify the configured LDAP groups configured for User-Initiated Enrollment. Only exiting Access Groups can be updated.",
 		Example: `  # Update a enrollment-setting from JSON
-  echo '{"name":"Updated"}' | jamf-cli enrollment-settings update 1
+  echo '{"name":"Updated"}' | jamf-cli pro enrollment-settings update 1
 
   # Update by name
-  jamf-cli enrollment-settings get --name "Example" -o json | jq '.field = "value"' | jamf-cli enrollment-settings update --name "Example"
+  jamf-cli pro enrollment-settings get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro enrollment-settings update --name "Example"
 
   # Get a enrollment-setting, modify, and update
-  jamf-cli enrollment-settings get 1 -o json | jq '.name = "New Name"' | jamf-cli enrollment-settings update 1`,
+  jamf-cli pro enrollment-settings get 1 -o json | jq '.name = "New Name"' | jamf-cli pro enrollment-settings update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -413,13 +413,13 @@ func newEnrollmentSettingsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete an LDAP group's access to user initiated Enrollment.",
 		Long:  "Deletes an LDAP group's access to user initiated enrollment. The group \"All LDAP Users\" cannot be deleted, but it can be modified to disallow User-Initiated Enrollment.",
 		Example: `  # Delete a enrollment-setting (with confirmation)
-  jamf-cli enrollment-settings delete 1
+  jamf-cli pro enrollment-settings delete 1
 
   # Delete by name
-  jamf-cli enrollment-settings delete --name "Example" --yes
+  jamf-cli pro enrollment-settings delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli enrollment-settings delete 1 --yes`,
+  jamf-cli pro enrollment-settings delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -528,7 +528,7 @@ func newEnrollmentSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get sorted and paged Enrollment history object",
 		Long:  "Gets sorted and paged Enrollment history object",
 		Example: `  # Get history for a enrollment-setting
-  jamf-cli enrollment-settings history 1`,
+  jamf-cli pro enrollment-settings history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -959,19 +959,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a enrollment-setting from a JSON file
-  jamf-cli enrollment-settings apply --from-file enrollment-setting.json
+  jamf-cli pro enrollment-settings apply --from-file enrollment-setting.json
 
   # Apply a enrollment-setting from a YAML file
-  jamf-cli enrollment-settings apply --from-file enrollment-setting.yaml
+  jamf-cli pro enrollment-settings apply --from-file enrollment-setting.yaml
 
   # Apply from stdin
-  cat enrollment-setting.json | jamf-cli enrollment-settings apply
+  cat enrollment-setting.json | jamf-cli pro enrollment-settings apply
 
   # Apply without replacement confirmation
-  jamf-cli enrollment-settings apply --from-file enrollment-setting.json --yes
+  jamf-cli pro enrollment-settings apply --from-file enrollment-setting.json --yes
 
   # Preview what would happen
-  jamf-cli enrollment-settings apply --from-file enrollment-setting.json --dry-run`,
+  jamf-cli pro enrollment-settings apply --from-file enrollment-setting.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/groups.go
+++ b/internal/commands/pro/generated/groups.go
@@ -49,10 +49,10 @@ func newGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Returns group information for all Mobile Device and Computer groups",
 		Long:  "Returns group information for all Mobile Device and Computer groups. The type of groups returned will be dependent upon the corresponding group type READ privileges. Results can be sorted by name, description, group type, or isSmart. Default sorting is by group name in ascending order.",
 		Example: `  # List all groups
-  jamf-cli groups list
+  jamf-cli pro groups list
 
   # List groups and extract IDs
-  jamf-cli groups list --field id`,
+  jamf-cli pro groups list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -175,13 +175,13 @@ func newGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Returns group information for the given platform UUID",
 		Long:  "Returns group information for the given platform UUID. Dependent upon the returned group type the corresponding READ privilege for that group type will be needed.",
 		Example: `  # Get a group by ID
-  jamf-cli groups get 1
+  jamf-cli pro groups get 1
 
   # Get a group by name
-  jamf-cli groups get --name "Example"
+  jamf-cli pro groups get --name "Example"
 
   # Get a group and output as YAML
-  jamf-cli groups get 1 -o yaml`,
+  jamf-cli pro groups get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -238,13 +238,13 @@ func newGroupsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete a group by platform UUID",
 		Long:  "Deletes a group by its platform UUID. Returns a 400 error if the group is being used as a dependency. Requires appropriate DELETE privileges.",
 		Example: `  # Delete a group (with confirmation)
-  jamf-cli groups delete 1
+  jamf-cli pro groups delete 1
 
   # Delete by name
-  jamf-cli groups delete --name "Example" --yes
+  jamf-cli pro groups delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli groups delete 1 --yes`,
+  jamf-cli pro groups delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -352,16 +352,16 @@ func newGroupsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a group by platform UUID",
 		Long:  "Updates a group by its platform UUID. For both smart and static groups, groupName and groupDescription can be updated. For smart groups, criteria can also be updated. For static groups, assignments can also be updated. Requires appropriate UPDATE privileges.\n\nIdentify the resource by ID (positional arg), --name, . Omit ID to use a lookup flag.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  groupDescription                             string\n  groupName                                    string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field by ID
-  jamf-cli groups patch 1 --set general.managed=true
+  jamf-cli pro groups patch 1 --set general.managed=true
 
   # Update multiple fields
-  jamf-cli groups patch 1 --set field1=value1 --set field2=value2
+  jamf-cli pro groups patch 1 --set field1=value1 --set field2=value2
 
   # Update by name
-  jamf-cli groups patch --name "Example" --set general.managed=true
+  jamf-cli pro groups patch --name "Example" --set general.managed=true
 
   # Patch from a file
-  jamf-cli groups patch 1 --from-file changes.json`,
+  jamf-cli pro groups patch 1 --from-file changes.json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/gsx_connection.go
+++ b/internal/commands/pro/generated/gsx_connection.go
@@ -42,10 +42,10 @@ func newGsxConnectionGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Finds the Jamf Pro GSX Connection information",
 		Long:  "Finds the Jamf Pro GSX Connection information",
 		Example: `  # Get gsx-connection
-  jamf-cli gsx-connection get
+  jamf-cli pro gsx-connection get
 
   # Get gsx-connection and output as YAML
-  jamf-cli gsx-connection get -o yaml`,
+  jamf-cli pro gsx-connection get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -82,10 +82,10 @@ func newGsxConnectionUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Updates Jamf Pro GSX Connection information",
 		Long:  "Updates Jamf Pro GSX Connection information",
 		Example: `  # Update gsx-connection
-  jamf-cli gsx-connection get -o json | jq '.field = "value"' | jamf-cli gsx-connection update
+  jamf-cli pro gsx-connection get -o json | jq '.field = "value"' | jamf-cli pro gsx-connection update
 
   # Update from a file
-  jamf-cli gsx-connection update --from-file gsx-connection.json`,
+  jamf-cli pro gsx-connection update --from-file gsx-connection.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -157,7 +157,7 @@ func newGsxConnectionHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified GSX Connection History object",
 		Long:  "Gets specified GSX Connection history object",
 		Example: `  # Get history for a gsx-connection
-  jamf-cli gsx-connection history 1`,
+  jamf-cli pro gsx-connection history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -342,10 +342,10 @@ func newGsxConnectionPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Updates Jamf Pro GSX Connection information",
 		Long:  "Updates Jamf Pro GSX Connection information\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  enabled                                      boolean\n  gsxKeystore.keystoreBytes                    string\n  gsxKeystore.keystorePassword                 string\n  gsxKeystore.name                             string\n  serviceAccountNo                             string\n  shipToNo                                     string\n  token                                        string\n  username                                     string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field
-  jamf-cli gsx-connection patch --set field=value
+  jamf-cli pro gsx-connection patch --set field=value
 
   # Update using JSON
-  jamf-cli gsx-connection get -o json | jq '.field = "value"' | jamf-cli gsx-connection patch`,
+  jamf-cli pro gsx-connection get -o json | jq '.field = "value"' | jamf-cli pro gsx-connection patch`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/icons.go
+++ b/internal/commands/pro/generated/icons.go
@@ -42,13 +42,13 @@ func newIconsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get an icon",
 		Long:  "Get an icon",
 		Example: `  # Get a icon by ID
-  jamf-cli icons get 1
+  jamf-cli pro icons get 1
 
   # Get a icon by name
-  jamf-cli icons get --name "Example"
+  jamf-cli pro icons get --name "Example"
 
   # Get a icon and output as YAML
-  jamf-cli icons get 1 -o yaml`,
+  jamf-cli pro icons get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/impact_alert_notification_settings.go
+++ b/internal/commands/pro/generated/impact_alert_notification_settings.go
@@ -36,10 +36,10 @@ func newImpactAlertNotificationSettingsGetCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Get Impact Alert Notification Settings",
 		Long:  "Get Impact Alert Notification Settings",
 		Example: `  # Get impact-alert-notification-settings
-  jamf-cli impact-alert-notification-settings get
+  jamf-cli pro impact-alert-notification-settings get
 
   # Get impact-alert-notification-settings and output as YAML
-  jamf-cli impact-alert-notification-settings get -o yaml`,
+  jamf-cli pro impact-alert-notification-settings get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -76,10 +76,10 @@ func newImpactAlertNotificationSettingsUpdateCmd(ctx *registry.CLIContext) *cobr
 		Short: "Update Impact Alert Notification Settings",
 		Long:  "Update Impact Alert Notification Settings",
 		Example: `  # Update impact-alert-notification-settings
-  jamf-cli impact-alert-notification-settings get -o json | jq '.field = "value"' | jamf-cli impact-alert-notification-settings update
+  jamf-cli pro impact-alert-notification-settings get -o json | jq '.field = "value"' | jamf-cli pro impact-alert-notification-settings update
 
   # Update from a file
-  jamf-cli impact-alert-notification-settings update --from-file impact-alert-notification-settings.json`,
+  jamf-cli pro impact-alert-notification-settings update --from-file impact-alert-notification-settings.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/inventory_informations.go
+++ b/internal/commands/pro/generated/inventory_informations.go
@@ -31,10 +31,10 @@ func newInventoryInformationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get statistics about managed/unmanaged devices and computers in the inventory",
 		Long:  "Gets statistics about managed/unmanaged devices and computers in the inventory.",
 		Example: `  # List all inventory-informations
-  jamf-cli inventory-informations list
+  jamf-cli pro inventory-informations list
 
   # List inventory-informations and extract IDs
-  jamf-cli inventory-informations list --field id`,
+  jamf-cli pro inventory-informations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/inventory_preloads.go
+++ b/internal/commands/pro/generated/inventory_preloads.go
@@ -62,10 +62,10 @@ func newInventoryPreloadsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Return all Inventory Preload records",
 		Long:  "Returns all Inventory Preload records.",
 		Example: `  # List all inventory-preloads
-  jamf-cli inventory-preloads list
+  jamf-cli pro inventory-preloads list
 
   # List inventory-preloads and extract IDs
-  jamf-cli inventory-preloads list --field id`,
+  jamf-cli pro inventory-preloads list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -188,13 +188,13 @@ func newInventoryPreloadsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get an Inventory Preload record",
 		Long:  "Retrieves an Inventory Preload record.",
 		Example: `  # Get a inventory-preload by ID
-  jamf-cli inventory-preloads get 1
+  jamf-cli pro inventory-preloads get 1
 
   # Get a inventory-preload by name
-  jamf-cli inventory-preloads get --name "Example"
+  jamf-cli pro inventory-preloads get --name "Example"
 
   # Get a inventory-preload and output as YAML
-  jamf-cli inventory-preloads get 1 -o yaml`,
+  jamf-cli pro inventory-preloads get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -249,13 +249,13 @@ func newInventoryPreloadsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a new Inventory Preload record using JSON",
 		Long:  "Create a new Inventory Preload record using JSON.",
 		Example: `  # Show the JSON template for creating a inventory-preload
-  jamf-cli inventory-preloads create --scaffold
+  jamf-cli pro inventory-preloads create --scaffold
 
   # Create a inventory-preload from JSON
-  echo '{"name":"Example"}' | jamf-cli inventory-preloads create
+  echo '{"name":"Example"}' | jamf-cli pro inventory-preloads create
 
   # Get a inventory-preload, modify it, and create a copy
-  jamf-cli inventory-preloads get 1 -o json | jq '.name = "Copy"' | jamf-cli inventory-preloads create`,
+  jamf-cli pro inventory-preloads get 1 -o json | jq '.name = "Copy"' | jamf-cli pro inventory-preloads create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -341,13 +341,13 @@ func newInventoryPreloadsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update an Inventory Preload record",
 		Long:  "Updates an Inventory Preload record.",
 		Example: `  # Update a inventory-preload from JSON
-  echo '{"name":"Updated"}' | jamf-cli inventory-preloads update 1
+  echo '{"name":"Updated"}' | jamf-cli pro inventory-preloads update 1
 
   # Update by name
-  jamf-cli inventory-preloads get --name "Example" -o json | jq '.field = "value"' | jamf-cli inventory-preloads update --name "Example"
+  jamf-cli pro inventory-preloads get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro inventory-preloads update --name "Example"
 
   # Get a inventory-preload, modify, and update
-  jamf-cli inventory-preloads get 1 -o json | jq '.name = "New Name"' | jamf-cli inventory-preloads update 1`,
+  jamf-cli pro inventory-preloads get 1 -o json | jq '.name = "New Name"' | jamf-cli pro inventory-preloads update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -451,13 +451,13 @@ func newInventoryPreloadsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete an Inventory Preload record",
 		Long:  "Deletes an Inventory Preload record.",
 		Example: `  # Delete a inventory-preload (with confirmation)
-  jamf-cli inventory-preloads delete 1
+  jamf-cli pro inventory-preloads delete 1
 
   # Delete by name
-  jamf-cli inventory-preloads delete --name "Example" --yes
+  jamf-cli pro inventory-preloads delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli inventory-preloads delete 1 --yes`,
+  jamf-cli pro inventory-preloads delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -567,7 +567,7 @@ func newInventoryPreloadsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Inventory Preload history entries",
 		Long:  "Gets Inventory Preload history entries.",
 		Example: `  # Get history for a inventory-preload
-  jamf-cli inventory-preloads history 1`,
+  jamf-cli pro inventory-preloads history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -757,7 +757,7 @@ func newInventoryPreloadsExportCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Export a collection of inventory preload records",
 		Long:  "Export a collection of inventory preload records",
 		Example: `  # Export inventory-preloads to CSV
-  jamf-cli inventory-preloads export --out-file inventory-preloads.csv`,
+  jamf-cli pro inventory-preloads export --out-file inventory-preloads.csv`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			reqCtx = registry.WithAccept(reqCtx, "*/*")
@@ -1221,19 +1221,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a inventory-preload from a JSON file
-  jamf-cli inventory-preloads apply --from-file inventory-preload.json
+  jamf-cli pro inventory-preloads apply --from-file inventory-preload.json
 
   # Apply a inventory-preload from a YAML file
-  jamf-cli inventory-preloads apply --from-file inventory-preload.yaml
+  jamf-cli pro inventory-preloads apply --from-file inventory-preload.yaml
 
   # Apply from stdin
-  cat inventory-preload.json | jamf-cli inventory-preloads apply
+  cat inventory-preload.json | jamf-cli pro inventory-preloads apply
 
   # Apply without replacement confirmation
-  jamf-cli inventory-preloads apply --from-file inventory-preload.json --yes
+  jamf-cli pro inventory-preloads apply --from-file inventory-preload.json --yes
 
   # Preview what would happen
-  jamf-cli inventory-preloads apply --from-file inventory-preload.json --dry-run`,
+  jamf-cli pro inventory-preloads apply --from-file inventory-preload.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/jamf_connect_deployment_tasks.go
+++ b/internal/commands/pro/generated/jamf_connect_deployment_tasks.go
@@ -39,13 +39,13 @@ func newJamfConnectDeploymentTasksCreateCmd(ctx *registry.CLIContext) *cobra.Com
 		Short: "Request a retry of Connect install tasks",
 		Long:  "Request a retry of Connect install tasks",
 		Example: `  # Show the JSON template for creating a jamf-connect-deployment-task
-  jamf-cli jamf-connect-deployment-tasks create --scaffold
+  jamf-cli pro jamf-connect-deployment-tasks create --scaffold
 
   # Create a jamf-connect-deployment-task from JSON
-  echo '{"name":"Example"}' | jamf-cli jamf-connect-deployment-tasks create
+  echo '{"name":"Example"}' | jamf-cli pro jamf-connect-deployment-tasks create
 
   # Get a jamf-connect-deployment-task, modify it, and create a copy
-  jamf-cli jamf-connect-deployment-tasks get 1 -o json | jq '.name = "Copy"' | jamf-cli jamf-connect-deployment-tasks create`,
+  jamf-cli pro jamf-connect-deployment-tasks get 1 -o json | jq '.name = "Copy"' | jamf-cli pro jamf-connect-deployment-tasks create`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/jamf_connects.go
+++ b/internal/commands/pro/generated/jamf_connects.go
@@ -48,10 +48,10 @@ func newJamfConnectsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Search for config profiles linked to Jamf Connect",
 		Long:  "Search for config profiles linked to Jamf Connect",
 		Example: `  # List all jamf-connects
-  jamf-cli jamf-connects list
+  jamf-cli pro jamf-connects list
 
   # List jamf-connects and extract IDs
-  jamf-cli jamf-connects list --field id`,
+  jamf-cli pro jamf-connects list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -175,13 +175,13 @@ func newJamfConnectsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update the way the Jamf Connect app gets updated on computers within scope of the associated configuration profile.",
 		Long:  "Update the way the Jamf Connect app gets updated on computers within scope of the associated configuration profile.",
 		Example: `  # Update a jamf-connect from JSON
-  echo '{"name":"Updated"}' | jamf-cli jamf-connects update 1
+  echo '{"name":"Updated"}' | jamf-cli pro jamf-connects update 1
 
   # Update by name
-  jamf-cli jamf-connects get --name "Example" -o json | jq '.field = "value"' | jamf-cli jamf-connects update --name "Example"
+  jamf-cli pro jamf-connects get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro jamf-connects update --name "Example"
 
   # Get a jamf-connect, modify, and update
-  jamf-cli jamf-connects get 1 -o json | jq '.name = "New Name"' | jamf-cli jamf-connects update 1`,
+  jamf-cli pro jamf-connects get 1 -o json | jq '.name = "New Name"' | jamf-cli pro jamf-connects update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -266,7 +266,7 @@ func newJamfConnectsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Jamf Connect history",
 		Long:  "Get Jamf Connect history",
 		Example: `  # Get history for a jamf-connect
-  jamf-cli jamf-connects history 1`,
+  jamf-cli pro jamf-connects history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/jamf_packages.go
+++ b/internal/commands/pro/generated/jamf_packages.go
@@ -34,10 +34,10 @@ func newJamfPackagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get the packages for a given Jamf application",
 		Long:  "Get the packages for a given Jamf application.",
 		Example: `  # List all jamf-packages
-  jamf-cli jamf-packages list
+  jamf-cli pro jamf-packages list
 
   # List jamf-packages and extract IDs
-  jamf-cli jamf-packages list --field id`,
+  jamf-cli pro jamf-packages list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/jamf_pro_informations.go
+++ b/internal/commands/pro/generated/jamf_pro_informations.go
@@ -31,10 +31,10 @@ func newJamfProInformationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get basic information about the Jamf Pro Server",
 		Long:  "Get basic information about the Jamf Pro Server",
 		Example: `  # List all jamf-pro-informations
-  jamf-cli jamf-pro-informations list
+  jamf-cli pro jamf-pro-informations list
 
   # List jamf-pro-informations and extract IDs
-  jamf-cli jamf-pro-informations list --field id`,
+  jamf-cli pro jamf-pro-informations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/jamf_pro_server_url.go
+++ b/internal/commands/pro/generated/jamf_pro_server_url.go
@@ -40,10 +40,10 @@ func newJamfProServerUrlGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Jamf Pro Server URL settings",
 		Long:  "Get Jamf Pro Server URL settings",
 		Example: `  # Get jamf-pro-server-url
-  jamf-cli jamf-pro-server-url get
+  jamf-cli pro jamf-pro-server-url get
 
   # Get jamf-pro-server-url and output as YAML
-  jamf-cli jamf-pro-server-url get -o yaml`,
+  jamf-cli pro jamf-pro-server-url get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -80,10 +80,10 @@ func newJamfProServerUrlUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update Jamf Pro Server URL settings",
 		Long:  "Update Jamf Pro Server URL settings",
 		Example: `  # Update jamf-pro-server-url
-  jamf-cli jamf-pro-server-url get -o json | jq '.field = "value"' | jamf-cli jamf-pro-server-url update
+  jamf-cli pro jamf-pro-server-url get -o json | jq '.field = "value"' | jamf-cli pro jamf-pro-server-url update
 
   # Update from a file
-  jamf-cli jamf-pro-server-url update --from-file jamf-pro-server-url.json`,
+  jamf-cli pro jamf-pro-server-url update --from-file jamf-pro-server-url.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -151,7 +151,7 @@ func newJamfProServerUrlHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Jamf Pro Server URL settings history",
 		Long:  "Gets Jamf Pro Server URL settings history",
 		Example: `  # Get history for a jamf-pro-server-url
-  jamf-cli jamf-pro-server-url history 1`,
+  jamf-cli pro jamf-pro-server-url history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/jamf_pro_versions.go
+++ b/internal/commands/pro/generated/jamf_pro_versions.go
@@ -31,10 +31,10 @@ func newJamfProVersionsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Return information about the Jamf Pro including the current version",
 		Long:  "Returns information about the Jamf Pro including the current version.",
 		Example: `  # List all jamf-pro-versions
-  jamf-cli jamf-pro-versions list
+  jamf-cli pro jamf-pro-versions list
 
   # List jamf-pro-versions and extract IDs
-  jamf-cli jamf-pro-versions list --field id`,
+  jamf-cli pro jamf-pro-versions list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/jamf_protect.go
+++ b/internal/commands/pro/generated/jamf_protect.go
@@ -44,10 +44,10 @@ func newJamfProtectGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Jamf Protect integration settings",
 		Long:  "Jamf Protect integration settings",
 		Example: `  # Get jamf-protect
-  jamf-cli jamf-protect get
+  jamf-cli pro jamf-protect get
 
   # Get jamf-protect and output as YAML
-  jamf-cli jamf-protect get -o yaml`,
+  jamf-cli pro jamf-protect get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -84,13 +84,13 @@ func newJamfProtectCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Register a Jamf Protect API configuration with Jamf Pro",
 		Long:  "Register a Jamf Protect API configuration with Jamf Pro",
 		Example: `  # Show the JSON template for creating a jamf-protect
-  jamf-cli jamf-protect create --scaffold
+  jamf-cli pro jamf-protect create --scaffold
 
   # Create a jamf-protect from JSON
-  echo '{"name":"Example"}' | jamf-cli jamf-protect create
+  echo '{"name":"Example"}' | jamf-cli pro jamf-protect create
 
   # Get a jamf-protect, modify it, and create a copy
-  jamf-cli jamf-protect get 1 -o json | jq '.name = "Copy"' | jamf-cli jamf-protect create`,
+  jamf-cli pro jamf-protect get 1 -o json | jq '.name = "Copy"' | jamf-cli pro jamf-protect create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -154,10 +154,10 @@ func newJamfProtectUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Jamf Protect integration settings",
 		Long:  "Jamf Protect integration settings",
 		Example: `  # Update jamf-protect
-  jamf-cli jamf-protect get -o json | jq '.field = "value"' | jamf-cli jamf-protect update
+  jamf-cli pro jamf-protect get -o json | jq '.field = "value"' | jamf-cli pro jamf-protect update
 
   # Update from a file
-  jamf-cli jamf-protect update --from-file jamf-protect.json`,
+  jamf-cli pro jamf-protect update --from-file jamf-protect.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -220,10 +220,10 @@ func newJamfProtectDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete Jamf Protect API registration.",
 		Long:  "Deletes an existing Jamf Protect API registration if present. Jamf Protect API integration will be disabled.",
 		Example: `  # Delete a jamf-protect (with confirmation)
-  jamf-cli jamf-protect delete 1
+  jamf-cli pro jamf-protect delete 1
 
   # Delete without confirmation prompt
-  jamf-cli jamf-protect delete 1 --yes`,
+  jamf-cli pro jamf-protect delete 1 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -302,7 +302,7 @@ func newJamfProtectHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Jamf Protect history",
 		Long:  "Get Jamf Protect history",
 		Example: `  # Get history for a jamf-protect
-  jamf-cli jamf-protect history 1`,
+  jamf-cli pro jamf-protect history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/jamf_protect_plans.go
+++ b/internal/commands/pro/generated/jamf_protect_plans.go
@@ -45,10 +45,10 @@ func newJamfProtectPlansListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get all of the previously synced Jamf Protect Plans with information about their associated configuration profile",
 		Long:  "Get all of the previously synced Jamf Protect Plans with information about their associated configuration profile",
 		Example: `  # List all jamf-protect-plans
-  jamf-cli jamf-protect-plans list
+  jamf-cli pro jamf-protect-plans list
 
   # List jamf-protect-plans and extract IDs
-  jamf-cli jamf-protect-plans list --field id`,
+  jamf-cli pro jamf-protect-plans list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/jamf_remote_assist_session_histories.go
+++ b/internal/commands/pro/generated/jamf_remote_assist_session_histories.go
@@ -46,10 +46,10 @@ func newJamfRemoteAssistSessionHistoriesListCmd(ctx *registry.CLIContext) *cobra
 		Short: "Gets session history items.",
 		Long:  "Returns tenants sessions history.",
 		Example: `  # List all jamf-remote-assist-session-histories
-  jamf-cli jamf-remote-assist-session-histories list
+  jamf-cli pro jamf-remote-assist-session-histories list
 
   # List jamf-remote-assist-session-histories and extract IDs
-  jamf-cli jamf-remote-assist-session-histories list --field id`,
+  jamf-cli pro jamf-remote-assist-session-histories list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -172,13 +172,13 @@ func newJamfRemoteAssistSessionHistoriesGetCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Gets single session history item.",
 		Long:  "Returns tenants session history for specific session.",
 		Example: `  # Get a jamf-remote-assist-session-history by ID
-  jamf-cli jamf-remote-assist-session-histories get 1
+  jamf-cli pro jamf-remote-assist-session-histories get 1
 
   # Get a jamf-remote-assist-session-history by name
-  jamf-cli jamf-remote-assist-session-histories get --name "Example"
+  jamf-cli pro jamf-remote-assist-session-histories get --name "Example"
 
   # Get a jamf-remote-assist-session-history and output as YAML
-  jamf-cli jamf-remote-assist-session-histories get 1 -o yaml`,
+  jamf-cli pro jamf-remote-assist-session-histories get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -234,7 +234,7 @@ func newJamfRemoteAssistSessionHistoriesExportCmd(ctx *registry.CLIContext) *cob
 		Short: "Export Jamf Remote Assist sessions history",
 		Long:  "Export Jamf Remote Assist sessions history",
 		Example: `  # Export jamf-remote-assist-session-histories to CSV
-  jamf-cli jamf-remote-assist-session-histories export --out-file jamf-remote-assist-session-histories.csv`,
+  jamf-cli pro jamf-remote-assist-session-histories export --out-file jamf-remote-assist-session-histories.csv`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			reqCtx = registry.WithAccept(reqCtx, "*/*")

--- a/internal/commands/pro/generated/jcds.go
+++ b/internal/commands/pro/generated/jcds.go
@@ -43,10 +43,10 @@ func newJcdsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve a list of files and file metadata from the Jamf Cloud Distribution Service",
 		Long:  "Retrieve a list of files and file metadata from the Jamf Cloud Distribution Service.",
 		Example: `  # List all jcds
-  jamf-cli jcds list
+  jamf-cli pro jcds list
 
   # List jcds and extract IDs
-  jamf-cli jcds list --field id`,
+  jamf-cli pro jcds list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -83,13 +83,13 @@ func newJcdsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve a download URL for a specific file from the Jamf Cloud Distribution Service",
 		Long:  "Retrieve a download URL for a specific file from the Jamf Cloud Distribution Service.",
 		Example: `  # Get a jcd by ID
-  jamf-cli jcds get 1
+  jamf-cli pro jcds get 1
 
   # Get a jcd by name
-  jamf-cli jcds get --name "Example"
+  jamf-cli pro jcds get --name "Example"
 
   # Get a jcd and output as YAML
-  jamf-cli jcds get 1 -o yaml`,
+  jamf-cli pro jcds get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -146,13 +146,13 @@ func newJcdsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete a file from the Jamf Cloud Distribution Service",
 		Long:  "Delete a file by filename from the Jamf Cloud Distribution Service.",
 		Example: `  # Delete a jcd (with confirmation)
-  jamf-cli jcds delete 1
+  jamf-cli pro jcds delete 1
 
   # Delete by name
-  jamf-cli jcds delete --name "Example" --yes
+  jamf-cli pro jcds delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli jcds delete 1 --yes`,
+  jamf-cli pro jcds delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/local_admin_passwords.go
+++ b/internal/commands/pro/generated/local_admin_passwords.go
@@ -49,10 +49,10 @@ func newLocalAdminPasswordsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update settings for LAPS.",
 		Long:  "Update settings for LAPS.",
 		Example: `  # Update local-admin-passwords
-  jamf-cli local-admin-passwords get -o json | jq '.field = "value"' | jamf-cli local-admin-passwords update
+  jamf-cli pro local-admin-passwords get -o json | jq '.field = "value"' | jamf-cli pro local-admin-passwords update
 
   # Update from a file
-  jamf-cli local-admin-passwords update --from-file local-admin-passwords.json`,
+  jamf-cli pro local-admin-passwords update --from-file local-admin-passwords.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -115,7 +115,7 @@ func newLocalAdminPasswordsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get LAPS password viewed history, and rotation history.",
 		Long:  "Get the full history of all local admin passwords for all accounts for a specific management ID. History will include password, who viewed the password and when it was viewed. This will include rotation history as well.",
 		Example: `  # Get history for a local-admin-password
-  jamf-cli local-admin-passwords history 1`,
+  jamf-cli pro local-admin-passwords history 1`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/locales.go
+++ b/internal/commands/pro/generated/locales.go
@@ -31,10 +31,10 @@ func newLocalesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Return locales that can be used in other features",
 		Long:  "Returns locales that can be used in other features.",
 		Example: `  # List all locales
-  jamf-cli locales list
+  jamf-cli pro locales list
 
   # List locales and extract IDs
-  jamf-cli locales list --field id`,
+  jamf-cli pro locales list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/log_flushings.go
+++ b/internal/commands/pro/generated/log_flushings.go
@@ -42,10 +42,10 @@ func newLogFlushingsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get log flushing tasks",
 		Long:  "Get a list of all log flushing tasks and their statuses",
 		Example: `  # List all log-flushings
-  jamf-cli log-flushings list
+  jamf-cli pro log-flushings list
 
   # List log-flushings and extract IDs
-  jamf-cli log-flushings list --field id`,
+  jamf-cli pro log-flushings list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -82,13 +82,13 @@ func newLogFlushingsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get log flushing task",
 		Long:  "Get the log flushing task by the specified ID",
 		Example: `  # Get a log-flushing by ID
-  jamf-cli log-flushings get 1
+  jamf-cli pro log-flushings get 1
 
   # Get a log-flushing by name
-  jamf-cli log-flushings get --name "Example"
+  jamf-cli pro log-flushings get --name "Example"
 
   # Get a log-flushing and output as YAML
-  jamf-cli log-flushings get 1 -o yaml`,
+  jamf-cli pro log-flushings get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -145,13 +145,13 @@ func newLogFlushingsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Cancels a log flushing task",
 		Long:  "Cancels a log flushing task by ID",
 		Example: `  # Delete a log-flushing (with confirmation)
-  jamf-cli log-flushings delete 1
+  jamf-cli pro log-flushings delete 1
 
   # Delete by name
-  jamf-cli log-flushings delete --name "Example" --yes
+  jamf-cli pro log-flushings delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli log-flushings delete 1 --yes`,
+  jamf-cli pro log-flushings delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/login_customization.go
+++ b/internal/commands/pro/generated/login_customization.go
@@ -36,10 +36,10 @@ func newLoginCustomizationGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get current login disclaimer settings",
 		Long:  "Returns knob whether disclaimer is enabled and if saved, its contents.",
 		Example: `  # Get login-customization
-  jamf-cli login-customization get
+  jamf-cli pro login-customization get
 
   # Get login-customization and output as YAML
-  jamf-cli login-customization get -o yaml`,
+  jamf-cli pro login-customization get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -76,10 +76,10 @@ func newLoginCustomizationUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update current login disclaimer settings.",
 		Long:  "Update current login disclaimer settings.",
 		Example: `  # Update login-customization
-  jamf-cli login-customization get -o json | jq '.field = "value"' | jamf-cli login-customization update
+  jamf-cli pro login-customization get -o json | jq '.field = "value"' | jamf-cli pro login-customization update
 
   # Update from a file
-  jamf-cli login-customization update --from-file login-customization.json`,
+  jamf-cli pro login-customization update --from-file login-customization.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/mac_os_managed_software_updates.go
+++ b/internal/commands/pro/generated/mac_os_managed_software_updates.go
@@ -36,10 +36,10 @@ func newMacOsManagedSoftwareUpdatesListCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Retrieve available MacOs Managed Software Updates",
 		Long:  "Retrieves available MacOs Managed Software Updates",
 		Example: `  # List all mac-os-managed-software-updates
-  jamf-cli mac-os-managed-software-updates list
+  jamf-cli pro mac-os-managed-software-updates list
 
   # List mac-os-managed-software-updates and extract IDs
-  jamf-cli mac-os-managed-software-updates list --field id`,
+  jamf-cli pro mac-os-managed-software-updates list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/managed_software_updates.go
+++ b/internal/commands/pro/generated/managed_software_updates.go
@@ -37,13 +37,13 @@ func newManagedSoftwareUpdatesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve Managed Software Update Statuses for Computer Groups",
 		Long:  "Retrieve Managed Software Update Statuses for Computer Groups",
 		Example: `  # Get a managed-software-update by ID
-  jamf-cli managed-software-updates get 1
+  jamf-cli pro managed-software-updates get 1
 
   # Get a managed-software-update by name
-  jamf-cli managed-software-updates get --name "Example"
+  jamf-cli pro managed-software-updates get --name "Example"
 
   # Get a managed-software-update and output as YAML
-  jamf-cli managed-software-updates get 1 -o yaml`,
+  jamf-cli pro managed-software-updates get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/managed_software_updates_plans.go
+++ b/internal/commands/pro/generated/managed_software_updates_plans.go
@@ -53,10 +53,10 @@ func newManagedSoftwareUpdatesPlansListCmd(ctx *registry.CLIContext) *cobra.Comm
 		Short: "Retrieve Managed Software Update Plans",
 		Long:  "Retrieve Managed Software Update Plans",
 		Example: `  # List all managed-software-updates-plans
-  jamf-cli managed-software-updates-plans list
+  jamf-cli pro managed-software-updates-plans list
 
   # List managed-software-updates-plans and extract IDs
-  jamf-cli managed-software-updates-plans list --field id`,
+  jamf-cli pro managed-software-updates-plans list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -179,13 +179,13 @@ func newManagedSoftwareUpdatesPlansGetCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Retrieve a Managed Software Update Plan",
 		Long:  "Retrieves a Managed Software Update Plan",
 		Example: `  # Get a managed-software-updates-plan by ID
-  jamf-cli managed-software-updates-plans get 1
+  jamf-cli pro managed-software-updates-plans get 1
 
   # Get a managed-software-updates-plan by name
-  jamf-cli managed-software-updates-plans get --name "Example"
+  jamf-cli pro managed-software-updates-plans get --name "Example"
 
   # Get a managed-software-updates-plan and output as YAML
-  jamf-cli managed-software-updates-plans get 1 -o yaml`,
+  jamf-cli pro managed-software-updates-plans get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -240,13 +240,13 @@ func newManagedSoftwareUpdatesPlansCreateCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Create a Managed Software Update Plan",
 		Long:  "Creates a Managed Software Update Plan.",
 		Example: `  # Show the JSON template for creating a managed-software-updates-plan
-  jamf-cli managed-software-updates-plans create --scaffold
+  jamf-cli pro managed-software-updates-plans create --scaffold
 
   # Create a managed-software-updates-plan from JSON
-  echo '{"name":"Example"}' | jamf-cli managed-software-updates-plans create
+  echo '{"name":"Example"}' | jamf-cli pro managed-software-updates-plans create
 
   # Get a managed-software-updates-plan, modify it, and create a copy
-  jamf-cli managed-software-updates-plans get 1 -o json | jq '.name = "Copy"' | jamf-cli managed-software-updates-plans create`,
+  jamf-cli pro managed-software-updates-plans get 1 -o json | jq '.name = "Copy"' | jamf-cli pro managed-software-updates-plans create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -309,10 +309,10 @@ func newManagedSoftwareUpdatesPlansUpdateCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Updates Feature Toggle Value",
 		Long:  "Updates the value of the Feature Toggle - This endpoint is asynchronous, the provided value will not be immediately updated. Please use the following endpoint to track the status of your toggle request. /v1/managed-software-updates/plans/feature-toggle/status:",
 		Example: `  # Update managed-software-updates-plans
-  jamf-cli managed-software-updates-plans get -o json | jq '.field = "value"' | jamf-cli managed-software-updates-plans update
+  jamf-cli pro managed-software-updates-plans get -o json | jq '.field = "value"' | jamf-cli pro managed-software-updates-plans update
 
   # Update from a file
-  jamf-cli managed-software-updates-plans update --from-file managed-software-updates-plans.json`,
+  jamf-cli pro managed-software-updates-plans update --from-file managed-software-updates-plans.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -603,19 +603,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a managed-software-updates-plan from a JSON file
-  jamf-cli managed-software-updates-plans apply --from-file managed-software-updates-plan.json
+  jamf-cli pro managed-software-updates-plans apply --from-file managed-software-updates-plan.json
 
   # Apply a managed-software-updates-plan from a YAML file
-  jamf-cli managed-software-updates-plans apply --from-file managed-software-updates-plan.yaml
+  jamf-cli pro managed-software-updates-plans apply --from-file managed-software-updates-plan.yaml
 
   # Apply from stdin
-  cat managed-software-updates-plan.json | jamf-cli managed-software-updates-plans apply
+  cat managed-software-updates-plan.json | jamf-cli pro managed-software-updates-plans apply
 
   # Apply without replacement confirmation
-  jamf-cli managed-software-updates-plans apply --from-file managed-software-updates-plan.json --yes
+  jamf-cli pro managed-software-updates-plans apply --from-file managed-software-updates-plan.json --yes
 
   # Preview what would happen
-  jamf-cli managed-software-updates-plans apply --from-file managed-software-updates-plan.json --dry-run`,
+  jamf-cli pro managed-software-updates-plans apply --from-file managed-software-updates-plan.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/mdm_commands.go
+++ b/internal/commands/pro/generated/mdm_commands.go
@@ -46,10 +46,10 @@ func newMdmCommandsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get information about mdm commands made by Jamf Pro.",
 		Long:  "Get information about mdm commands made by Jamf Pro.",
 		Example: `  # List all mdm-commands
-  jamf-cli mdm-commands list
+  jamf-cli pro mdm-commands list
 
   # List mdm-commands and extract IDs
-  jamf-cli mdm-commands list --field id`,
+  jamf-cli pro mdm-commands list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/mdm_renewals.go
+++ b/internal/commands/pro/generated/mdm_renewals.go
@@ -42,13 +42,13 @@ func newMdmRenewalsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get device common details for a client management ID",
 		Long:  "Retrieves device common details associated with a specific client management ID",
 		Example: `  # Get a mdm-renewal by ID
-  jamf-cli mdm-renewals get 1
+  jamf-cli pro mdm-renewals get 1
 
   # Get a mdm-renewal by name
-  jamf-cli mdm-renewals get --name "Example"
+  jamf-cli pro mdm-renewals get --name "Example"
 
   # Get a mdm-renewal and output as YAML
-  jamf-cli mdm-renewals get 1 -o yaml`,
+  jamf-cli pro mdm-renewals get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -105,13 +105,13 @@ func newMdmRenewalsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete MDM renewal strategies for a client management ID",
 		Long:  "Deletes all MDM renewal strategies and errors associated with the specified client management ID",
 		Example: `  # Delete a mdm-renewal (with confirmation)
-  jamf-cli mdm-renewals delete 1
+  jamf-cli pro mdm-renewals delete 1
 
   # Delete by name
-  jamf-cli mdm-renewals delete --name "Example" --yes
+  jamf-cli pro mdm-renewals delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli mdm-renewals delete 1 --yes`,
+  jamf-cli pro mdm-renewals delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -218,10 +218,10 @@ func newMdmRenewalsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update device common details (partial update)",
 		Long:  "Partially updates existing device common details. The clientManagementId must be provided in the request body to identify which record to update. Only updates fields that are explicitly provided in the request - missing fields preserve their existing values. Only updates existing records; does not create new ones.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  clientManagementId                           string\n  mdmCheckinUrl                                string\n  mdmProfileNeedsRenewalDueToCaRenewed         boolean\n  mdmProfileNeedsRenewalDueToDeviceIdentityCertExpiring boolean\n  mdmServerUrl                                 string\n  renewMdmProfileStartDate                     string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field
-  jamf-cli mdm-renewals patch --set field=value
+  jamf-cli pro mdm-renewals patch --set field=value
 
   # Update using JSON
-  jamf-cli mdm-renewals get -o json | jq '.field = "value"' | jamf-cli mdm-renewals patch`,
+  jamf-cli pro mdm-renewals get -o json | jq '.field = "value"' | jamf-cli pro mdm-renewals patch`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/mobile_device_extension_attributes.go
+++ b/internal/commands/pro/generated/mobile_device_extension_attributes.go
@@ -54,10 +54,10 @@ func newMobileDeviceExtensionAttributesListCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Retrieve Mobile Device Extension Attributes.",
 		Long:  "Retrieves all mobile device extension attributes configuration.",
 		Example: `  # List all mobile-device-extension-attributes
-  jamf-cli mobile-device-extension-attributes list
+  jamf-cli pro mobile-device-extension-attributes list
 
   # List mobile-device-extension-attributes and extract IDs
-  jamf-cli mobile-device-extension-attributes list --field id`,
+  jamf-cli pro mobile-device-extension-attributes list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -180,13 +180,13 @@ func newMobileDeviceExtensionAttributesGetCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Get specified Mobile Device Extension Attribute object.",
 		Long:  "Gets specified Mobile Device Extension Attribute object.",
 		Example: `  # Get a mobile-device-extension-attribute by ID
-  jamf-cli mobile-device-extension-attributes get 1
+  jamf-cli pro mobile-device-extension-attributes get 1
 
   # Get a mobile-device-extension-attribute by name
-  jamf-cli mobile-device-extension-attributes get --name "Example"
+  jamf-cli pro mobile-device-extension-attributes get --name "Example"
 
   # Get a mobile-device-extension-attribute and output as YAML
-  jamf-cli mobile-device-extension-attributes get 1 -o yaml`,
+  jamf-cli pro mobile-device-extension-attributes get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -241,13 +241,13 @@ func newMobileDeviceExtensionAttributesCreateCmd(ctx *registry.CLIContext) *cobr
 		Short: "Create Mobile Device Extension Attribute.",
 		Long:  "Create Mobile Device Extension Attribute to collect extra inventory information.",
 		Example: `  # Show the JSON template for creating a mobile-device-extension-attribute
-  jamf-cli mobile-device-extension-attributes create --scaffold
+  jamf-cli pro mobile-device-extension-attributes create --scaffold
 
   # Create a mobile-device-extension-attribute from JSON
-  echo '{"name":"Example"}' | jamf-cli mobile-device-extension-attributes create
+  echo '{"name":"Example"}' | jamf-cli pro mobile-device-extension-attributes create
 
   # Get a mobile-device-extension-attribute, modify it, and create a copy
-  jamf-cli mobile-device-extension-attributes get 1 -o json | jq '.name = "Copy"' | jamf-cli mobile-device-extension-attributes create`,
+  jamf-cli pro mobile-device-extension-attributes get 1 -o json | jq '.name = "Copy"' | jamf-cli pro mobile-device-extension-attributes create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -320,13 +320,13 @@ func newMobileDeviceExtensionAttributesUpdateCmd(ctx *registry.CLIContext) *cobr
 		Short: "Update specified Mobile Device Extension Attribute object.",
 		Long:  "Update specified Mobile Device Extension Attribute object.",
 		Example: `  # Update a mobile-device-extension-attribute from JSON
-  echo '{"name":"Updated"}' | jamf-cli mobile-device-extension-attributes update 1
+  echo '{"name":"Updated"}' | jamf-cli pro mobile-device-extension-attributes update 1
 
   # Update by name
-  jamf-cli mobile-device-extension-attributes get --name "Example" -o json | jq '.field = "value"' | jamf-cli mobile-device-extension-attributes update --name "Example"
+  jamf-cli pro mobile-device-extension-attributes get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro mobile-device-extension-attributes update --name "Example"
 
   # Get a mobile-device-extension-attribute, modify, and update
-  jamf-cli mobile-device-extension-attributes get 1 -o json | jq '.name = "New Name"' | jamf-cli mobile-device-extension-attributes update 1`,
+  jamf-cli pro mobile-device-extension-attributes get 1 -o json | jq '.name = "New Name"' | jamf-cli pro mobile-device-extension-attributes update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -417,13 +417,13 @@ func newMobileDeviceExtensionAttributesDeleteCmd(ctx *registry.CLIContext) *cobr
 		Short: "Delete a Mobile Device Extension Attribute by ID.",
 		Long:  "Deletes the Mobile Device Extension Attribute identified by the provided ID.<\\br> In addition to removing the attribute itself, this operation will also delete any related dependent data, including:<\\br>   - Associated popup menu choices.<\\br>   - Fields used in saved search displays.<\\br>   - User preferences that reference the attribute.",
 		Example: `  # Delete a mobile-device-extension-attribute (with confirmation)
-  jamf-cli mobile-device-extension-attributes delete 1
+  jamf-cli pro mobile-device-extension-attributes delete 1
 
   # Delete by name
-  jamf-cli mobile-device-extension-attributes delete --name "Example" --yes
+  jamf-cli pro mobile-device-extension-attributes delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli mobile-device-extension-attributes delete 1 --yes`,
+  jamf-cli pro mobile-device-extension-attributes delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -534,10 +534,10 @@ func newMobileDeviceExtensionAttributesHistoryCmd(ctx *registry.CLIContext) *cob
 		Short: "Get specified Mobile Device Extension Attribute History object",
 		Long:  "Get specified Mobile Device Extension Attribute history object",
 		Example: `  # Get history for a mobile-device-extension-attribute by ID
-  jamf-cli mobile-device-extension-attributes history 1
+  jamf-cli pro mobile-device-extension-attributes history 1
 
   # Get history by name
-  jamf-cli mobile-device-extension-attributes history --name "Example"`,
+  jamf-cli pro mobile-device-extension-attributes history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -816,19 +816,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a mobile-device-extension-attribute from a JSON file
-  jamf-cli mobile-device-extension-attributes apply --from-file mobile-device-extension-attribute.json
+  jamf-cli pro mobile-device-extension-attributes apply --from-file mobile-device-extension-attribute.json
 
   # Apply a mobile-device-extension-attribute from a YAML file
-  jamf-cli mobile-device-extension-attributes apply --from-file mobile-device-extension-attribute.yaml
+  jamf-cli pro mobile-device-extension-attributes apply --from-file mobile-device-extension-attribute.yaml
 
   # Apply from stdin
-  cat mobile-device-extension-attribute.json | jamf-cli mobile-device-extension-attributes apply
+  cat mobile-device-extension-attribute.json | jamf-cli pro mobile-device-extension-attributes apply
 
   # Apply without replacement confirmation
-  jamf-cli mobile-device-extension-attributes apply --from-file mobile-device-extension-attribute.json --yes
+  jamf-cli pro mobile-device-extension-attributes apply --from-file mobile-device-extension-attribute.json --yes
 
   # Preview what would happen
-  jamf-cli mobile-device-extension-attributes apply --from-file mobile-device-extension-attribute.json --dry-run`,
+  jamf-cli pro mobile-device-extension-attributes apply --from-file mobile-device-extension-attribute.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/mobile_device_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups.go
@@ -39,10 +39,10 @@ func newMobileDeviceGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Return the list of all Mobile Device Groups",
 		Long:  "Returns the list of all mobile device groups.",
 		Example: `  # List all mobile-device-groups
-  jamf-cli mobile-device-groups list
+  jamf-cli pro mobile-device-groups list
 
   # List mobile-device-groups and extract IDs
-  jamf-cli mobile-device-groups list --field id`,
+  jamf-cli pro mobile-device-groups list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -83,13 +83,13 @@ func newMobileDeviceGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Smart Group Membership by Id",
 		Long:  "Get Smart Group Membership by Id",
 		Example: `  # Get a mobile-device-group by ID
-  jamf-cli mobile-device-groups get 1
+  jamf-cli pro mobile-device-groups get 1
 
   # Get a mobile-device-group by name
-  jamf-cli mobile-device-groups get --name "Example"
+  jamf-cli pro mobile-device-groups get --name "Example"
 
   # Get a mobile-device-group and output as YAML
-  jamf-cli mobile-device-groups get 1 -o yaml`,
+  jamf-cli pro mobile-device-groups get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
@@ -51,10 +51,10 @@ func newMobileDeviceGroupsSmartGroupsListCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Get Smart Groups",
 		Long:  "Get Smart Groups",
 		Example: `  # List all mobile-device-groups-smart-groups
-  jamf-cli mobile-device-groups-smart-groups list
+  jamf-cli pro mobile-device-groups-smart-groups list
 
   # List mobile-device-groups-smart-groups and extract IDs
-  jamf-cli mobile-device-groups-smart-groups list --field id`,
+  jamf-cli pro mobile-device-groups-smart-groups list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -177,13 +177,13 @@ func newMobileDeviceGroupsSmartGroupsGetCmd(ctx *registry.CLIContext) *cobra.Com
 		Short: "Get Smart Group by Id",
 		Long:  "Get Smart Group by Id",
 		Example: `  # Get a mobile-device-groups-smart-groups by ID
-  jamf-cli mobile-device-groups-smart-groups get 1
+  jamf-cli pro mobile-device-groups-smart-groups get 1
 
   # Get a mobile-device-groups-smart-groups by name
-  jamf-cli mobile-device-groups-smart-groups get --name "Example"
+  jamf-cli pro mobile-device-groups-smart-groups get --name "Example"
 
   # Get a mobile-device-groups-smart-groups and output as YAML
-  jamf-cli mobile-device-groups-smart-groups get 1 -o yaml`,
+  jamf-cli pro mobile-device-groups-smart-groups get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -239,13 +239,13 @@ func newMobileDeviceGroupsSmartGroupsCreateCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Create a smart group",
 		Long:  "Create a smart group",
 		Example: `  # Show the JSON template for creating a mobile-device-groups-smart-groups
-  jamf-cli mobile-device-groups-smart-groups create --scaffold
+  jamf-cli pro mobile-device-groups-smart-groups create --scaffold
 
   # Create a mobile-device-groups-smart-groups from JSON
-  echo '{"name":"Example"}' | jamf-cli mobile-device-groups-smart-groups create
+  echo '{"name":"Example"}' | jamf-cli pro mobile-device-groups-smart-groups create
 
   # Get a mobile-device-groups-smart-groups, modify it, and create a copy
-  jamf-cli mobile-device-groups-smart-groups get 1 -o json | jq '.name = "Copy"' | jamf-cli mobile-device-groups-smart-groups create`,
+  jamf-cli pro mobile-device-groups-smart-groups get 1 -o json | jq '.name = "Copy"' | jamf-cli pro mobile-device-groups-smart-groups create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -315,13 +315,13 @@ func newMobileDeviceGroupsSmartGroupsUpdateCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Update a smart group",
 		Long:  "Update a smart group",
 		Example: `  # Update a mobile-device-groups-smart-groups from JSON
-  echo '{"name":"Updated"}' | jamf-cli mobile-device-groups-smart-groups update 1
+  echo '{"name":"Updated"}' | jamf-cli pro mobile-device-groups-smart-groups update 1
 
   # Update by name
-  jamf-cli mobile-device-groups-smart-groups get --name "Example" -o json | jq '.field = "value"' | jamf-cli mobile-device-groups-smart-groups update --name "Example"
+  jamf-cli pro mobile-device-groups-smart-groups get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro mobile-device-groups-smart-groups update --name "Example"
 
   # Get a mobile-device-groups-smart-groups, modify, and update
-  jamf-cli mobile-device-groups-smart-groups get 1 -o json | jq '.name = "New Name"' | jamf-cli mobile-device-groups-smart-groups update 1`,
+  jamf-cli pro mobile-device-groups-smart-groups get 1 -o json | jq '.name = "New Name"' | jamf-cli pro mobile-device-groups-smart-groups update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -405,13 +405,13 @@ func newMobileDeviceGroupsSmartGroupsDeleteCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Remove Smart Group by Id",
 		Long:  "Remove Smart Group by Id",
 		Example: `  # Delete a mobile-device-groups-smart-groups (with confirmation)
-  jamf-cli mobile-device-groups-smart-groups delete 1
+  jamf-cli pro mobile-device-groups-smart-groups delete 1
 
   # Delete by name
-  jamf-cli mobile-device-groups-smart-groups delete --name "Example" --yes
+  jamf-cli pro mobile-device-groups-smart-groups delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli mobile-device-groups-smart-groups delete 1 --yes`,
+  jamf-cli pro mobile-device-groups-smart-groups delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -523,19 +523,19 @@ The groupName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a mobile-device-groups-smart-groups from a JSON file
-  jamf-cli mobile-device-groups-smart-groups apply --from-file mobile-device-groups-smart-groups.json
+  jamf-cli pro mobile-device-groups-smart-groups apply --from-file mobile-device-groups-smart-groups.json
 
   # Apply a mobile-device-groups-smart-groups from a YAML file
-  jamf-cli mobile-device-groups-smart-groups apply --from-file mobile-device-groups-smart-groups.yaml
+  jamf-cli pro mobile-device-groups-smart-groups apply --from-file mobile-device-groups-smart-groups.yaml
 
   # Apply from stdin
-  cat mobile-device-groups-smart-groups.json | jamf-cli mobile-device-groups-smart-groups apply
+  cat mobile-device-groups-smart-groups.json | jamf-cli pro mobile-device-groups-smart-groups apply
 
   # Apply without replacement confirmation
-  jamf-cli mobile-device-groups-smart-groups apply --from-file mobile-device-groups-smart-groups.json --yes
+  jamf-cli pro mobile-device-groups-smart-groups apply --from-file mobile-device-groups-smart-groups.json --yes
 
   # Preview what would happen
-  jamf-cli mobile-device-groups-smart-groups apply --from-file mobile-device-groups-smart-groups.json --dry-run`,
+  jamf-cli pro mobile-device-groups-smart-groups apply --from-file mobile-device-groups-smart-groups.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/mobile_device_groups_static_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_static_groups.go
@@ -51,10 +51,10 @@ func newMobileDeviceGroupsStaticGroupsListCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Get Static Groups",
 		Long:  "Get Static Groups",
 		Example: `  # List all mobile-device-groups-static-groups
-  jamf-cli mobile-device-groups-static-groups list
+  jamf-cli pro mobile-device-groups-static-groups list
 
   # List mobile-device-groups-static-groups and extract IDs
-  jamf-cli mobile-device-groups-static-groups list --field id`,
+  jamf-cli pro mobile-device-groups-static-groups list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -177,13 +177,13 @@ func newMobileDeviceGroupsStaticGroupsGetCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Get Static Group by Id",
 		Long:  "Get Static Group by Id",
 		Example: `  # Get a mobile-device-groups-static-groups by ID
-  jamf-cli mobile-device-groups-static-groups get 1
+  jamf-cli pro mobile-device-groups-static-groups get 1
 
   # Get a mobile-device-groups-static-groups by name
-  jamf-cli mobile-device-groups-static-groups get --name "Example"
+  jamf-cli pro mobile-device-groups-static-groups get --name "Example"
 
   # Get a mobile-device-groups-static-groups and output as YAML
-  jamf-cli mobile-device-groups-static-groups get 1 -o yaml`,
+  jamf-cli pro mobile-device-groups-static-groups get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -239,13 +239,13 @@ func newMobileDeviceGroupsStaticGroupsCreateCmd(ctx *registry.CLIContext) *cobra
 		Short: "Create membership of a static group",
 		Long:  "Create membership of a static group",
 		Example: `  # Show the JSON template for creating a mobile-device-groups-static-groups
-  jamf-cli mobile-device-groups-static-groups create --scaffold
+  jamf-cli pro mobile-device-groups-static-groups create --scaffold
 
   # Create a mobile-device-groups-static-groups from JSON
-  echo '{"name":"Example"}' | jamf-cli mobile-device-groups-static-groups create
+  echo '{"name":"Example"}' | jamf-cli pro mobile-device-groups-static-groups create
 
   # Get a mobile-device-groups-static-groups, modify it, and create a copy
-  jamf-cli mobile-device-groups-static-groups get 1 -o json | jq '.name = "Copy"' | jamf-cli mobile-device-groups-static-groups create`,
+  jamf-cli pro mobile-device-groups-static-groups get 1 -o json | jq '.name = "Copy"' | jamf-cli pro mobile-device-groups-static-groups create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -316,13 +316,13 @@ func newMobileDeviceGroupsStaticGroupsDeleteCmd(ctx *registry.CLIContext) *cobra
 		Short: "Remove Static Group by Id",
 		Long:  "Remove Static Group by Id",
 		Example: `  # Delete a mobile-device-groups-static-groups (with confirmation)
-  jamf-cli mobile-device-groups-static-groups delete 1
+  jamf-cli pro mobile-device-groups-static-groups delete 1
 
   # Delete by name
-  jamf-cli mobile-device-groups-static-groups delete --name "Example" --yes
+  jamf-cli pro mobile-device-groups-static-groups delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli mobile-device-groups-static-groups delete 1 --yes`,
+  jamf-cli pro mobile-device-groups-static-groups delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -430,16 +430,16 @@ func newMobileDeviceGroupsStaticGroupsPatchCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Update membership of a static group",
 		Long:  "Update membership of a static group\n\nIdentify the resource by ID (positional arg), --name, . Omit ID to use a lookup flag.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  groupDescription                             string\n  groupName                                    string\n  siteId                                       string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field by ID
-  jamf-cli mobile-device-groups-static-groups patch 1 --set general.managed=true
+  jamf-cli pro mobile-device-groups-static-groups patch 1 --set general.managed=true
 
   # Update multiple fields
-  jamf-cli mobile-device-groups-static-groups patch 1 --set field1=value1 --set field2=value2
+  jamf-cli pro mobile-device-groups-static-groups patch 1 --set field1=value1 --set field2=value2
 
   # Update by name
-  jamf-cli mobile-device-groups-static-groups patch --name "Example" --set general.managed=true
+  jamf-cli pro mobile-device-groups-static-groups patch --name "Example" --set general.managed=true
 
   # Patch from a file
-  jamf-cli mobile-device-groups-static-groups patch 1 --from-file changes.json`,
+  jamf-cli pro mobile-device-groups-static-groups patch 1 --from-file changes.json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -549,19 +549,19 @@ The groupName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a mobile-device-groups-static-groups from a JSON file
-  jamf-cli mobile-device-groups-static-groups apply --from-file mobile-device-groups-static-groups.json
+  jamf-cli pro mobile-device-groups-static-groups apply --from-file mobile-device-groups-static-groups.json
 
   # Apply a mobile-device-groups-static-groups from a YAML file
-  jamf-cli mobile-device-groups-static-groups apply --from-file mobile-device-groups-static-groups.yaml
+  jamf-cli pro mobile-device-groups-static-groups apply --from-file mobile-device-groups-static-groups.yaml
 
   # Apply from stdin
-  cat mobile-device-groups-static-groups.json | jamf-cli mobile-device-groups-static-groups apply
+  cat mobile-device-groups-static-groups.json | jamf-cli pro mobile-device-groups-static-groups apply
 
   # Apply without replacement confirmation
-  jamf-cli mobile-device-groups-static-groups apply --from-file mobile-device-groups-static-groups.json --yes
+  jamf-cli pro mobile-device-groups-static-groups apply --from-file mobile-device-groups-static-groups.json --yes
 
   # Preview what would happen
-  jamf-cli mobile-device-groups-static-groups apply --from-file mobile-device-groups-static-groups.json --dry-run`,
+  jamf-cli pro mobile-device-groups-static-groups apply --from-file mobile-device-groups-static-groups.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/mobile_device_inventory_details.go
+++ b/internal/commands/pro/generated/mobile_device_inventory_details.go
@@ -44,10 +44,10 @@ func newMobileDeviceInventoryDetailsListCmd(ctx *registry.CLIContext) *cobra.Com
 		Short: "Return paginated Mobile Device Inventory records",
 		Long:  "Return paginated Mobile Device Inventory records",
 		Example: `  # List all mobile-device-inventory-details
-  jamf-cli mobile-device-inventory-details list
+  jamf-cli pro mobile-device-inventory-details list
 
   # List mobile-device-inventory-details and extract IDs
-  jamf-cli mobile-device-inventory-details list --field id`,
+  jamf-cli pro mobile-device-inventory-details list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/mobile_device_prestage_scopes.go
+++ b/internal/commands/pro/generated/mobile_device_prestage_scopes.go
@@ -42,10 +42,10 @@ func newMobileDevicePrestageScopesListCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Get all Device Scope for all Mobile Device Prestages",
 		Long:  "Get all device scope for all mobile device prestages",
 		Example: `  # List all mobile-device-prestage-scopes
-  jamf-cli mobile-device-prestage-scopes list
+  jamf-cli pro mobile-device-prestage-scopes list
 
   # List mobile-device-prestage-scopes and extract IDs
-  jamf-cli mobile-device-prestage-scopes list --field id`,
+  jamf-cli pro mobile-device-prestage-scopes list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -85,7 +85,7 @@ func newMobileDevicePrestageScopesDeleteMultipleCmd(ctx *registry.CLIContext) *c
 		Short: "Remove Device Scope for a specific Mobile Device Prestage",
 		Long:  "Remove device scope for a specific mobile device prestage",
 		Example: `  # Delete multiple mobile-device-prestage-scopes by IDs
-  jamf-cli mobile-device-prestage-scopes delete-multiple --ids 1,2,3 --yes`,
+  jamf-cli pro mobile-device-prestage-scopes delete-multiple --ids 1,2,3 --yes`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/mobile_device_prestage_sync_states.go
+++ b/internal/commands/pro/generated/mobile_device_prestage_sync_states.go
@@ -34,10 +34,10 @@ func newMobileDevicePrestageSyncStatesListCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Get all Prestage sync States for all prestages",
 		Long:  "Get all prestage sync states for all prestages",
 		Example: `  # List all mobile-device-prestage-sync-states
-  jamf-cli mobile-device-prestage-sync-states list
+  jamf-cli pro mobile-device-prestage-sync-states list
 
   # List mobile-device-prestage-sync-states and extract IDs
-  jamf-cli mobile-device-prestage-sync-states list --field id`,
+  jamf-cli pro mobile-device-prestage-sync-states list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/mobile_device_prestages.go
+++ b/internal/commands/pro/generated/mobile_device_prestages.go
@@ -57,10 +57,10 @@ func newMobileDevicePrestagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get sorted and paged Mobile Device Prestages",
 		Long:  "Gets sorted and paged mobile device prestages",
 		Example: `  # List all mobile-device-prestages
-  jamf-cli mobile-device-prestages list
+  jamf-cli pro mobile-device-prestages list
 
   # List mobile-device-prestages and extract IDs
-  jamf-cli mobile-device-prestages list --field id`,
+  jamf-cli pro mobile-device-prestages list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -179,13 +179,13 @@ func newMobileDevicePrestagesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve a Mobile Device Prestage with the supplied id",
 		Long:  "Retrieves a Mobile Device Prestage with the supplied id",
 		Example: `  # Get a mobile-device-prestage by ID
-  jamf-cli mobile-device-prestages get 1
+  jamf-cli pro mobile-device-prestages get 1
 
   # Get a mobile-device-prestage by name
-  jamf-cli mobile-device-prestages get --name "Example"
+  jamf-cli pro mobile-device-prestages get --name "Example"
 
   # Get a mobile-device-prestage and output as YAML
-  jamf-cli mobile-device-prestages get 1 -o yaml`,
+  jamf-cli pro mobile-device-prestages get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -240,13 +240,13 @@ func newMobileDevicePrestagesCreateCmd(ctx *registry.CLIContext) *cobra.Command 
 		Short: "Create a Mobile Device Prestage",
 		Long:  "Create a mobile device prestage",
 		Example: `  # Show the JSON template for creating a mobile-device-prestage
-  jamf-cli mobile-device-prestages create --scaffold
+  jamf-cli pro mobile-device-prestages create --scaffold
 
   # Create a mobile-device-prestage from JSON
-  echo '{"name":"Example"}' | jamf-cli mobile-device-prestages create
+  echo '{"name":"Example"}' | jamf-cli pro mobile-device-prestages create
 
   # Get a mobile-device-prestage, modify it, and create a copy
-  jamf-cli mobile-device-prestages get 1 -o json | jq '.name = "Copy"' | jamf-cli mobile-device-prestages create`,
+  jamf-cli pro mobile-device-prestages get 1 -o json | jq '.name = "Copy"' | jamf-cli pro mobile-device-prestages create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -358,13 +358,13 @@ func newMobileDevicePrestagesUpdateCmd(ctx *registry.CLIContext) *cobra.Command 
 		Short: "Update a Mobile Device Prestage",
 		Long:  "Updates a Mobile Device Prestage",
 		Example: `  # Update a mobile-device-prestage from JSON
-  echo '{"name":"Updated"}' | jamf-cli mobile-device-prestages update 1
+  echo '{"name":"Updated"}' | jamf-cli pro mobile-device-prestages update 1
 
   # Update by name
-  jamf-cli mobile-device-prestages get --name "Example" -o json | jq '.field = "value"' | jamf-cli mobile-device-prestages update --name "Example"
+  jamf-cli pro mobile-device-prestages get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro mobile-device-prestages update --name "Example"
 
   # Get a mobile-device-prestage, modify, and update
-  jamf-cli mobile-device-prestages get 1 -o json | jq '.name = "New Name"' | jamf-cli mobile-device-prestages update 1`,
+  jamf-cli pro mobile-device-prestages get 1 -o json | jq '.name = "New Name"' | jamf-cli pro mobile-device-prestages update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -505,13 +505,13 @@ func newMobileDevicePrestagesDeleteCmd(ctx *registry.CLIContext) *cobra.Command 
 		Short: "Delete a Mobile Device Prestage with the supplied id",
 		Long:  "Deletes a Mobile Device Prestage with the supplied id",
 		Example: `  # Delete a mobile-device-prestage (with confirmation)
-  jamf-cli mobile-device-prestages delete 1
+  jamf-cli pro mobile-device-prestages delete 1
 
   # Delete by name
-  jamf-cli mobile-device-prestages delete --name "Example" --yes
+  jamf-cli pro mobile-device-prestages delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli mobile-device-prestages delete 1 --yes`,
+  jamf-cli pro mobile-device-prestages delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -620,7 +620,7 @@ func newMobileDevicePrestagesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Remove an attachment for a Mobile Device Prestage",
 		Long:  "Remove an attachment for a Mobile Device Prestage",
 		Example: `  # Delete multiple mobile-device-prestages by IDs
-  jamf-cli mobile-device-prestages delete-multiple --ids 1,2,3 --yes`,
+  jamf-cli pro mobile-device-prestages delete-multiple --ids 1,2,3 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -750,10 +750,10 @@ func newMobileDevicePrestagesHistoryCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Get sorted and paged Mobile Device Prestage history objects",
 		Long:  "Gets sorted and paged mobile device prestage history objects",
 		Example: `  # Get history for a mobile-device-prestage by ID
-  jamf-cli mobile-device-prestages history 1
+  jamf-cli pro mobile-device-prestages history 1
 
   # Get history by name
-  jamf-cli mobile-device-prestages history --name "Example"`,
+  jamf-cli pro mobile-device-prestages history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -1102,19 +1102,19 @@ The displayName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a mobile-device-prestage from a JSON file
-  jamf-cli mobile-device-prestages apply --from-file mobile-device-prestage.json
+  jamf-cli pro mobile-device-prestages apply --from-file mobile-device-prestage.json
 
   # Apply a mobile-device-prestage from a YAML file
-  jamf-cli mobile-device-prestages apply --from-file mobile-device-prestage.yaml
+  jamf-cli pro mobile-device-prestages apply --from-file mobile-device-prestage.yaml
 
   # Apply from stdin
-  cat mobile-device-prestage.json | jamf-cli mobile-device-prestages apply
+  cat mobile-device-prestage.json | jamf-cli pro mobile-device-prestages apply
 
   # Apply without replacement confirmation
-  jamf-cli mobile-device-prestages apply --from-file mobile-device-prestage.json --yes
+  jamf-cli pro mobile-device-prestages apply --from-file mobile-device-prestage.json --yes
 
   # Preview what would happen
-  jamf-cli mobile-device-prestages apply --from-file mobile-device-prestage.json --dry-run`,
+  jamf-cli pro mobile-device-prestages apply --from-file mobile-device-prestage.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/mobile_devices.go
+++ b/internal/commands/pro/generated/mobile_devices.go
@@ -46,10 +46,10 @@ func newMobileDevicesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Mobile Device objects",
 		Long:  "Gets Mobile Device objects.",
 		Example: `  # List all mobile-devices
-  jamf-cli mobile-devices list
+  jamf-cli pro mobile-devices list
 
   # List mobile-devices and extract IDs
-  jamf-cli mobile-devices list --field id`,
+  jamf-cli pro mobile-devices list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -188,13 +188,13 @@ func newMobileDevicesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Mobile Device",
 		Long:  "Get MobileDevice",
 		Example: `  # Get a mobile-device by ID
-  jamf-cli mobile-devices get 1
+  jamf-cli pro mobile-devices get 1
 
   # Get a mobile-device by name
-  jamf-cli mobile-devices get --name "Example"
+  jamf-cli pro mobile-devices get --name "Example"
 
   # Get a mobile-device and output as YAML
-  jamf-cli mobile-devices get 1 -o yaml`,
+  jamf-cli pro mobile-devices get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -269,22 +269,22 @@ func newMobileDevicesPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update fields on a mobile device that are allowed to be modified by users",
 		Long:  "Updates fields on a mobile device that are allowed to be modified by users.\n\nIdentify the resource by ID (positional arg), --name, --serial, --udid. Omit ID to use a lookup flag.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  assetTag                                     string\n  enforceName                                  boolean\n  location.buildingId                          string\n  location.departmentId                        string\n  location.emailAddress                        string\n  location.phoneNumber                         string\n  location.position                            string\n  location.realName                            string\n  location.room                                string\n  location.username                            string\n  name                                         string\n  siteId                                       string\n  timeZone                                     string\n  tvos.airplayPassword                         string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field by ID
-  jamf-cli mobile-devices patch 1 --set general.managed=true
+  jamf-cli pro mobile-devices patch 1 --set general.managed=true
 
   # Update multiple fields
-  jamf-cli mobile-devices patch 1 --set field1=value1 --set field2=value2
+  jamf-cli pro mobile-devices patch 1 --set field1=value1 --set field2=value2
 
   # Update by name
-  jamf-cli mobile-devices patch --name "Example" --set general.managed=true
+  jamf-cli pro mobile-devices patch --name "Example" --set general.managed=true
 
   # Update by serial
-  jamf-cli mobile-devices patch --serial <value> --set general.managed=true
+  jamf-cli pro mobile-devices patch --serial <value> --set general.managed=true
 
   # Update by udid
-  jamf-cli mobile-devices patch --udid <value> --set general.managed=true
+  jamf-cli pro mobile-devices patch --udid <value> --set general.managed=true
 
   # Patch from a file
-  jamf-cli mobile-devices patch 1 --from-file changes.json`,
+  jamf-cli pro mobile-devices patch 1 --from-file changes.json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/notifications.go
+++ b/internal/commands/pro/generated/notifications.go
@@ -37,10 +37,10 @@ func newNotificationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Notifications for user and site",
 		Long:  "Gets notifications for user and site",
 		Example: `  # List all notifications
-  jamf-cli notifications list
+  jamf-cli pro notifications list
 
   # List notifications and extract IDs
-  jamf-cli notifications list --field id`,
+  jamf-cli pro notifications list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -79,10 +79,10 @@ func newNotificationsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete Notifications",
 		Long:  "Deletes notifications with given type and id.",
 		Example: `  # Delete a notification (with confirmation)
-  jamf-cli notifications delete 1 2
+  jamf-cli pro notifications delete 1 2
 
   # Delete without confirmation prompt
-  jamf-cli notifications delete 1 2 --yes`,
+  jamf-cli pro notifications delete 1 2 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/oauth_token_sessions.go
+++ b/internal/commands/pro/generated/oauth_token_sessions.go
@@ -31,10 +31,10 @@ func newOauthTokenSessionsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve the access token and user information for the current session.",
 		Long:  "Retrieve the access token and user information for the current session.",
 		Example: `  # List all oauth-token-sessions
-  jamf-cli oauth-token-sessions list
+  jamf-cli pro oauth-token-sessions list
 
   # List oauth-token-sessions and extract IDs
-  jamf-cli oauth-token-sessions list --field id`,
+  jamf-cli pro oauth-token-sessions list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/onboarding_configuration.go
+++ b/internal/commands/pro/generated/onboarding_configuration.go
@@ -36,10 +36,10 @@ func newOnboardingConfigurationGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get the current onboarding settings configuration.",
 		Long:  "Get the current onboarding settings configuration.",
 		Example: `  # Get onboarding-configuration
-  jamf-cli onboarding-configuration get
+  jamf-cli pro onboarding-configuration get
 
   # Get onboarding-configuration and output as YAML
-  jamf-cli onboarding-configuration get -o yaml`,
+  jamf-cli pro onboarding-configuration get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -76,10 +76,10 @@ func newOnboardingConfigurationUpdateCmd(ctx *registry.CLIContext) *cobra.Comman
 		Short: "Update the onboarding configuration.",
 		Long:  "Update the onboarding configuration.",
 		Example: `  # Update onboarding-configuration
-  jamf-cli onboarding-configuration get -o json | jq '.field = "value"' | jamf-cli onboarding-configuration update
+  jamf-cli pro onboarding-configuration get -o json | jq '.field = "value"' | jamf-cli pro onboarding-configuration update
 
   # Update from a file
-  jamf-cli onboarding-configuration update --from-file onboarding-configuration.json`,
+  jamf-cli pro onboarding-configuration update --from-file onboarding-configuration.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/onboardings.go
+++ b/internal/commands/pro/generated/onboardings.go
@@ -49,7 +49,7 @@ func newOnboardingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Onboarding history object",
 		Long:  "Gets Onboarding history object",
 		Example: `  # Get history for a onboarding
-  jamf-cli onboardings history 1`,
+  jamf-cli pro onboardings history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/packages.go
+++ b/internal/commands/pro/generated/packages.go
@@ -59,10 +59,10 @@ func newPackagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve Packages",
 		Long:  "Retrieves packages",
 		Example: `  # List all packages
-  jamf-cli packages list
+  jamf-cli pro packages list
 
   # List packages and extract IDs
-  jamf-cli packages list --field id`,
+  jamf-cli pro packages list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -185,13 +185,13 @@ func newPackagesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Package object",
 		Long:  "Gets specified Package object",
 		Example: `  # Get a package by ID
-  jamf-cli packages get 1
+  jamf-cli pro packages get 1
 
   # Get a package by name
-  jamf-cli packages get --name "Example"
+  jamf-cli pro packages get --name "Example"
 
   # Get a package and output as YAML
-  jamf-cli packages get 1 -o yaml`,
+  jamf-cli pro packages get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -246,13 +246,13 @@ func newPackagesCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create package",
 		Long:  "Create package",
 		Example: `  # Show the JSON template for creating a package
-  jamf-cli packages create --scaffold
+  jamf-cli pro packages create --scaffold
 
   # Create a package from JSON
-  echo '{"name":"Example"}' | jamf-cli packages create
+  echo '{"name":"Example"}' | jamf-cli pro packages create
 
   # Get a package, modify it, and create a copy
-  jamf-cli packages get 1 -o json | jq '.name = "Copy"' | jamf-cli packages create`,
+  jamf-cli pro packages get 1 -o json | jq '.name = "Copy"' | jamf-cli pro packages create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -346,13 +346,13 @@ func newPackagesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update specified package object",
 		Long:  "Update specified package object",
 		Example: `  # Update a package from JSON
-  echo '{"name":"Updated"}' | jamf-cli packages update 1
+  echo '{"name":"Updated"}' | jamf-cli pro packages update 1
 
   # Update by name
-  jamf-cli packages get --name "Example" -o json | jq '.field = "value"' | jamf-cli packages update --name "Example"
+  jamf-cli pro packages get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro packages update --name "Example"
 
   # Get a package, modify, and update
-  jamf-cli packages get 1 -o json | jq '.name = "New Name"' | jamf-cli packages update 1`,
+  jamf-cli pro packages get 1 -o json | jq '.name = "New Name"' | jamf-cli pro packages update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -464,13 +464,13 @@ func newPackagesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Remove specified package",
 		Long:  "Removes specified package",
 		Example: `  # Delete a package (with confirmation)
-  jamf-cli packages delete 1
+  jamf-cli pro packages delete 1
 
   # Delete by name
-  jamf-cli packages delete --name "Example" --yes
+  jamf-cli pro packages delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli packages delete 1 --yes`,
+  jamf-cli pro packages delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -578,7 +578,7 @@ func newPackagesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete multiple packages at once",
 		Long:  "IDs of the packages to be deleted",
 		Example: `  # Delete multiple packages by IDs
-  jamf-cli packages delete-multiple --ids 1,2,3 --yes`,
+  jamf-cli pro packages delete-multiple --ids 1,2,3 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -678,10 +678,10 @@ func newPackagesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Package History object",
 		Long:  "Gets specified Package history object",
 		Example: `  # Get history for a package by ID
-  jamf-cli packages history 1
+  jamf-cli pro packages history 1
 
   # Get history by name
-  jamf-cli packages history --name "Example"`,
+  jamf-cli pro packages history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -907,7 +907,7 @@ func newPackagesExportCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Export Packages collection",
 		Long:  "Export Packages collection",
 		Example: `  # Export packages to CSV
-  jamf-cli packages export --out-file packages.csv`,
+  jamf-cli pro packages export --out-file packages.csv`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 			reqCtx = registry.WithAccept(reqCtx, "*/*")
@@ -1244,19 +1244,19 @@ The packageName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a package from a JSON file
-  jamf-cli packages apply --from-file package.json
+  jamf-cli pro packages apply --from-file package.json
 
   # Apply a package from a YAML file
-  jamf-cli packages apply --from-file package.yaml
+  jamf-cli pro packages apply --from-file package.yaml
 
   # Apply from stdin
-  cat package.json | jamf-cli packages apply
+  cat package.json | jamf-cli pro packages apply
 
   # Apply without replacement confirmation
-  jamf-cli packages apply --from-file package.json --yes
+  jamf-cli pro packages apply --from-file package.json --yes
 
   # Preview what would happen
-  jamf-cli packages apply --from-file package.json --dry-run`,
+  jamf-cli pro packages apply --from-file package.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/parent_app.go
+++ b/internal/commands/pro/generated/parent_app.go
@@ -40,10 +40,10 @@ func newParentAppGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get the current Jamf Parent app settings",
 		Long:  "Get the current Jamf Parent app settings",
 		Example: `  # Get parent-app
-  jamf-cli parent-app get
+  jamf-cli pro parent-app get
 
   # Get parent-app and output as YAML
-  jamf-cli parent-app get -o yaml`,
+  jamf-cli pro parent-app get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -80,10 +80,10 @@ func newParentAppUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update Jamf Parent app settings",
 		Long:  "Update Jamf Parent app settings",
 		Example: `  # Update parent-app
-  jamf-cli parent-app get -o json | jq '.field = "value"' | jamf-cli parent-app update
+  jamf-cli pro parent-app get -o json | jq '.field = "value"' | jamf-cli pro parent-app update
 
   # Update from a file
-  jamf-cli parent-app update --from-file parent-app.json`,
+  jamf-cli pro parent-app update --from-file parent-app.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -162,7 +162,7 @@ func newParentAppHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Jamf Parent app settings history",
 		Long:  "Gets Jamf Parent app settings history",
 		Example: `  # Get history for a parent-app
-  jamf-cli parent-app history 1`,
+  jamf-cli pro parent-app history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/patch_policies.go
+++ b/internal/commands/pro/generated/patch_policies.go
@@ -50,10 +50,10 @@ func newPatchPoliciesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve Patch Policies",
 		Long:  "Retrieves a list of patch policies.",
 		Example: `  # List all patch-policies
-  jamf-cli patch-policies list
+  jamf-cli pro patch-policies list
 
   # List patch-policies and extract IDs
-  jamf-cli patch-policies list --field id`,
+  jamf-cli pro patch-policies list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -178,13 +178,13 @@ func newPatchPoliciesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Remove a patch policy from the dashboard",
 		Long:  "Removes a patch policy from the dashboard.",
 		Example: `  # Delete a patch-policy (with confirmation)
-  jamf-cli patch-policies delete 1
+  jamf-cli pro patch-policies delete 1
 
   # Delete by name
-  jamf-cli patch-policies delete --name "Example" --yes
+  jamf-cli pro patch-policies delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli patch-policies delete 1 --yes`,
+  jamf-cli pro patch-policies delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/patch_software_title_configurations.go
+++ b/internal/commands/pro/generated/patch_software_title_configurations.go
@@ -55,10 +55,10 @@ func newPatchSoftwareTitleConfigurationsListCmd(ctx *registry.CLIContext) *cobra
 		Short: "Retrieve Patch Software Title Configurations",
 		Long:  "Retrieves patch software title configurations",
 		Example: `  # List all patch-software-title-configurations
-  jamf-cli patch-software-title-configurations list
+  jamf-cli pro patch-software-title-configurations list
 
   # List patch-software-title-configurations and extract IDs
-  jamf-cli patch-software-title-configurations list --field id`,
+  jamf-cli pro patch-software-title-configurations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -95,13 +95,13 @@ func newPatchSoftwareTitleConfigurationsGetCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Retrieve Patch Software Title Configurations with the supplied id",
 		Long:  "Retrieves Patch Software Title Configurations with the supplied id",
 		Example: `  # Get a patch-software-title-configuration by ID
-  jamf-cli patch-software-title-configurations get 1
+  jamf-cli pro patch-software-title-configurations get 1
 
   # Get a patch-software-title-configuration by name
-  jamf-cli patch-software-title-configurations get --name "Example"
+  jamf-cli pro patch-software-title-configurations get --name "Example"
 
   # Get a patch-software-title-configuration and output as YAML
-  jamf-cli patch-software-title-configurations get 1 -o yaml`,
+  jamf-cli pro patch-software-title-configurations get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -156,13 +156,13 @@ func newPatchSoftwareTitleConfigurationsCreateCmd(ctx *registry.CLIContext) *cob
 		Short: "Create Patch Software Title Configurations",
 		Long:  "Creates Patch Software Title Configurations using sToken",
 		Example: `  # Show the JSON template for creating a patch-software-title-configuration
-  jamf-cli patch-software-title-configurations create --scaffold
+  jamf-cli pro patch-software-title-configurations create --scaffold
 
   # Create a patch-software-title-configuration from JSON
-  echo '{"name":"Example"}' | jamf-cli patch-software-title-configurations create
+  echo '{"name":"Example"}' | jamf-cli pro patch-software-title-configurations create
 
   # Get a patch-software-title-configuration, modify it, and create a copy
-  jamf-cli patch-software-title-configurations get 1 -o json | jq '.name = "Copy"' | jamf-cli patch-software-title-configurations create`,
+  jamf-cli pro patch-software-title-configurations get 1 -o json | jq '.name = "Copy"' | jamf-cli pro patch-software-title-configurations create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -232,13 +232,13 @@ func newPatchSoftwareTitleConfigurationsDeleteCmd(ctx *registry.CLIContext) *cob
 		Short: "Delete Patch Software Title Configurations with the supplied id",
 		Long:  "Deletes Patch Software Title Configurations with the supplied id",
 		Example: `  # Delete a patch-software-title-configuration (with confirmation)
-  jamf-cli patch-software-title-configurations delete 1
+  jamf-cli pro patch-software-title-configurations delete 1
 
   # Delete by name
-  jamf-cli patch-software-title-configurations delete --name "Example" --yes
+  jamf-cli pro patch-software-title-configurations delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli patch-software-title-configurations delete 1 --yes`,
+  jamf-cli pro patch-software-title-configurations delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -349,10 +349,10 @@ func newPatchSoftwareTitleConfigurationsHistoryCmd(ctx *registry.CLIContext) *co
 		Short: "Get specified Patch Software Title Configuration history object",
 		Long:  "Gets specified Patch Software Title Configuration history object",
 		Example: `  # Get history for a patch-software-title-configuration by ID
-  jamf-cli patch-software-title-configurations history 1
+  jamf-cli pro patch-software-title-configurations history 1
 
   # Get history by name
-  jamf-cli patch-software-title-configurations history --name "Example"`,
+  jamf-cli pro patch-software-title-configurations history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -574,16 +574,16 @@ func newPatchSoftwareTitleConfigurationsPatchCmd(ctx *registry.CLIContext) *cobr
 		Short: "Update Patch Software Title Configurations",
 		Long:  "Updates Patch Software Title Configurations\n\nIdentify the resource by ID (positional arg), --name, . Omit ID to use a lookup flag.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  categoryId                                   string\n  displayName                                  string\n  emailNotifications                           boolean\n  siteId                                       string\n  softwareTitleId                              string\n  uiNotifications                              boolean\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field by ID
-  jamf-cli patch-software-title-configurations patch 1 --set general.managed=true
+  jamf-cli pro patch-software-title-configurations patch 1 --set general.managed=true
 
   # Update multiple fields
-  jamf-cli patch-software-title-configurations patch 1 --set field1=value1 --set field2=value2
+  jamf-cli pro patch-software-title-configurations patch 1 --set field1=value1 --set field2=value2
 
   # Update by name
-  jamf-cli patch-software-title-configurations patch --name "Example" --set general.managed=true
+  jamf-cli pro patch-software-title-configurations patch --name "Example" --set general.managed=true
 
   # Patch from a file
-  jamf-cli patch-software-title-configurations patch 1 --from-file changes.json`,
+  jamf-cli pro patch-software-title-configurations patch 1 --from-file changes.json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -1269,19 +1269,19 @@ The displayName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a patch-software-title-configuration from a JSON file
-  jamf-cli patch-software-title-configurations apply --from-file patch-software-title-configuration.json
+  jamf-cli pro patch-software-title-configurations apply --from-file patch-software-title-configuration.json
 
   # Apply a patch-software-title-configuration from a YAML file
-  jamf-cli patch-software-title-configurations apply --from-file patch-software-title-configuration.yaml
+  jamf-cli pro patch-software-title-configurations apply --from-file patch-software-title-configuration.yaml
 
   # Apply from stdin
-  cat patch-software-title-configuration.json | jamf-cli patch-software-title-configurations apply
+  cat patch-software-title-configuration.json | jamf-cli pro patch-software-title-configurations apply
 
   # Apply without replacement confirmation
-  jamf-cli patch-software-title-configurations apply --from-file patch-software-title-configuration.json --yes
+  jamf-cli pro patch-software-title-configurations apply --from-file patch-software-title-configuration.json --yes
 
   # Preview what would happen
-  jamf-cli patch-software-title-configurations apply --from-file patch-software-title-configuration.json --dry-run`,
+  jamf-cli pro patch-software-title-configurations apply --from-file patch-software-title-configuration.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/reenrollment.go
+++ b/internal/commands/pro/generated/reenrollment.go
@@ -41,10 +41,10 @@ func newReenrollmentGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Re-enrollment object",
 		Long:  "Gets Re-enrollment object",
 		Example: `  # Get reenrollment
-  jamf-cli reenrollment get
+  jamf-cli pro reenrollment get
 
   # Get reenrollment and output as YAML
-  jamf-cli reenrollment get -o yaml`,
+  jamf-cli pro reenrollment get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -81,10 +81,10 @@ func newReenrollmentUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update the Re-enrollment object",
 		Long:  "Update the Re-enrollment object",
 		Example: `  # Update reenrollment
-  jamf-cli reenrollment get -o json | jq '.field = "value"' | jamf-cli reenrollment update
+  jamf-cli pro reenrollment get -o json | jq '.field = "value"' | jamf-cli pro reenrollment update
 
   # Update from a file
-  jamf-cli reenrollment update --from-file reenrollment.json`,
+  jamf-cli pro reenrollment update --from-file reenrollment.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -157,7 +157,7 @@ func newReenrollmentHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Re-enrollment history object",
 		Long:  "Gets Re-enrollment history object",
 		Example: `  # Get history for a reenrollment
-  jamf-cli reenrollment history 1`,
+  jamf-cli pro reenrollment history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/remote_administration_configurations.go
+++ b/internal/commands/pro/generated/remote_administration_configurations.go
@@ -39,10 +39,10 @@ func newRemoteAdministrationConfigurationsListCmd(ctx *registry.CLIContext) *cob
 		Short: "Get information about all remote administration configurations.",
 		Long:  "Remote administration feature creates a secure screen-sharing experience between Jamf Pro administrators and their end-users.",
 		Example: `  # List all remote-administration-configurations
-  jamf-cli remote-administration-configurations list
+  jamf-cli pro remote-administration-configurations list
 
   # List remote-administration-configurations and extract IDs
-  jamf-cli remote-administration-configurations list --field id`,
+  jamf-cli pro remote-administration-configurations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/return_to_service_configurations.go
+++ b/internal/commands/pro/generated/return_to_service_configurations.go
@@ -43,10 +43,10 @@ func newReturnToServiceConfigurationsListCmd(ctx *registry.CLIContext) *cobra.Co
 		Short: "Get all Return to Service Configurations",
 		Long:  "Gets all return to service configurations.",
 		Example: `  # List all return-to-service-configurations
-  jamf-cli return-to-service-configurations list
+  jamf-cli pro return-to-service-configurations list
 
   # List return-to-service-configurations and extract IDs
-  jamf-cli return-to-service-configurations list --field id`,
+  jamf-cli pro return-to-service-configurations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -83,13 +83,13 @@ func newReturnToServiceConfigurationsGetCmd(ctx *registry.CLIContext) *cobra.Com
 		Short: "Retrieve a Return to Service Configuration with the supplied id",
 		Long:  "Retrieves a Return to Service Configuration with the supplied id",
 		Example: `  # Get a return-to-service-configuration by ID
-  jamf-cli return-to-service-configurations get 1
+  jamf-cli pro return-to-service-configurations get 1
 
   # Get a return-to-service-configuration by name
-  jamf-cli return-to-service-configurations get --name "Example"
+  jamf-cli pro return-to-service-configurations get --name "Example"
 
   # Get a return-to-service-configuration and output as YAML
-  jamf-cli return-to-service-configurations get 1 -o yaml`,
+  jamf-cli pro return-to-service-configurations get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -144,13 +144,13 @@ func newReturnToServiceConfigurationsCreateCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Create a Return to Service Configuration",
 		Long:  "Create a return to service configuration",
 		Example: `  # Show the JSON template for creating a return-to-service-configuration
-  jamf-cli return-to-service-configurations create --scaffold
+  jamf-cli pro return-to-service-configurations create --scaffold
 
   # Create a return-to-service-configuration from JSON
-  echo '{"name":"Example"}' | jamf-cli return-to-service-configurations create
+  echo '{"name":"Example"}' | jamf-cli pro return-to-service-configurations create
 
   # Get a return-to-service-configuration, modify it, and create a copy
-  jamf-cli return-to-service-configurations get 1 -o json | jq '.name = "Copy"' | jamf-cli return-to-service-configurations create`,
+  jamf-cli pro return-to-service-configurations get 1 -o json | jq '.name = "Copy"' | jamf-cli pro return-to-service-configurations create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -214,13 +214,13 @@ func newReturnToServiceConfigurationsUpdateCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Update a Return to Service Configuration",
 		Long:  "Updates a Return to Service Configuration",
 		Example: `  # Update a return-to-service-configuration from JSON
-  echo '{"name":"Updated"}' | jamf-cli return-to-service-configurations update 1
+  echo '{"name":"Updated"}' | jamf-cli pro return-to-service-configurations update 1
 
   # Update by name
-  jamf-cli return-to-service-configurations get --name "Example" -o json | jq '.field = "value"' | jamf-cli return-to-service-configurations update --name "Example"
+  jamf-cli pro return-to-service-configurations get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro return-to-service-configurations update --name "Example"
 
   # Get a return-to-service-configuration, modify, and update
-  jamf-cli return-to-service-configurations get 1 -o json | jq '.name = "New Name"' | jamf-cli return-to-service-configurations update 1`,
+  jamf-cli pro return-to-service-configurations get 1 -o json | jq '.name = "New Name"' | jamf-cli pro return-to-service-configurations update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -302,13 +302,13 @@ func newReturnToServiceConfigurationsDeleteCmd(ctx *registry.CLIContext) *cobra.
 		Short: "Delete a Return To Service Configuration with the supplied id",
 		Long:  "Deletes a Return To Service Configuration with the supplied id",
 		Example: `  # Delete a return-to-service-configuration (with confirmation)
-  jamf-cli return-to-service-configurations delete 1
+  jamf-cli pro return-to-service-configurations delete 1
 
   # Delete by name
-  jamf-cli return-to-service-configurations delete --name "Example" --yes
+  jamf-cli pro return-to-service-configurations delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli return-to-service-configurations delete 1 --yes`,
+  jamf-cli pro return-to-service-configurations delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -420,19 +420,19 @@ The displayName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a return-to-service-configuration from a JSON file
-  jamf-cli return-to-service-configurations apply --from-file return-to-service-configuration.json
+  jamf-cli pro return-to-service-configurations apply --from-file return-to-service-configuration.json
 
   # Apply a return-to-service-configuration from a YAML file
-  jamf-cli return-to-service-configurations apply --from-file return-to-service-configuration.yaml
+  jamf-cli pro return-to-service-configurations apply --from-file return-to-service-configuration.yaml
 
   # Apply from stdin
-  cat return-to-service-configuration.json | jamf-cli return-to-service-configurations apply
+  cat return-to-service-configuration.json | jamf-cli pro return-to-service-configurations apply
 
   # Apply without replacement confirmation
-  jamf-cli return-to-service-configurations apply --from-file return-to-service-configuration.json --yes
+  jamf-cli pro return-to-service-configurations apply --from-file return-to-service-configuration.json --yes
 
   # Preview what would happen
-  jamf-cli return-to-service-configurations apply --from-file return-to-service-configuration.json --dry-run`,
+  jamf-cli pro return-to-service-configurations apply --from-file return-to-service-configuration.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/schedulers.go
+++ b/internal/commands/pro/generated/schedulers.go
@@ -35,10 +35,10 @@ func newSchedulersListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve all Jamf Pro Scheduler jobs",
 		Long:  "Retrieves the names of all Jamf Pro Scheduler jobs",
 		Example: `  # List all schedulers
-  jamf-cli schedulers list
+  jamf-cli pro schedulers list
 
   # List schedulers and extract IDs
-  jamf-cli schedulers list --field id`,
+  jamf-cli pro schedulers list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/scripts.go
+++ b/internal/commands/pro/generated/scripts.go
@@ -54,10 +54,10 @@ func newScriptsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Search for sorted and paged Scripts",
 		Long:  "Search for sorted and paged scripts",
 		Example: `  # List all scripts
-  jamf-cli scripts list
+  jamf-cli pro scripts list
 
   # List scripts and extract IDs
-  jamf-cli scripts list --field id`,
+  jamf-cli pro scripts list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -180,13 +180,13 @@ func newScriptsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve a full script object",
 		Long:  "Retrieves a full script object",
 		Example: `  # Get a script by ID
-  jamf-cli scripts get 1
+  jamf-cli pro scripts get 1
 
   # Get a script by name
-  jamf-cli scripts get --name "Example"
+  jamf-cli pro scripts get --name "Example"
 
   # Get a script and output as YAML
-  jamf-cli scripts get 1 -o yaml`,
+  jamf-cli pro scripts get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -242,13 +242,13 @@ func newScriptsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a Script",
 		Long:  "Creates a script",
 		Example: `  # Show the JSON template for creating a script
-  jamf-cli scripts create --scaffold
+  jamf-cli pro scripts create --scaffold
 
   # Create a script from JSON
-  echo '{"name":"Example"}' | jamf-cli scripts create
+  echo '{"name":"Example"}' | jamf-cli pro scripts create
 
   # Get a script, modify it, and create a copy
-  jamf-cli scripts get 1 -o json | jq '.name = "Copy"' | jamf-cli scripts create`,
+  jamf-cli pro scripts get 1 -o json | jq '.name = "Copy"' | jamf-cli pro scripts create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -339,13 +339,13 @@ func newScriptsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Replace the script at the id with the supplied information",
 		Long:  "Replaces the script at the id with the supplied information",
 		Example: `  # Update a script from JSON
-  echo '{"name":"Updated"}' | jamf-cli scripts update 1
+  echo '{"name":"Updated"}' | jamf-cli pro scripts update 1
 
   # Update by name
-  jamf-cli scripts get --name "Example" -o json | jq '.field = "value"' | jamf-cli scripts update --name "Example"
+  jamf-cli pro scripts get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro scripts update --name "Example"
 
   # Get a script, modify, and update
-  jamf-cli scripts get 1 -o json | jq '.name = "New Name"' | jamf-cli scripts update 1`,
+  jamf-cli pro scripts get 1 -o json | jq '.name = "New Name"' | jamf-cli pro scripts update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -453,13 +453,13 @@ func newScriptsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete a Script at the specified id",
 		Long:  "Deletes a script at the specified id",
 		Example: `  # Delete a script (with confirmation)
-  jamf-cli scripts delete 1
+  jamf-cli pro scripts delete 1
 
   # Delete by name
-  jamf-cli scripts delete --name "Example" --yes
+  jamf-cli pro scripts delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli scripts delete 1 --yes`,
+  jamf-cli pro scripts delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -570,10 +570,10 @@ func newScriptsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Script history object",
 		Long:  "Gets specified Script history object",
 		Example: `  # Get history for a script by ID
-  jamf-cli scripts history 1
+  jamf-cli pro scripts history 1
 
   # Get history by name
-  jamf-cli scripts history --name "Example"`,
+  jamf-cli pro scripts history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -875,19 +875,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a script from a JSON file
-  jamf-cli scripts apply --from-file script.json
+  jamf-cli pro scripts apply --from-file script.json
 
   # Apply a script from a YAML file
-  jamf-cli scripts apply --from-file script.yaml
+  jamf-cli pro scripts apply --from-file script.yaml
 
   # Apply from stdin
-  cat script.json | jamf-cli scripts apply
+  cat script.json | jamf-cli pro scripts apply
 
   # Apply without replacement confirmation
-  jamf-cli scripts apply --from-file script.json --yes
+  jamf-cli pro scripts apply --from-file script.json --yes
 
   # Preview what would happen
-  jamf-cli scripts apply --from-file script.json --dry-run`,
+  jamf-cli pro scripts apply --from-file script.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/self_service_branding_ios_resource.go
+++ b/internal/commands/pro/generated/self_service_branding_ios_resource.go
@@ -50,10 +50,10 @@ func newSelfServiceBrandingIosListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Search for sorted and paged iOS branding configurations",
 		Long:  "Search for sorted and paged iOS branding configurations",
 		Example: `  # List all self-service-branding-ios
-  jamf-cli self-service-branding-ios list
+  jamf-cli pro self-service-branding-ios list
 
   # List self-service-branding-ios and extract IDs
-  jamf-cli self-service-branding-ios list --field id`,
+  jamf-cli pro self-service-branding-ios list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -172,13 +172,13 @@ func newSelfServiceBrandingIosGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Read a single Self Service iOS branding configuration indicated by the provided id",
 		Long:  "Read a single Self Service iOS branding configuration indicated by the provided id.",
 		Example: `  # Get a self-service-branding-ios by ID
-  jamf-cli self-service-branding-ios get 1
+  jamf-cli pro self-service-branding-ios get 1
 
   # Get a self-service-branding-ios by name
-  jamf-cli self-service-branding-ios get --name "Example"
+  jamf-cli pro self-service-branding-ios get --name "Example"
 
   # Get a self-service-branding-ios and output as YAML
-  jamf-cli self-service-branding-ios get 1 -o yaml`,
+  jamf-cli pro self-service-branding-ios get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -233,13 +233,13 @@ func newSelfServiceBrandingIosCreateCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Create a Self Service iOS branding configuration with the supplied",
 		Long:  "Create a Self Service iOS branding configuration with the supplied details",
 		Example: `  # Show the JSON template for creating a self-service-branding-ios
-  jamf-cli self-service-branding-ios create --scaffold
+  jamf-cli pro self-service-branding-ios create --scaffold
 
   # Create a self-service-branding-ios from JSON
-  echo '{"name":"Example"}' | jamf-cli self-service-branding-ios create
+  echo '{"name":"Example"}' | jamf-cli pro self-service-branding-ios create
 
   # Get a self-service-branding-ios, modify it, and create a copy
-  jamf-cli self-service-branding-ios get 1 -o json | jq '.name = "Copy"' | jamf-cli self-service-branding-ios create`,
+  jamf-cli pro self-service-branding-ios get 1 -o json | jq '.name = "Copy"' | jamf-cli pro self-service-branding-ios create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -307,13 +307,13 @@ func newSelfServiceBrandingIosUpdateCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Update a Self Service iOS branding configuration with the supplied details",
 		Long:  "Update a Self Service iOS branding configuration with the supplied details",
 		Example: `  # Update a self-service-branding-ios from JSON
-  echo '{"name":"Updated"}' | jamf-cli self-service-branding-ios update 1
+  echo '{"name":"Updated"}' | jamf-cli pro self-service-branding-ios update 1
 
   # Update by name
-  jamf-cli self-service-branding-ios get --name "Example" -o json | jq '.field = "value"' | jamf-cli self-service-branding-ios update --name "Example"
+  jamf-cli pro self-service-branding-ios get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro self-service-branding-ios update --name "Example"
 
   # Get a self-service-branding-ios, modify, and update
-  jamf-cli self-service-branding-ios get 1 -o json | jq '.name = "New Name"' | jamf-cli self-service-branding-ios update 1`,
+  jamf-cli pro self-service-branding-ios get 1 -o json | jq '.name = "New Name"' | jamf-cli pro self-service-branding-ios update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -399,13 +399,13 @@ func newSelfServiceBrandingIosDeleteCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Delete the Self Service iOS branding configuration indicated by the provided id",
 		Long:  "Delete the Self Service iOS branding configuration indicated by the provided id.",
 		Example: `  # Delete a self-service-branding-ios (with confirmation)
-  jamf-cli self-service-branding-ios delete 1
+  jamf-cli pro self-service-branding-ios delete 1
 
   # Delete by name
-  jamf-cli self-service-branding-ios delete --name "Example" --yes
+  jamf-cli pro self-service-branding-ios delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli self-service-branding-ios delete 1 --yes`,
+  jamf-cli pro self-service-branding-ios delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -517,19 +517,19 @@ The brandingName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a self-service-branding-ios from a JSON file
-  jamf-cli self-service-branding-ios apply --from-file self-service-branding-ios.json
+  jamf-cli pro self-service-branding-ios apply --from-file self-service-branding-ios.json
 
   # Apply a self-service-branding-ios from a YAML file
-  jamf-cli self-service-branding-ios apply --from-file self-service-branding-ios.yaml
+  jamf-cli pro self-service-branding-ios apply --from-file self-service-branding-ios.yaml
 
   # Apply from stdin
-  cat self-service-branding-ios.json | jamf-cli self-service-branding-ios apply
+  cat self-service-branding-ios.json | jamf-cli pro self-service-branding-ios apply
 
   # Apply without replacement confirmation
-  jamf-cli self-service-branding-ios apply --from-file self-service-branding-ios.json --yes
+  jamf-cli pro self-service-branding-ios apply --from-file self-service-branding-ios.json --yes
 
   # Preview what would happen
-  jamf-cli self-service-branding-ios apply --from-file self-service-branding-ios.json --dry-run`,
+  jamf-cli pro self-service-branding-ios apply --from-file self-service-branding-ios.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/self_service_branding_macos.go
+++ b/internal/commands/pro/generated/self_service_branding_macos.go
@@ -50,10 +50,10 @@ func newSelfServiceBrandingMacosListCmd(ctx *registry.CLIContext) *cobra.Command
 		Short: "Search for sorted and paged macOS branding configurations",
 		Long:  "Search for sorted and paged macOS branding configurations",
 		Example: `  # List all self-service-branding-macos
-  jamf-cli self-service-branding-macos list
+  jamf-cli pro self-service-branding-macos list
 
   # List self-service-branding-macos and extract IDs
-  jamf-cli self-service-branding-macos list --field id`,
+  jamf-cli pro self-service-branding-macos list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -172,13 +172,13 @@ func newSelfServiceBrandingMacosGetCmd(ctx *registry.CLIContext) *cobra.Command 
 		Short: "Read a single Self Service macOS branding configuration indicated by the provided id",
 		Long:  "Read a single Self Service macOS branding configuration indicated by the provided id.",
 		Example: `  # Get a self-service-branding-macos by ID
-  jamf-cli self-service-branding-macos get 1
+  jamf-cli pro self-service-branding-macos get 1
 
   # Get a self-service-branding-macos by name
-  jamf-cli self-service-branding-macos get --name "Example"
+  jamf-cli pro self-service-branding-macos get --name "Example"
 
   # Get a self-service-branding-macos and output as YAML
-  jamf-cli self-service-branding-macos get 1 -o yaml`,
+  jamf-cli pro self-service-branding-macos get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -233,13 +233,13 @@ func newSelfServiceBrandingMacosCreateCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Create a Self Service macOS branding configuration with the supplied",
 		Long:  "Create a Self Service macOS branding configuration with the supplied details",
 		Example: `  # Show the JSON template for creating a self-service-branding-macos
-  jamf-cli self-service-branding-macos create --scaffold
+  jamf-cli pro self-service-branding-macos create --scaffold
 
   # Create a self-service-branding-macos from JSON
-  echo '{"name":"Example"}' | jamf-cli self-service-branding-macos create
+  echo '{"name":"Example"}' | jamf-cli pro self-service-branding-macos create
 
   # Get a self-service-branding-macos, modify it, and create a copy
-  jamf-cli self-service-branding-macos get 1 -o json | jq '.name = "Copy"' | jamf-cli self-service-branding-macos create`,
+  jamf-cli pro self-service-branding-macos get 1 -o json | jq '.name = "Copy"' | jamf-cli pro self-service-branding-macos create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -308,13 +308,13 @@ func newSelfServiceBrandingMacosUpdateCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Update a Self Service macOS branding configuration with the supplied details",
 		Long:  "Update a Self Service macOS branding configuration with the supplied details",
 		Example: `  # Update a self-service-branding-macos from JSON
-  echo '{"name":"Updated"}' | jamf-cli self-service-branding-macos update 1
+  echo '{"name":"Updated"}' | jamf-cli pro self-service-branding-macos update 1
 
   # Update by name
-  jamf-cli self-service-branding-macos get --name "Example" -o json | jq '.field = "value"' | jamf-cli self-service-branding-macos update --name "Example"
+  jamf-cli pro self-service-branding-macos get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro self-service-branding-macos update --name "Example"
 
   # Get a self-service-branding-macos, modify, and update
-  jamf-cli self-service-branding-macos get 1 -o json | jq '.name = "New Name"' | jamf-cli self-service-branding-macos update 1`,
+  jamf-cli pro self-service-branding-macos get 1 -o json | jq '.name = "New Name"' | jamf-cli pro self-service-branding-macos update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -401,13 +401,13 @@ func newSelfServiceBrandingMacosDeleteCmd(ctx *registry.CLIContext) *cobra.Comma
 		Short: "Delete the Self Service macOS branding configuration indicated by the provided id",
 		Long:  "Delete the Self Service macOS branding configuration indicated by the provided id.",
 		Example: `  # Delete a self-service-branding-macos (with confirmation)
-  jamf-cli self-service-branding-macos delete 1
+  jamf-cli pro self-service-branding-macos delete 1
 
   # Delete by name
-  jamf-cli self-service-branding-macos delete --name "Example" --yes
+  jamf-cli pro self-service-branding-macos delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli self-service-branding-macos delete 1 --yes`,
+  jamf-cli pro self-service-branding-macos delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -519,19 +519,19 @@ The brandingName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a self-service-branding-macos from a JSON file
-  jamf-cli self-service-branding-macos apply --from-file self-service-branding-macos.json
+  jamf-cli pro self-service-branding-macos apply --from-file self-service-branding-macos.json
 
   # Apply a self-service-branding-macos from a YAML file
-  jamf-cli self-service-branding-macos apply --from-file self-service-branding-macos.yaml
+  jamf-cli pro self-service-branding-macos apply --from-file self-service-branding-macos.yaml
 
   # Apply from stdin
-  cat self-service-branding-macos.json | jamf-cli self-service-branding-macos apply
+  cat self-service-branding-macos.json | jamf-cli pro self-service-branding-macos apply
 
   # Apply without replacement confirmation
-  jamf-cli self-service-branding-macos apply --from-file self-service-branding-macos.json --yes
+  jamf-cli pro self-service-branding-macos apply --from-file self-service-branding-macos.json --yes
 
   # Preview what would happen
-  jamf-cli self-service-branding-macos apply --from-file self-service-branding-macos.json --dry-run`,
+  jamf-cli pro self-service-branding-macos apply --from-file self-service-branding-macos.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/self_service_plus.go
+++ b/internal/commands/pro/generated/self_service_plus.go
@@ -39,10 +39,10 @@ func newSelfServicePlusUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Save Self Service Plus settings.",
 		Long:  "Save Self Service Plus settings.",
 		Example: `  # Update self-service-plus
-  jamf-cli self-service-plus get -o json | jq '.field = "value"' | jamf-cli self-service-plus update
+  jamf-cli pro self-service-plus get -o json | jq '.field = "value"' | jamf-cli pro self-service-plus update
 
   # Update from a file
-  jamf-cli self-service-plus update --from-file self-service-plus.json`,
+  jamf-cli pro self-service-plus update --from-file self-service-plus.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/self_service_settings.go
+++ b/internal/commands/pro/generated/self_service_settings.go
@@ -40,10 +40,10 @@ func newSelfServiceSettingsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get an object representation of Self Service settings",
 		Long:  "gets an object representation of Self Service settings",
 		Example: `  # Get self-service-settings
-  jamf-cli self-service-settings get
+  jamf-cli pro self-service-settings get
 
   # Get self-service-settings and output as YAML
-  jamf-cli self-service-settings get -o yaml`,
+  jamf-cli pro self-service-settings get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -80,10 +80,10 @@ func newSelfServiceSettingsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Put an object representation of Self Service settings",
 		Long:  "puts an object representation of Self Service settings",
 		Example: `  # Update self-service-settings
-  jamf-cli self-service-settings get -o json | jq '.field = "value"' | jamf-cli self-service-settings update
+  jamf-cli pro self-service-settings get -o json | jq '.field = "value"' | jamf-cli pro self-service-settings update
 
   # Update from a file
-  jamf-cli self-service-settings update --from-file self-service-settings.json`,
+  jamf-cli pro self-service-settings update --from-file self-service-settings.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -152,7 +152,7 @@ func newSelfServiceSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get a page of Self Service settings history",
 		Long:  "Get a page of Self Service settings history",
 		Example: `  # Get history for a self-service-settings
-  jamf-cli self-service-settings history 1`,
+  jamf-cli pro self-service-settings history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/service_discovery.go
+++ b/internal/commands/pro/generated/service_discovery.go
@@ -36,10 +36,10 @@ func newServiceDiscoveryGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get service discovery well-known settings for all organizations",
 		Long:  "Returns current settings for all AxM organizations.",
 		Example: `  # Get service-discovery
-  jamf-cli service-discovery get
+  jamf-cli pro service-discovery get
 
   # Get service-discovery and output as YAML
-  jamf-cli service-discovery get -o yaml`,
+  jamf-cli pro service-discovery get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -76,10 +76,10 @@ func newServiceDiscoveryUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update service discovery well-known settings",
 		Long:  "Accepts JSON payload to update enrollment types for AxM organizations. Requires \"Update User-Initiated Enrollment\" privilege.",
 		Example: `  # Update service-discovery
-  jamf-cli service-discovery get -o json | jq '.field = "value"' | jamf-cli service-discovery update
+  jamf-cli pro service-discovery get -o json | jq '.field = "value"' | jamf-cli pro service-discovery update
 
   # Update from a file
-  jamf-cli service-discovery update --from-file service-discovery.json`,
+  jamf-cli pro service-discovery update --from-file service-discovery.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/sites.go
+++ b/internal/commands/pro/generated/sites.go
@@ -34,10 +34,10 @@ func newSitesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Find all sites",
 		Long:  "Find all sites",
 		Example: `  # List all sites
-  jamf-cli sites list
+  jamf-cli pro sites list
 
   # List sites and extract IDs
-  jamf-cli sites list --field id`,
+  jamf-cli pro sites list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/slasas.go
+++ b/internal/commands/pro/generated/slasas.go
@@ -36,10 +36,10 @@ func newSlasasListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get the status of SLASA",
 		Long:  "Get if SLASA has been accepted or not",
 		Example: `  # List all slasas
-  jamf-cli slasas list
+  jamf-cli pro slasas list
 
   # List slasas and extract IDs
-  jamf-cli slasas list --field id`,
+  jamf-cli pro slasas list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/smart_computer_groups.go
+++ b/internal/commands/pro/generated/smart_computer_groups.go
@@ -51,10 +51,10 @@ func newSmartComputerGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Search for Smart Computer Groups",
 		Long:  "Search for Smart Computer Groups",
 		Example: `  # List all smart-computer-groups
-  jamf-cli smart-computer-groups list
+  jamf-cli pro smart-computer-groups list
 
   # List smart-computer-groups and extract IDs
-  jamf-cli smart-computer-groups list --field id`,
+  jamf-cli pro smart-computer-groups list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -177,13 +177,13 @@ func newSmartComputerGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Smart Computer Group by Id",
 		Long:  "Get Smart Computer Group by Id",
 		Example: `  # Get a smart-computer-group by ID
-  jamf-cli smart-computer-groups get 1
+  jamf-cli pro smart-computer-groups get 1
 
   # Get a smart-computer-group by name
-  jamf-cli smart-computer-groups get --name "Example"
+  jamf-cli pro smart-computer-groups get --name "Example"
 
   # Get a smart-computer-group and output as YAML
-  jamf-cli smart-computer-groups get 1 -o yaml`,
+  jamf-cli pro smart-computer-groups get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -239,13 +239,13 @@ func newSmartComputerGroupsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a Smart Computer Group",
 		Long:  "Creates a Smart Computer Group",
 		Example: `  # Show the JSON template for creating a smart-computer-group
-  jamf-cli smart-computer-groups create --scaffold
+  jamf-cli pro smart-computer-groups create --scaffold
 
   # Create a smart-computer-group from JSON
-  echo '{"name":"Example"}' | jamf-cli smart-computer-groups create
+  echo '{"name":"Example"}' | jamf-cli pro smart-computer-groups create
 
   # Get a smart-computer-group, modify it, and create a copy
-  jamf-cli smart-computer-groups get 1 -o json | jq '.name = "Copy"' | jamf-cli smart-computer-groups create`,
+  jamf-cli pro smart-computer-groups get 1 -o json | jq '.name = "Copy"' | jamf-cli pro smart-computer-groups create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -315,13 +315,13 @@ func newSmartComputerGroupsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a Smart Computer Group",
 		Long:  "Updates a Smart Computer Group",
 		Example: `  # Update a smart-computer-group from JSON
-  echo '{"name":"Updated"}' | jamf-cli smart-computer-groups update 1
+  echo '{"name":"Updated"}' | jamf-cli pro smart-computer-groups update 1
 
   # Update by name
-  jamf-cli smart-computer-groups get --name "Example" -o json | jq '.field = "value"' | jamf-cli smart-computer-groups update --name "Example"
+  jamf-cli pro smart-computer-groups get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro smart-computer-groups update --name "Example"
 
   # Get a smart-computer-group, modify, and update
-  jamf-cli smart-computer-groups get 1 -o json | jq '.name = "New Name"' | jamf-cli smart-computer-groups update 1`,
+  jamf-cli pro smart-computer-groups get 1 -o json | jq '.name = "New Name"' | jamf-cli pro smart-computer-groups update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -405,13 +405,13 @@ func newSmartComputerGroupsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Remove specified Smart Computer Group",
 		Long:  "Remove specified Smart Computer Group",
 		Example: `  # Delete a smart-computer-group (with confirmation)
-  jamf-cli smart-computer-groups delete 1
+  jamf-cli pro smart-computer-groups delete 1
 
   # Delete by name
-  jamf-cli smart-computer-groups delete --name "Example" --yes
+  jamf-cli pro smart-computer-groups delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli smart-computer-groups delete 1 --yes`,
+  jamf-cli pro smart-computer-groups delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -523,19 +523,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a smart-computer-group from a JSON file
-  jamf-cli smart-computer-groups apply --from-file smart-computer-group.json
+  jamf-cli pro smart-computer-groups apply --from-file smart-computer-group.json
 
   # Apply a smart-computer-group from a YAML file
-  jamf-cli smart-computer-groups apply --from-file smart-computer-group.yaml
+  jamf-cli pro smart-computer-groups apply --from-file smart-computer-group.yaml
 
   # Apply from stdin
-  cat smart-computer-group.json | jamf-cli smart-computer-groups apply
+  cat smart-computer-group.json | jamf-cli pro smart-computer-groups apply
 
   # Apply without replacement confirmation
-  jamf-cli smart-computer-groups apply --from-file smart-computer-group.json --yes
+  jamf-cli pro smart-computer-groups apply --from-file smart-computer-group.json --yes
 
   # Preview what would happen
-  jamf-cli smart-computer-groups apply --from-file smart-computer-group.json --dry-run`,
+  jamf-cli pro smart-computer-groups apply --from-file smart-computer-group.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/smtp_server.go
+++ b/internal/commands/pro/generated/smtp_server.go
@@ -41,10 +41,10 @@ func newSmtpServerGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Finds the Jamf Pro SMTP Server information",
 		Long:  "Finds the Jamf Pro SMTP Server information",
 		Example: `  # Get smtp-server
-  jamf-cli smtp-server get
+  jamf-cli pro smtp-server get
 
   # Get smtp-server and output as YAML
-  jamf-cli smtp-server get -o yaml`,
+  jamf-cli pro smtp-server get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -82,10 +82,10 @@ func newSmtpServerUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Updates Jamf Pro SMTP Server information",
 		Long:  "Updates Jamf Pro SMTP Server information. If requiresAuthentication is set to true, a username and password must be provided",
 		Example: `  # Update smtp-server
-  jamf-cli smtp-server get -o json | jq '.field = "value"' | jamf-cli smtp-server update
+  jamf-cli pro smtp-server get -o json | jq '.field = "value"' | jamf-cli pro smtp-server update
 
   # Update from a file
-  jamf-cli smtp-server update --from-file smtp-server.json`,
+  jamf-cli pro smtp-server update --from-file smtp-server.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -162,7 +162,7 @@ func newSmtpServerHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified SMTP Server history object",
 		Long:  "Get specified SMTP Server history object",
 		Example: `  # Get history for a smtp-server
-  jamf-cli smtp-server history 1`,
+  jamf-cli pro smtp-server history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/sso_failovers.go
+++ b/internal/commands/pro/generated/sso_failovers.go
@@ -36,10 +36,10 @@ func newSsoFailoversListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve the current failover settings",
 		Long:  "Retrieve the current failover settings",
 		Example: `  # List all sso-failovers
-  jamf-cli sso-failovers list
+  jamf-cli pro sso-failovers list
 
   # List sso-failovers and extract IDs
-  jamf-cli sso-failovers list --field id`,
+  jamf-cli pro sso-failovers list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/sso_settings.go
+++ b/internal/commands/pro/generated/sso_settings.go
@@ -45,10 +45,10 @@ func newSsoSettingsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Updates the current Single Sign On configuration settings",
 		Long:  "Updates the current Single Sign On configuration settings",
 		Example: `  # Update sso-settings
-  jamf-cli sso-settings get -o json | jq '.field = "value"' | jamf-cli sso-settings update
+  jamf-cli pro sso-settings get -o json | jq '.field = "value"' | jamf-cli pro sso-settings update
 
   # Update from a file
-  jamf-cli sso-settings update --from-file sso-settings.json`,
+  jamf-cli pro sso-settings update --from-file sso-settings.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -125,7 +125,7 @@ func newSsoSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get SSO history object",
 		Long:  "Gets SSO history object",
 		Example: `  # Get history for a sso-settings
-  jamf-cli sso-settings history 1`,
+  jamf-cli pro sso-settings history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/sso_settings_cert.go
+++ b/internal/commands/pro/generated/sso_settings_cert.go
@@ -42,10 +42,10 @@ func newSsoSettingsCertGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve the certificate currently configured for use with SSO",
 		Long:  "Retrieves the certificate currently configured for use with SSO.",
 		Example: `  # Get sso-settings-cert
-  jamf-cli sso-settings-cert get
+  jamf-cli pro sso-settings-cert get
 
   # Get sso-settings-cert and output as YAML
-  jamf-cli sso-settings-cert get -o yaml`,
+  jamf-cli pro sso-settings-cert get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -82,10 +82,10 @@ func newSsoSettingsCertUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update the certificate used by Jamf Pro to sign SSO requests to the identify provider",
 		Long:  "Update the certificate used by Jamf Pro to sign SSO requests to the identify provider.",
 		Example: `  # Update sso-settings-cert
-  jamf-cli sso-settings-cert get -o json | jq '.field = "value"' | jamf-cli sso-settings-cert update
+  jamf-cli pro sso-settings-cert get -o json | jq '.field = "value"' | jamf-cli pro sso-settings-cert update
 
   # Update from a file
-  jamf-cli sso-settings-cert update --from-file sso-settings-cert.json`,
+  jamf-cli pro sso-settings-cert update --from-file sso-settings-cert.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -155,10 +155,10 @@ func newSsoSettingsCertDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete the currently configured certificate used by SSO",
 		Long:  "Deletes the currently configured certificate used by SSO.",
 		Example: `  # Delete a sso-settings-cert (with confirmation)
-  jamf-cli sso-settings-cert delete 1
+  jamf-cli pro sso-settings-cert delete 1
 
   # Delete without confirmation prompt
-  jamf-cli sso-settings-cert delete 1 --yes`,
+  jamf-cli pro sso-settings-cert delete 1 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/startup_status.go
+++ b/internal/commands/pro/generated/startup_status.go
@@ -31,10 +31,10 @@ func newStartupStatusListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve information about application startup",
 		Long:  "Retrieves information about application startup. Current startup operation taking place (if any) and overall startup completion percentage.",
 		Example: `  # List all startup-status
-  jamf-cli startup-status list
+  jamf-cli pro startup-status list
 
   # List startup-status and extract IDs
-  jamf-cli startup-status list --field id`,
+  jamf-cli pro startup-status list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/static_computer_groups.go
+++ b/internal/commands/pro/generated/static_computer_groups.go
@@ -51,10 +51,10 @@ func newStaticComputerGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Search for Static Computer Groups",
 		Long:  "Search for Static Computer Groups",
 		Example: `  # List all static-computer-groups
-  jamf-cli static-computer-groups list
+  jamf-cli pro static-computer-groups list
 
   # List static-computer-groups and extract IDs
-  jamf-cli static-computer-groups list --field id`,
+  jamf-cli pro static-computer-groups list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -177,13 +177,13 @@ func newStaticComputerGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Static Computer Group by Id",
 		Long:  "Get Static Computer Group by Id",
 		Example: `  # Get a static-computer-group by ID
-  jamf-cli static-computer-groups get 1
+  jamf-cli pro static-computer-groups get 1
 
   # Get a static-computer-group by name
-  jamf-cli static-computer-groups get --name "Example"
+  jamf-cli pro static-computer-groups get --name "Example"
 
   # Get a static-computer-group and output as YAML
-  jamf-cli static-computer-groups get 1 -o yaml`,
+  jamf-cli pro static-computer-groups get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -239,13 +239,13 @@ func newStaticComputerGroupsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create membership of a static computer group.",
 		Long:  "Create membership of a static computer group.",
 		Example: `  # Show the JSON template for creating a static-computer-group
-  jamf-cli static-computer-groups create --scaffold
+  jamf-cli pro static-computer-groups create --scaffold
 
   # Create a static-computer-group from JSON
-  echo '{"name":"Example"}' | jamf-cli static-computer-groups create
+  echo '{"name":"Example"}' | jamf-cli pro static-computer-groups create
 
   # Get a static-computer-group, modify it, and create a copy
-  jamf-cli static-computer-groups get 1 -o json | jq '.name = "Copy"' | jamf-cli static-computer-groups create`,
+  jamf-cli pro static-computer-groups get 1 -o json | jq '.name = "Copy"' | jamf-cli pro static-computer-groups create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -315,13 +315,13 @@ func newStaticComputerGroupsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update membership of a static computer group.",
 		Long:  "Update membership of a static computer group.",
 		Example: `  # Update a static-computer-group from JSON
-  echo '{"name":"Updated"}' | jamf-cli static-computer-groups update 1
+  echo '{"name":"Updated"}' | jamf-cli pro static-computer-groups update 1
 
   # Update by name
-  jamf-cli static-computer-groups get --name "Example" -o json | jq '.field = "value"' | jamf-cli static-computer-groups update --name "Example"
+  jamf-cli pro static-computer-groups get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro static-computer-groups update --name "Example"
 
   # Get a static-computer-group, modify, and update
-  jamf-cli static-computer-groups get 1 -o json | jq '.name = "New Name"' | jamf-cli static-computer-groups update 1`,
+  jamf-cli pro static-computer-groups get 1 -o json | jq '.name = "New Name"' | jamf-cli pro static-computer-groups update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -405,13 +405,13 @@ func newStaticComputerGroupsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Remove Static Computer Group by Id",
 		Long:  "Remove Static Computer Group by Id",
 		Example: `  # Delete a static-computer-group (with confirmation)
-  jamf-cli static-computer-groups delete 1
+  jamf-cli pro static-computer-groups delete 1
 
   # Delete by name
-  jamf-cli static-computer-groups delete --name "Example" --yes
+  jamf-cli pro static-computer-groups delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli static-computer-groups delete 1 --yes`,
+  jamf-cli pro static-computer-groups delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -523,19 +523,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a static-computer-group from a JSON file
-  jamf-cli static-computer-groups apply --from-file static-computer-group.json
+  jamf-cli pro static-computer-groups apply --from-file static-computer-group.json
 
   # Apply a static-computer-group from a YAML file
-  jamf-cli static-computer-groups apply --from-file static-computer-group.yaml
+  jamf-cli pro static-computer-groups apply --from-file static-computer-group.yaml
 
   # Apply from stdin
-  cat static-computer-group.json | jamf-cli static-computer-groups apply
+  cat static-computer-group.json | jamf-cli pro static-computer-groups apply
 
   # Apply without replacement confirmation
-  jamf-cli static-computer-groups apply --from-file static-computer-group.json --yes
+  jamf-cli pro static-computer-groups apply --from-file static-computer-group.json --yes
 
   # Preview what would happen
-  jamf-cli static-computer-groups apply --from-file static-computer-group.json --dry-run`,
+  jamf-cli pro static-computer-groups apply --from-file static-computer-group.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/static_user_groups.go
+++ b/internal/commands/pro/generated/static_user_groups.go
@@ -34,10 +34,10 @@ func newStaticUserGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Return a list of all Static User Groups",
 		Long:  "Returns a list of all static user groups.",
 		Example: `  # List all static-user-groups
-  jamf-cli static-user-groups list
+  jamf-cli pro static-user-groups list
 
   # List static-user-groups and extract IDs
-  jamf-cli static-user-groups list --field id`,
+  jamf-cli pro static-user-groups list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -74,13 +74,13 @@ func newStaticUserGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Return a specific Static User Group by id",
 		Long:  "Returns a specific static user group by id.",
 		Example: `  # Get a static-user-group by ID
-  jamf-cli static-user-groups get 1
+  jamf-cli pro static-user-groups get 1
 
   # Get a static-user-group by name
-  jamf-cli static-user-groups get --name "Example"
+  jamf-cli pro static-user-groups get --name "Example"
 
   # Get a static-user-group and output as YAML
-  jamf-cli static-user-groups get 1 -o yaml`,
+  jamf-cli pro static-user-groups get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/supervision_identities.go
+++ b/internal/commands/pro/generated/supervision_identities.go
@@ -54,10 +54,10 @@ func newSupervisionIdentitiesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Search for sorted and paged Supervision Identities",
 		Long:  "Search for sorted and paged supervision identities",
 		Example: `  # List all supervision-identities
-  jamf-cli supervision-identities list
+  jamf-cli pro supervision-identities list
 
   # List supervision-identities and extract IDs
-  jamf-cli supervision-identities list --field id`,
+  jamf-cli pro supervision-identities list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -182,13 +182,13 @@ func newSupervisionIdentitiesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve a Supervision Identity with the supplied id",
 		Long:  "Retrieves a Supervision Identity with the supplied id",
 		Example: `  # Get a supervision-identity by ID
-  jamf-cli supervision-identities get 1
+  jamf-cli pro supervision-identities get 1
 
   # Get a supervision-identity by name
-  jamf-cli supervision-identities get --name "Example"
+  jamf-cli pro supervision-identities get --name "Example"
 
   # Get a supervision-identity and output as YAML
-  jamf-cli supervision-identities get 1 -o yaml`,
+  jamf-cli pro supervision-identities get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -243,13 +243,13 @@ func newSupervisionIdentitiesCreateCmd(ctx *registry.CLIContext) *cobra.Command 
 		Short: "Create a Supervision Identity for the supplied information",
 		Long:  "Creates a Supervision Identity for the supplied information",
 		Example: `  # Show the JSON template for creating a supervision-identity
-  jamf-cli supervision-identities create --scaffold
+  jamf-cli pro supervision-identities create --scaffold
 
   # Create a supervision-identity from JSON
-  echo '{"name":"Example"}' | jamf-cli supervision-identities create
+  echo '{"name":"Example"}' | jamf-cli pro supervision-identities create
 
   # Get a supervision-identity, modify it, and create a copy
-  jamf-cli supervision-identities get 1 -o json | jq '.name = "Copy"' | jamf-cli supervision-identities create`,
+  jamf-cli pro supervision-identities get 1 -o json | jq '.name = "Copy"' | jamf-cli pro supervision-identities create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -313,13 +313,13 @@ func newSupervisionIdentitiesUpdateCmd(ctx *registry.CLIContext) *cobra.Command 
 		Short: "Update a Supervision Identity with the supplied information",
 		Long:  "Updates a Supervision Identity with the supplied information",
 		Example: `  # Update a supervision-identity from JSON
-  echo '{"name":"Updated"}' | jamf-cli supervision-identities update 1
+  echo '{"name":"Updated"}' | jamf-cli pro supervision-identities update 1
 
   # Update by name
-  jamf-cli supervision-identities get --name "Example" -o json | jq '.field = "value"' | jamf-cli supervision-identities update --name "Example"
+  jamf-cli pro supervision-identities get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro supervision-identities update --name "Example"
 
   # Get a supervision-identity, modify, and update
-  jamf-cli supervision-identities get 1 -o json | jq '.name = "New Name"' | jamf-cli supervision-identities update 1`,
+  jamf-cli pro supervision-identities get 1 -o json | jq '.name = "New Name"' | jamf-cli pro supervision-identities update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -400,13 +400,13 @@ func newSupervisionIdentitiesDeleteCmd(ctx *registry.CLIContext) *cobra.Command 
 		Short: "Delete a Supervision Identity with the supplied id",
 		Long:  "Deletes a Supervision Identity with the supplied id",
 		Example: `  # Delete a supervision-identity (with confirmation)
-  jamf-cli supervision-identities delete 1
+  jamf-cli pro supervision-identities delete 1
 
   # Delete by name
-  jamf-cli supervision-identities delete --name "Example" --yes
+  jamf-cli pro supervision-identities delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli supervision-identities delete 1 --yes`,
+  jamf-cli pro supervision-identities delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -655,19 +655,19 @@ The displayName field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a supervision-identity from a JSON file
-  jamf-cli supervision-identities apply --from-file supervision-identity.json
+  jamf-cli pro supervision-identities apply --from-file supervision-identity.json
 
   # Apply a supervision-identity from a YAML file
-  jamf-cli supervision-identities apply --from-file supervision-identity.yaml
+  jamf-cli pro supervision-identities apply --from-file supervision-identity.yaml
 
   # Apply from stdin
-  cat supervision-identity.json | jamf-cli supervision-identities apply
+  cat supervision-identity.json | jamf-cli pro supervision-identities apply
 
   # Apply without replacement confirmation
-  jamf-cli supervision-identities apply --from-file supervision-identity.json --yes
+  jamf-cli pro supervision-identities apply --from-file supervision-identity.json --yes
 
   # Preview what would happen
-  jamf-cli supervision-identities apply --from-file supervision-identity.json --dry-run`,
+  jamf-cli pro supervision-identities apply --from-file supervision-identity.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/teacher_settings.go
+++ b/internal/commands/pro/generated/teacher_settings.go
@@ -40,10 +40,10 @@ func newTeacherSettingsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get the Jamf Teacher settings that you have access to see",
 		Long:  "Get the Jamf Teacher settings that you have access to see.",
 		Example: `  # Get teacher-settings
-  jamf-cli teacher-settings get
+  jamf-cli pro teacher-settings get
 
   # Get teacher-settings and output as YAML
-  jamf-cli teacher-settings get -o yaml`,
+  jamf-cli pro teacher-settings get -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -80,10 +80,10 @@ func newTeacherSettingsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a Jamf Teacher settings object",
 		Long:  "Update a Jamf Teacher settings object.",
 		Example: `  # Update teacher-settings
-  jamf-cli teacher-settings get -o json | jq '.field = "value"' | jamf-cli teacher-settings update
+  jamf-cli pro teacher-settings get -o json | jq '.field = "value"' | jamf-cli pro teacher-settings update
 
   # Update from a file
-  jamf-cli teacher-settings update --from-file teacher-settings.json`,
+  jamf-cli pro teacher-settings update --from-file teacher-settings.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -154,7 +154,7 @@ func newTeacherSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get Jamf Teacher app settings history",
 		Long:  "Gets Jamf Teacher app settings history",
 		Example: `  # Get history for a teacher-settings
-  jamf-cli teacher-settings history 1`,
+  jamf-cli pro teacher-settings history 1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/team_viewer_remote_administrations.go
+++ b/internal/commands/pro/generated/team_viewer_remote_administrations.go
@@ -49,13 +49,13 @@ func newTeamViewerRemoteAdministrationsGetCmd(ctx *registry.CLIContext) *cobra.C
 		Short: "Get Team Viewer Remote Administration connection configuration",
 		Long:  "Returns Team Viewer Remote Administration connection configuration",
 		Example: `  # Get a team-viewer-remote-administration by ID
-  jamf-cli team-viewer-remote-administrations get 1
+  jamf-cli pro team-viewer-remote-administrations get 1
 
   # Get a team-viewer-remote-administration by name
-  jamf-cli team-viewer-remote-administrations get --name "Example"
+  jamf-cli pro team-viewer-remote-administrations get --name "Example"
 
   # Get a team-viewer-remote-administration and output as YAML
-  jamf-cli team-viewer-remote-administrations get 1 -o yaml`,
+  jamf-cli pro team-viewer-remote-administrations get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -110,13 +110,13 @@ func newTeamViewerRemoteAdministrationsCreateCmd(ctx *registry.CLIContext) *cobr
 		Short: "Create Team Viewer Remote Administration connection configuration",
 		Long:  "Creates Team Viewer Remote Administration connection configuration",
 		Example: `  # Show the JSON template for creating a team-viewer-remote-administration
-  jamf-cli team-viewer-remote-administrations create --scaffold
+  jamf-cli pro team-viewer-remote-administrations create --scaffold
 
   # Create a team-viewer-remote-administration from JSON
-  echo '{"name":"Example"}' | jamf-cli team-viewer-remote-administrations create
+  echo '{"name":"Example"}' | jamf-cli pro team-viewer-remote-administrations create
 
   # Get a team-viewer-remote-administration, modify it, and create a copy
-  jamf-cli team-viewer-remote-administrations get 1 -o json | jq '.name = "Copy"' | jamf-cli team-viewer-remote-administrations create`,
+  jamf-cli pro team-viewer-remote-administrations get 1 -o json | jq '.name = "Copy"' | jamf-cli pro team-viewer-remote-administrations create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -184,13 +184,13 @@ func newTeamViewerRemoteAdministrationsDeleteCmd(ctx *registry.CLIContext) *cobr
 		Short: "Delete Team Viewer Remote Administration connection configuration",
 		Long:  "Deletes Team Viewer Remote Administration connection configuration",
 		Example: `  # Delete a team-viewer-remote-administration (with confirmation)
-  jamf-cli team-viewer-remote-administrations delete 1
+  jamf-cli pro team-viewer-remote-administrations delete 1
 
   # Delete by name
-  jamf-cli team-viewer-remote-administrations delete --name "Example" --yes
+  jamf-cli pro team-viewer-remote-administrations delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli team-viewer-remote-administrations delete 1 --yes`,
+  jamf-cli pro team-viewer-remote-administrations delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -559,16 +559,16 @@ func newTeamViewerRemoteAdministrationsPatchCmd(ctx *registry.CLIContext) *cobra
 		Short: "Update Team Viewer Remote Administration connection configuration",
 		Long:  "Updates Team Viewer Remote Administration connection configuration\n\nIdentify the resource by ID (positional arg), --name, . Omit ID to use a lookup flag.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  displayName                                  string\n  enabled                                      boolean\n  sessionTimeout                               integer\n  token                                        string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field by ID
-  jamf-cli team-viewer-remote-administrations patch 1 --set general.managed=true
+  jamf-cli pro team-viewer-remote-administrations patch 1 --set general.managed=true
 
   # Update multiple fields
-  jamf-cli team-viewer-remote-administrations patch 1 --set field1=value1 --set field2=value2
+  jamf-cli pro team-viewer-remote-administrations patch 1 --set field1=value1 --set field2=value2
 
   # Update by name
-  jamf-cli team-viewer-remote-administrations patch --name "Example" --set general.managed=true
+  jamf-cli pro team-viewer-remote-administrations patch --name "Example" --set general.managed=true
 
   # Patch from a file
-  jamf-cli team-viewer-remote-administrations patch 1 --from-file changes.json`,
+  jamf-cli pro team-viewer-remote-administrations patch 1 --from-file changes.json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -731,19 +731,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a team-viewer-remote-administration from a JSON file
-  jamf-cli team-viewer-remote-administrations apply --from-file team-viewer-remote-administration.json
+  jamf-cli pro team-viewer-remote-administrations apply --from-file team-viewer-remote-administration.json
 
   # Apply a team-viewer-remote-administration from a YAML file
-  jamf-cli team-viewer-remote-administrations apply --from-file team-viewer-remote-administration.yaml
+  jamf-cli pro team-viewer-remote-administrations apply --from-file team-viewer-remote-administration.yaml
 
   # Apply from stdin
-  cat team-viewer-remote-administration.json | jamf-cli team-viewer-remote-administrations apply
+  cat team-viewer-remote-administration.json | jamf-cli pro team-viewer-remote-administrations apply
 
   # Apply without replacement confirmation
-  jamf-cli team-viewer-remote-administrations apply --from-file team-viewer-remote-administration.json --yes
+  jamf-cli pro team-viewer-remote-administrations apply --from-file team-viewer-remote-administration.json --yes
 
   # Preview what would happen
-  jamf-cli team-viewer-remote-administrations apply --from-file team-viewer-remote-administration.json --dry-run`,
+  jamf-cli pro team-viewer-remote-administrations apply --from-file team-viewer-remote-administration.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/time_zones.go
+++ b/internal/commands/pro/generated/time_zones.go
@@ -31,10 +31,10 @@ func newTimeZonesListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Return information about the currently supported Time Zones",
 		Long:  "Returns information about the currently supported time zones",
 		Example: `  # List all time-zones
-  jamf-cli time-zones list
+  jamf-cli pro time-zones list
 
   # List time-zones and extract IDs
-  jamf-cli time-zones list --field id`,
+  jamf-cli pro time-zones list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/user_accounts.go
+++ b/internal/commands/pro/generated/user_accounts.go
@@ -49,10 +49,10 @@ func newUserAccountsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get user accounts",
 		Long:  "Get all user accounts with pagination, sorting, and filtering support.",
 		Example: `  # List all user-accounts
-  jamf-cli user-accounts list
+  jamf-cli pro user-accounts list
 
   # List user-accounts and extract IDs
-  jamf-cli user-accounts list --field id`,
+  jamf-cli pro user-accounts list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -175,13 +175,13 @@ func newUserAccountsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Gets the user account.",
 		Long:  "Gets the user account for the given id.",
 		Example: `  # Get a user-account by ID
-  jamf-cli user-accounts get 1
+  jamf-cli pro user-accounts get 1
 
   # Get a user-account by name
-  jamf-cli user-accounts get --name "Example"
+  jamf-cli pro user-accounts get --name "Example"
 
   # Get a user-account and output as YAML
-  jamf-cli user-accounts get 1 -o yaml`,
+  jamf-cli pro user-accounts get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -236,13 +236,13 @@ func newUserAccountsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Adds new account.",
 		Long:  "Adds the user account provided.",
 		Example: `  # Show the JSON template for creating a user-account
-  jamf-cli user-accounts create --scaffold
+  jamf-cli pro user-accounts create --scaffold
 
   # Create a user-account from JSON
-  echo '{"name":"Example"}' | jamf-cli user-accounts create
+  echo '{"name":"Example"}' | jamf-cli pro user-accounts create
 
   # Get a user-account, modify it, and create a copy
-  jamf-cli user-accounts get 1 -o json | jq '.name = "Copy"' | jamf-cli user-accounts create`,
+  jamf-cli pro user-accounts get 1 -o json | jq '.name = "Copy"' | jamf-cli pro user-accounts create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -318,13 +318,13 @@ func newUserAccountsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Deletes the user account.",
 		Long:  "Deletes the user account for the given id.",
 		Example: `  # Delete a user-account (with confirmation)
-  jamf-cli user-accounts delete 1
+  jamf-cli pro user-accounts delete 1
 
   # Delete by name
-  jamf-cli user-accounts delete --name "Example" --yes
+  jamf-cli pro user-accounts delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli user-accounts delete 1 --yes`,
+  jamf-cli pro user-accounts delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/user_preferences.go
+++ b/internal/commands/pro/generated/user_preferences.go
@@ -42,13 +42,13 @@ func newUserPreferencesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get the user preferences for the authenticated user and key.",
 		Long:  "Gets the user preferences for the authenticated user and key.",
 		Example: `  # Get a user-preference by ID
-  jamf-cli user-preferences get 1
+  jamf-cli pro user-preferences get 1
 
   # Get a user-preference by name
-  jamf-cli user-preferences get --name "Example"
+  jamf-cli pro user-preferences get --name "Example"
 
   # Get a user-preference and output as YAML
-  jamf-cli user-preferences get 1 -o yaml`,
+  jamf-cli pro user-preferences get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -103,13 +103,13 @@ func newUserPreferencesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Persist the user setting",
 		Long:  "Persists the user setting",
 		Example: `  # Update a user-preference from JSON
-  echo '{"name":"Updated"}' | jamf-cli user-preferences update 1
+  echo '{"name":"Updated"}' | jamf-cli pro user-preferences update 1
 
   # Update by name
-  jamf-cli user-preferences get --name "Example" -o json | jq '.field = "value"' | jamf-cli user-preferences update --name "Example"
+  jamf-cli pro user-preferences get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro user-preferences update --name "Example"
 
   # Get a user-preference, modify, and update
-  jamf-cli user-preferences get 1 -o json | jq '.name = "New Name"' | jamf-cli user-preferences update 1`,
+  jamf-cli pro user-preferences get 1 -o json | jq '.name = "New Name"' | jamf-cli pro user-preferences update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -183,13 +183,13 @@ func newUserPreferencesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Remove specified setting for authenticated user",
 		Long:  "Remove specified setting for authenticated user",
 		Example: `  # Delete a user-preference (with confirmation)
-  jamf-cli user-preferences delete 1
+  jamf-cli pro user-preferences delete 1
 
   # Delete by name
-  jamf-cli user-preferences delete --name "Example" --yes
+  jamf-cli pro user-preferences delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli user-preferences delete 1 --yes`,
+  jamf-cli pro user-preferences delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()

--- a/internal/commands/pro/generated/user_sessions.go
+++ b/internal/commands/pro/generated/user_sessions.go
@@ -36,10 +36,10 @@ func newUserSessionsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Return all Jamf Pro user acounts",
 		Long:  "Return all Jamf Pro user acounts.",
 		Example: `  # List all user-sessions
-  jamf-cli user-sessions list
+  jamf-cli pro user-sessions list
 
   # List user-sessions and extract IDs
-  jamf-cli user-sessions list --field id`,
+  jamf-cli pro user-sessions list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -76,13 +76,13 @@ func newUserSessionsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update values in the User's current session",
 		Long:  "Updates values in the user's current session.",
 		Example: `  # Show the JSON template for creating a user-session
-  jamf-cli user-sessions create --scaffold
+  jamf-cli pro user-sessions create --scaffold
 
   # Create a user-session from JSON
-  echo '{"name":"Example"}' | jamf-cli user-sessions create
+  echo '{"name":"Example"}' | jamf-cli pro user-sessions create
 
   # Get a user-session, modify it, and create a copy
-  jamf-cli user-sessions get 1 -o json | jq '.name = "Copy"' | jamf-cli user-sessions create`,
+  jamf-cli pro user-sessions get 1 -o json | jq '.name = "Copy"' | jamf-cli pro user-sessions create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/users.go
+++ b/internal/commands/pro/generated/users.go
@@ -51,10 +51,10 @@ func newUsersListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Search for Users",
 		Long:  "Retrieves a paginated list of users with optional filtering and sorting.",
 		Example: `  # List all users
-  jamf-cli users list
+  jamf-cli pro users list
 
   # List users and extract IDs
-  jamf-cli users list --field id`,
+  jamf-cli pro users list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -177,13 +177,13 @@ func newUsersGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified User object",
 		Long:  "Gets the specified User object.",
 		Example: `  # Get a user by ID
-  jamf-cli users get 1
+  jamf-cli pro users get 1
 
   # Get a user by name
-  jamf-cli users get --name "Example"
+  jamf-cli pro users get --name "Example"
 
   # Get a user and output as YAML
-  jamf-cli users get 1 -o yaml`,
+  jamf-cli pro users get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -238,13 +238,13 @@ func newUsersCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create User record",
 		Long:  "Creates a new user in inventory.",
 		Example: `  # Show the JSON template for creating a user
-  jamf-cli users create --scaffold
+  jamf-cli pro users create --scaffold
 
   # Create a user from JSON
-  echo '{"name":"Example"}' | jamf-cli users create
+  echo '{"name":"Example"}' | jamf-cli pro users create
 
   # Get a user, modify it, and create a copy
-  jamf-cli users get 1 -o json | jq '.name = "Copy"' | jamf-cli users create`,
+  jamf-cli pro users get 1 -o json | jq '.name = "Copy"' | jamf-cli pro users create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -314,13 +314,13 @@ func newUsersUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update specified User object",
 		Long:  "Updates the specified User object.",
 		Example: `  # Update a user from JSON
-  echo '{"name":"Updated"}' | jamf-cli users update 1
+  echo '{"name":"Updated"}' | jamf-cli pro users update 1
 
   # Update by name
-  jamf-cli users get --name "Example" -o json | jq '.field = "value"' | jamf-cli users update --name "Example"
+  jamf-cli pro users get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro users update --name "Example"
 
   # Get a user, modify, and update
-  jamf-cli users get 1 -o json | jq '.name = "New Name"' | jamf-cli users update 1`,
+  jamf-cli pro users get 1 -o json | jq '.name = "New Name"' | jamf-cli pro users update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -408,13 +408,13 @@ func newUsersDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete specified User object",
 		Long:  "Deletes the specified User object.",
 		Example: `  # Delete a user (with confirmation)
-  jamf-cli users delete 1
+  jamf-cli pro users delete 1
 
   # Delete by name
-  jamf-cli users delete --name "Example" --yes
+  jamf-cli pro users delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli users delete 1 --yes`,
+  jamf-cli pro users delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -526,19 +526,19 @@ The username field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a user from a JSON file
-  jamf-cli users apply --from-file user.json
+  jamf-cli pro users apply --from-file user.json
 
   # Apply a user from a YAML file
-  jamf-cli users apply --from-file user.yaml
+  jamf-cli pro users apply --from-file user.yaml
 
   # Apply from stdin
-  cat user.json | jamf-cli users apply
+  cat user.json | jamf-cli pro users apply
 
   # Apply without replacement confirmation
-  jamf-cli users apply --from-file user.json --yes
+  jamf-cli pro users apply --from-file user.json --yes
 
   # Preview what would happen
-  jamf-cli users apply --from-file user.json --dry-run`,
+  jamf-cli pro users apply --from-file user.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/venafis.go
+++ b/internal/commands/pro/generated/venafis.go
@@ -51,13 +51,13 @@ func newVenafisGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve a Venafi PKI configuration from Jamf Pro",
 		Long:  "Retrieve a Venafi PKI configuration from Jamf Pro",
 		Example: `  # Get a venafi by ID
-  jamf-cli venafis get 1
+  jamf-cli pro venafis get 1
 
   # Get a venafi by name
-  jamf-cli venafis get --name "Example"
+  jamf-cli pro venafis get --name "Example"
 
   # Get a venafi and output as YAML
-  jamf-cli venafis get 1 -o yaml`,
+  jamf-cli pro venafis get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -112,13 +112,13 @@ func newVenafisCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a PKI configuration in Jamf Pro for Venafi",
 		Long:  "Creates a Venafi PKI configuration in Jamf Pro, which can be used to issue certificates",
 		Example: `  # Show the JSON template for creating a venafi
-  jamf-cli venafis create --scaffold
+  jamf-cli pro venafis create --scaffold
 
   # Create a venafi from JSON
-  echo '{"name":"Example"}' | jamf-cli venafis create
+  echo '{"name":"Example"}' | jamf-cli pro venafis create
 
   # Get a venafi, modify it, and create a copy
-  jamf-cli venafis get 1 -o json | jq '.name = "Copy"' | jamf-cli venafis create`,
+  jamf-cli pro venafis get 1 -o json | jq '.name = "Copy"' | jamf-cli pro venafis create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -186,13 +186,13 @@ func newVenafisDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete a Venafi PKI configuration from Jamf Pro",
 		Long:  "Delete a Venafi PKI configuration from Jamf Pro",
 		Example: `  # Delete a venafi (with confirmation)
-  jamf-cli venafis delete 1
+  jamf-cli pro venafis delete 1
 
   # Delete by name
-  jamf-cli venafis delete --name "Example" --yes
+  jamf-cli pro venafis delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli venafis delete 1 --yes`,
+  jamf-cli pro venafis delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -303,10 +303,10 @@ func newVenafisHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Venafi CA history object",
 		Long:  "Get specified Venafi CA history object",
 		Example: `  # Get history for a venafi by ID
-  jamf-cli venafis history 1
+  jamf-cli pro venafis history 1
 
   # Get history by name
-  jamf-cli venafis history --name "Example"`,
+  jamf-cli pro venafis history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -528,16 +528,16 @@ func newVenafisPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a Venafi PKI configuration in Jamf Pro",
 		Long:  "Update a Venafi PKI configuration in Jamf Pro\n\nIdentify the resource by ID (positional arg), --name, . Omit ID to use a lookup flag.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  clientId                                     string\n  name                                         string\n  proxyAddress                                 string\n  refreshToken                                 string\n  revocationEnabled                            boolean\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field by ID
-  jamf-cli venafis patch 1 --set general.managed=true
+  jamf-cli pro venafis patch 1 --set general.managed=true
 
   # Update multiple fields
-  jamf-cli venafis patch 1 --set field1=value1 --set field2=value2
+  jamf-cli pro venafis patch 1 --set field1=value1 --set field2=value2
 
   # Update by name
-  jamf-cli venafis patch --name "Example" --set general.managed=true
+  jamf-cli pro venafis patch --name "Example" --set general.managed=true
 
   # Patch from a file
-  jamf-cli venafis patch 1 --from-file changes.json`,
+  jamf-cli pro venafis patch 1 --from-file changes.json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -899,19 +899,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a venafi from a JSON file
-  jamf-cli venafis apply --from-file venafi.json
+  jamf-cli pro venafis apply --from-file venafi.json
 
   # Apply a venafi from a YAML file
-  jamf-cli venafis apply --from-file venafi.yaml
+  jamf-cli pro venafis apply --from-file venafi.yaml
 
   # Apply from stdin
-  cat venafi.json | jamf-cli venafis apply
+  cat venafi.json | jamf-cli pro venafis apply
 
   # Apply without replacement confirmation
-  jamf-cli venafis apply --from-file venafi.json --yes
+  jamf-cli pro venafis apply --from-file venafi.json --yes
 
   # Preview what would happen
-  jamf-cli venafis apply --from-file venafi.json --dry-run`,
+  jamf-cli pro venafis apply --from-file venafi.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/vpp_locations.go
+++ b/internal/commands/pro/generated/vpp_locations.go
@@ -56,10 +56,10 @@ func newVppLocationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve Volume Purchasing Locations",
 		Long:  "Retrieves Volume Purchasing Locations",
 		Example: `  # List all vpp-locations
-  jamf-cli vpp-locations list
+  jamf-cli pro vpp-locations list
 
   # List vpp-locations and extract IDs
-  jamf-cli vpp-locations list --field id`,
+  jamf-cli pro vpp-locations list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -182,13 +182,13 @@ func newVppLocationsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve a Volume Purchasing Location with the supplied id",
 		Long:  "Retrieves a Volume Purchasing Location with the supplied id",
 		Example: `  # Get a vpp-location by ID
-  jamf-cli vpp-locations get 1
+  jamf-cli pro vpp-locations get 1
 
   # Get a vpp-location by name
-  jamf-cli vpp-locations get --name "Example"
+  jamf-cli pro vpp-locations get --name "Example"
 
   # Get a vpp-location and output as YAML
-  jamf-cli vpp-locations get 1 -o yaml`,
+  jamf-cli pro vpp-locations get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -246,13 +246,13 @@ func newVppLocationsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a Volume Purchasing Location",
 		Long:  "Creates a Volume Purchasing Location using an sToken",
 		Example: `  # Show the JSON template for creating a vpp-location
-  jamf-cli vpp-locations create --scaffold
+  jamf-cli pro vpp-locations create --scaffold
 
   # Create a vpp-location from JSON
-  echo '{"name":"Example"}' | jamf-cli vpp-locations create
+  echo '{"name":"Example"}' | jamf-cli pro vpp-locations create
 
   # Get a vpp-location, modify it, and create a copy
-  jamf-cli vpp-locations get 1 -o json | jq '.name = "Copy"' | jamf-cli vpp-locations create`,
+  jamf-cli pro vpp-locations get 1 -o json | jq '.name = "Copy"' | jamf-cli pro vpp-locations create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -338,13 +338,13 @@ func newVppLocationsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete a Volume Purchasing Location with the supplied id",
 		Long:  "Deletes a Volume Purchasing Location with the supplied id",
 		Example: `  # Delete a vpp-location (with confirmation)
-  jamf-cli vpp-locations delete 1
+  jamf-cli pro vpp-locations delete 1
 
   # Delete by name
-  jamf-cli vpp-locations delete --name "Example" --yes
+  jamf-cli pro vpp-locations delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli vpp-locations delete 1 --yes`,
+  jamf-cli pro vpp-locations delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -455,10 +455,10 @@ func newVppLocationsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Volume Purchasing Location history object",
 		Long:  "Gets specified Volume Purchasing Location history object",
 		Example: `  # Get history for a vpp-location by ID
-  jamf-cli vpp-locations history 1
+  jamf-cli pro vpp-locations history 1
 
   # Get history by name
-  jamf-cli vpp-locations history --name "Example"`,
+  jamf-cli pro vpp-locations history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -682,16 +682,16 @@ func newVppLocationsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a Volume Purchasing Location",
 		Long:  "Updates a Volume Purchasing Location\n\nIdentify the resource by ID (positional arg), --name, . Omit ID to use a lookup flag.\n\nUse --set KEY=VALUE to update scalar fields (repeatable). Omitted fields are unchanged.\n\nAvailable fields:\n  autoRegisterManagedUsers                     boolean\n  automaticallyPopulatePurchasedContent        boolean\n  name                                         string\n  sendNotificationWhenNoLongerAssigned         boolean\n  serviceToken                                 string\n  siteId                                       string\n\nUse --from-file or pipe JSON to stdin for complex updates (arrays, bulk changes).",
 		Example: `  # Update a field by ID
-  jamf-cli vpp-locations patch 1 --set general.managed=true
+  jamf-cli pro vpp-locations patch 1 --set general.managed=true
 
   # Update multiple fields
-  jamf-cli vpp-locations patch 1 --set field1=value1 --set field2=value2
+  jamf-cli pro vpp-locations patch 1 --set field1=value1 --set field2=value2
 
   # Update by name
-  jamf-cli vpp-locations patch --name "Example" --set general.managed=true
+  jamf-cli pro vpp-locations patch --name "Example" --set general.managed=true
 
   # Patch from a file
-  jamf-cli vpp-locations patch 1 --from-file changes.json`,
+  jamf-cli pro vpp-locations patch 1 --from-file changes.json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -1034,19 +1034,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a vpp-location from a JSON file
-  jamf-cli vpp-locations apply --from-file vpp-location.json
+  jamf-cli pro vpp-locations apply --from-file vpp-location.json
 
   # Apply a vpp-location from a YAML file
-  jamf-cli vpp-locations apply --from-file vpp-location.yaml
+  jamf-cli pro vpp-locations apply --from-file vpp-location.yaml
 
   # Apply from stdin
-  cat vpp-location.json | jamf-cli vpp-locations apply
+  cat vpp-location.json | jamf-cli pro vpp-locations apply
 
   # Apply without replacement confirmation
-  jamf-cli vpp-locations apply --from-file vpp-location.json --yes
+  jamf-cli pro vpp-locations apply --from-file vpp-location.json --yes
 
   # Preview what would happen
-  jamf-cli vpp-locations apply --from-file vpp-location.json --dry-run`,
+  jamf-cli pro vpp-locations apply --from-file vpp-location.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {

--- a/internal/commands/pro/generated/vpp_subscriptions.go
+++ b/internal/commands/pro/generated/vpp_subscriptions.go
@@ -52,10 +52,10 @@ func newVppSubscriptionsListCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve Volume Purchasing Subscriptions",
 		Long:  "Retrieves Volume Purchasing Subscriptions",
 		Example: `  # List all vpp-subscriptions
-  jamf-cli vpp-subscriptions list
+  jamf-cli pro vpp-subscriptions list
 
   # List vpp-subscriptions and extract IDs
-  jamf-cli vpp-subscriptions list --field id`,
+  jamf-cli pro vpp-subscriptions list --field id`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -174,13 +174,13 @@ func newVppSubscriptionsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Retrieve a Volume Purchasing Subscription with the supplied id",
 		Long:  "Retrieves a Volume Purchasing Subscription with the supplied id",
 		Example: `  # Get a vpp-subscription by ID
-  jamf-cli vpp-subscriptions get 1
+  jamf-cli pro vpp-subscriptions get 1
 
   # Get a vpp-subscription by name
-  jamf-cli vpp-subscriptions get --name "Example"
+  jamf-cli pro vpp-subscriptions get --name "Example"
 
   # Get a vpp-subscription and output as YAML
-  jamf-cli vpp-subscriptions get 1 -o yaml`,
+  jamf-cli pro vpp-subscriptions get 1 -o yaml`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -235,13 +235,13 @@ func newVppSubscriptionsCreateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Create a Volume Purchasing Subscription",
 		Long:  "Creates a Volume Purchasing Subscription",
 		Example: `  # Show the JSON template for creating a vpp-subscription
-  jamf-cli vpp-subscriptions create --scaffold
+  jamf-cli pro vpp-subscriptions create --scaffold
 
   # Create a vpp-subscription from JSON
-  echo '{"name":"Example"}' | jamf-cli vpp-subscriptions create
+  echo '{"name":"Example"}' | jamf-cli pro vpp-subscriptions create
 
   # Get a vpp-subscription, modify it, and create a copy
-  jamf-cli vpp-subscriptions get 1 -o json | jq '.name = "Copy"' | jamf-cli vpp-subscriptions create`,
+  jamf-cli pro vpp-subscriptions get 1 -o json | jq '.name = "Copy"' | jamf-cli pro vpp-subscriptions create`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -310,13 +310,13 @@ func newVppSubscriptionsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Update a Volume Purchasing Subscription",
 		Long:  "Updates a Volume Purchasing Subscription",
 		Example: `  # Update a vpp-subscription from JSON
-  echo '{"name":"Updated"}' | jamf-cli vpp-subscriptions update 1
+  echo '{"name":"Updated"}' | jamf-cli pro vpp-subscriptions update 1
 
   # Update by name
-  jamf-cli vpp-subscriptions get --name "Example" -o json | jq '.field = "value"' | jamf-cli vpp-subscriptions update --name "Example"
+  jamf-cli pro vpp-subscriptions get --name "Example" -o json | jq '.field = "value"' | jamf-cli pro vpp-subscriptions update --name "Example"
 
   # Get a vpp-subscription, modify, and update
-  jamf-cli vpp-subscriptions get 1 -o json | jq '.name = "New Name"' | jamf-cli vpp-subscriptions update 1`,
+  jamf-cli pro vpp-subscriptions get 1 -o json | jq '.name = "New Name"' | jamf-cli pro vpp-subscriptions update 1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -403,13 +403,13 @@ func newVppSubscriptionsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Delete a Volume Purchasing Subscription with the supplied id",
 		Long:  "Deletes a Volume Purchasing Subscription with the supplied id",
 		Example: `  # Delete a vpp-subscription (with confirmation)
-  jamf-cli vpp-subscriptions delete 1
+  jamf-cli pro vpp-subscriptions delete 1
 
   # Delete by name
-  jamf-cli vpp-subscriptions delete --name "Example" --yes
+  jamf-cli pro vpp-subscriptions delete --name "Example" --yes
 
   # Delete without confirmation prompt
-  jamf-cli vpp-subscriptions delete 1 --yes`,
+  jamf-cli pro vpp-subscriptions delete 1 --yes`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -520,10 +520,10 @@ func newVppSubscriptionsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 		Short: "Get specified Volume Purchasing Subscription history object",
 		Long:  "Gets specified Volume Purchasing Subscription history object",
 		Example: `  # Get history for a vpp-subscription by ID
-  jamf-cli vpp-subscriptions history 1
+  jamf-cli pro vpp-subscriptions history 1
 
   # Get history by name
-  jamf-cli vpp-subscriptions history --name "Example"`,
+  jamf-cli pro vpp-subscriptions history --name "Example"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
@@ -749,19 +749,19 @@ The name field in the input is used to check if the resource
 already exists. If it does, the resource is replaced (with confirmation).
 If not, a new resource is created.`,
 		Example: `  # Apply a vpp-subscription from a JSON file
-  jamf-cli vpp-subscriptions apply --from-file vpp-subscription.json
+  jamf-cli pro vpp-subscriptions apply --from-file vpp-subscription.json
 
   # Apply a vpp-subscription from a YAML file
-  jamf-cli vpp-subscriptions apply --from-file vpp-subscription.yaml
+  jamf-cli pro vpp-subscriptions apply --from-file vpp-subscription.yaml
 
   # Apply from stdin
-  cat vpp-subscription.json | jamf-cli vpp-subscriptions apply
+  cat vpp-subscription.json | jamf-cli pro vpp-subscriptions apply
 
   # Apply without replacement confirmation
-  jamf-cli vpp-subscriptions apply --from-file vpp-subscription.json --yes
+  jamf-cli pro vpp-subscriptions apply --from-file vpp-subscription.json --yes
 
   # Preview what would happen
-  jamf-cli vpp-subscriptions apply --from-file vpp-subscription.json --dry-run`,
+  jamf-cli pro vpp-subscriptions apply --from-file vpp-subscription.json --dry-run`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reqCtx := cmd.Context()
 			if flagScaffold {


### PR DESCRIPTION
Update all command examples in the help output to include the 'pro' prefix, ensuring consistency across the CLI documentation.

Closes: #159