### PR TITLE
feat: add -vv (headers) and -vvv (bodies) verbose levels

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -380,7 +380,7 @@ func logHeaders(w io.Writer, h http.Header, redactAuth bool) {
 		if redactAuth && strings.EqualFold(k, "Authorization") {
 			v = "[redacted]"
 		}
-		fmt.Fprintf(w, "    %s: %s\n", k, v)
+		_, _ = fmt.Fprintf(w, "    %s: %s\n", k, v)
 	}
 }
 
@@ -391,9 +391,9 @@ func logBody(w io.Writer, data []byte) {
 		return
 	}
 	truncated := len(data) >= bodyLogLimit
-	fmt.Fprintf(w, "    %s\n", strings.ReplaceAll(strings.TrimRight(string(data), "\n"), "\n", "\n    "))
+	_, _ = fmt.Fprintf(w, "    %s\n", strings.ReplaceAll(strings.TrimRight(string(data), "\n"), "\n", "\n    "))
 	if truncated {
-		fmt.Fprintf(w, "    [body truncated at %d bytes]\n", bodyLogLimit)
+		_, _ = fmt.Fprintf(w, "    [body truncated at %d bytes]\n", bodyLogLimit)
 	}
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -21,20 +22,20 @@ import (
 
 // Client is the HTTP client for Jamf Pro API
 type Client struct {
-	baseURL    string
-	httpClient *http.Client
-	auth       auth.Provider
-	verbose    bool
-	tenantID   string // non-empty when using platform gateway auth
+	baseURL      string
+	httpClient   *http.Client
+	auth         auth.Provider
+	verboseLevel int    // 1 = request/response lines, 2 = +headers
+	tenantID     string // non-empty when using platform gateway auth
 }
 
 // Option configures the client
 type Option func(*Client)
 
-// WithVerbose enables verbose logging
-func WithVerbose(v bool) Option {
+// WithVerbose sets the verbosity level (1 = request/response lines, 2 = +headers).
+func WithVerbose(level int) Option {
 	return func(c *Client) {
-		c.verbose = v
+		c.verboseLevel = level
 	}
 }
 
@@ -130,8 +131,14 @@ func (c *Client) Do(ctx context.Context, method, path string, body io.Reader) (*
 		}
 	}
 
-	if c.verbose {
+	if c.verboseLevel >= 1 {
 		fmt.Fprintf(os.Stderr, "--> %s %s\n", method, req.URL)
+	}
+	if c.verboseLevel >= 2 {
+		logHeaders(os.Stderr, req.Header, true)
+	}
+	if c.verboseLevel >= 3 {
+		logBody(os.Stderr, bodyData)
 	}
 
 	resp, err := c.doWithRetry(ctx, req, bodyData)
@@ -139,14 +146,20 @@ func (c *Client) Do(ctx context.Context, method, path string, body io.Reader) (*
 		return nil, err
 	}
 
-	if c.verbose {
+	if c.verboseLevel >= 1 {
 		fmt.Fprintf(os.Stderr, "<-- %d %s\n", resp.StatusCode, resp.Status)
+	}
+	if c.verboseLevel >= 2 {
+		logHeaders(os.Stderr, resp.Header, false)
 	}
 
 	// Map HTTP error status codes to structured exit codes
 	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, bodyLogLimit))
 		_ = resp.Body.Close()
+		if c.verboseLevel >= 3 {
+			logBody(os.Stderr, body)
+		}
 		switch resp.StatusCode {
 		case http.StatusUnauthorized:
 			return nil, exitcode.New(exitcode.Authentication, fmt.Sprintf("authentication failed (HTTP 401): %s\nCheck your credentials with: jamf-cli config validate", string(body)))
@@ -159,6 +172,12 @@ func (c *Client) Do(ctx context.Context, method, path string, body io.Reader) (*
 		default:
 			return nil, exitcode.Wrap(exitcode.General, fmt.Errorf("request failed (HTTP %d): %s", resp.StatusCode, string(body)))
 		}
+	}
+
+	if c.verboseLevel >= 3 {
+		preview, _ := io.ReadAll(io.LimitReader(resp.Body, bodyLogLimit))
+		resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(preview), resp.Body))
+		logBody(os.Stderr, preview)
 	}
 
 	return resp, nil
@@ -209,12 +228,18 @@ func (c *Client) Upload(ctx context.Context, path string, body io.Reader, conten
 		req.Header.Set("Accept", "application/json")
 		req.ContentLength = contentLength
 
-		if c.verbose {
+		if c.verboseLevel >= 1 {
 			if maxAttempts > 1 {
 				fmt.Fprintf(os.Stderr, "--> POST %s (%d bytes, attempt %d/%d)\n", req.URL, contentLength, attempt+1, maxAttempts)
 			} else {
 				fmt.Fprintf(os.Stderr, "--> POST %s (%d bytes)\n", req.URL, contentLength)
 			}
+		}
+		if c.verboseLevel >= 2 {
+			logHeaders(os.Stderr, req.Header, true)
+		}
+		if c.verboseLevel >= 3 {
+			fmt.Fprintf(os.Stderr, "    [streaming body: %d bytes, %s]\n", contentLength, contentType)
 		}
 
 		resp, err := c.httpClient.Do(req)
@@ -226,7 +251,7 @@ func (c *Client) Upload(ctx context.Context, path string, body io.Reader, conten
 		if resp.StatusCode == http.StatusTooManyRequests && seeker != nil && attempt+1 < maxAttempts {
 			delay := parseRetryAfter(resp.Header.Get("Retry-After"), time.Second*time.Duration(1<<attempt))
 			_ = resp.Body.Close()
-			if c.verbose {
+			if c.verboseLevel >= 1 {
 				fmt.Fprintf(os.Stderr, "<-- 429 Too Many Requests, retrying in %v\n", delay)
 			}
 			if err := sleepWithContext(ctx, delay); err != nil {
@@ -235,17 +260,29 @@ func (c *Client) Upload(ctx context.Context, path string, body io.Reader, conten
 			continue
 		}
 
-		if c.verbose {
+		if c.verboseLevel >= 1 {
 			fmt.Fprintf(os.Stderr, "<-- %d %s\n", resp.StatusCode, resp.Status)
+		}
+		if c.verboseLevel >= 2 {
+			logHeaders(os.Stderr, resp.Header, false)
 		}
 
 		if resp.StatusCode >= 400 {
-			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, bodyLogLimit))
 			_ = resp.Body.Close()
+			if c.verboseLevel >= 3 {
+				logBody(os.Stderr, respBody)
+			}
 			if resp.StatusCode == http.StatusTooManyRequests {
 				return nil, exitcode.New(exitcode.RateLimited, fmt.Sprintf("upload rate limited (HTTP 429) after %d attempt(s): %s", attempt+1, string(respBody)))
 			}
 			return nil, exitcode.Wrap(exitcode.General, fmt.Errorf("upload failed (HTTP %d): %s", resp.StatusCode, string(respBody)))
+		}
+
+		if c.verboseLevel >= 3 {
+			preview, _ := io.ReadAll(io.LimitReader(resp.Body, bodyLogLimit))
+			resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(preview), resp.Body))
+			logBody(os.Stderr, preview)
 		}
 
 		return resp, nil
@@ -324,6 +361,39 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+// bodyLogLimit is the maximum number of body bytes written to stderr at -vvv.
+const bodyLogLimit = 64 << 10 // 64 KB
+
+// logHeaders prints HTTP headers to w in sorted order. When redactAuth is true,
+// the Authorization header value is replaced with "[redacted]".
+func logHeaders(w io.Writer, h http.Header, redactAuth bool) {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := strings.Join(h[k], ", ")
+		if redactAuth && strings.EqualFold(k, "Authorization") {
+			v = "[redacted]"
+		}
+		fmt.Fprintf(w, "    %s: %s\n", k, v)
+	}
+}
+
+// logBody prints body bytes to w indented by four spaces. Truncates at bodyLogLimit
+// and notes when truncation occurs.
+func logBody(w io.Writer, data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	truncated := len(data) >= bodyLogLimit
+	fmt.Fprintf(w, "    %s\n", strings.ReplaceAll(strings.TrimRight(string(data), "\n"), "\n", "\n    "))
+	if truncated {
+		fmt.Fprintf(w, "    [body truncated at %d bytes]\n", bodyLogLimit)
 	}
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -351,7 +351,7 @@ func TestDo_VerboseOutput(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, auth.NewTokenProvider("test-token"), WithVerbose(true))
+	c := New(srv.URL, auth.NewTokenProvider("test-token"), WithVerbose(1))
 
 	// Capture stderr
 	oldStderr := os.Stderr
@@ -383,13 +383,13 @@ func TestDo_VerboseOutput(t *testing.T) {
 
 func TestWithVerbose_SetsField(t *testing.T) {
 	c := New("https://example.com", auth.NewTokenProvider("tok"))
-	if c.verbose {
-		t.Error("verbose should default to false")
+	if c.verboseLevel != 0 {
+		t.Error("verboseLevel should default to 0")
 	}
 
-	c = New("https://example.com", auth.NewTokenProvider("tok"), WithVerbose(true))
-	if !c.verbose {
-		t.Error("WithVerbose(true) should set verbose to true")
+	c = New("https://example.com", auth.NewTokenProvider("tok"), WithVerbose(1))
+	if c.verboseLevel != 1 {
+		t.Error("WithVerbose(1) should set verboseLevel to 1")
 	}
 }
 

--- a/internal/commands/pro_backup.go
+++ b/internal/commands/pro_backup.go
@@ -115,7 +115,7 @@ func runBackup(ctx context.Context, cliCtx *registry.CLIContext, opts backupOpti
 		if u, ok := data["url"].(string); ok {
 			jamfProURL = strings.TrimSuffix(u, "/")
 		}
-	} else if verbose {
+	} else if verboseLevel >= 1 {
 		fmt.Fprintf(os.Stderr, "WARNING: could not resolve Jamf Pro URL for _meta: %v\n", err)
 	}
 

--- a/internal/commands/pro_diff.go
+++ b/internal/commands/pro_diff.go
@@ -250,7 +250,7 @@ func loadSnapshotFromProfile(ctx context.Context, profileName string, nameFilter
 		return nil, fmt.Errorf("resolving auth for profile %q: %w", profileName, err)
 	}
 
-	httpCli := &cliClient{client.New(resolvedURL, authProvider, client.WithVerbose(verbose))}
+	httpCli := &cliClient{client.New(resolvedURL, authProvider, client.WithVerbose(verboseLevel))}
 
 	defs, err := ResolveBackupResources(nameFilter)
 	if err != nil {
@@ -317,7 +317,7 @@ func loadSnapshotFromProfile(ctx context.Context, profileName string, nameFilter
 			return false
 		}
 
-		pc := newPlatformSDKClient(resolvedURL, p.ClientID(), p.ClientSecret(), p.TenantID(), !quiet && !verbose)
+		pc := newPlatformSDKClient(resolvedURL, p.ClientID(), p.ClientSecret(), p.TenantID(), !quiet && verboseLevel == 0)
 
 		if wantPlatform("blueprints") {
 			bps, err := pc.ListBlueprints(ctx, nil, "")

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -36,7 +36,7 @@ var (
 	profile      string
 	outputFmt    string
 	quiet        bool
-	verbose      bool
+	verboseLevel int
 	noInput      bool
 	noColor      bool
 	dryRun       bool
@@ -486,7 +486,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 			type jarProvider interface {
 				Jar() http.CookieJar
 			}
-			clientOpts := []client.Option{client.WithVerbose(verbose)}
+			clientOpts := []client.Option{client.WithVerbose(verboseLevel)}
 			if p, ok := authProvider.(*auth.PlatformOAuth2Provider); ok {
 				clientOpts = append(clientOpts, client.WithTenantID(p.TenantID()))
 			}
@@ -499,7 +499,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 			if dryRun {
 				httpClient = &dryRunClient{inner: httpClient}
 			}
-			if !quiet && !verbose {
+			if !quiet && verboseLevel == 0 {
 				httpClient = &spinnerClient{inner: httpClient}
 			}
 			cliCtx.Client = httpClient
@@ -527,7 +527,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 			if p, ok := authProvider.(*auth.PlatformOAuth2Provider); ok {
 				cliCtx.PlatformClient = newPlatformSDKClient(
 					resolvedURL, p.ClientID(), p.ClientSecret(), p.TenantID(),
-					!quiet && !verbose,
+					!quiet && verboseLevel == 0,
 				)
 			}
 
@@ -548,7 +548,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 	cmd.PersistentFlags().StringVarP(&profile, "profile", "p", "", "config profile to use (or JAMF_PROFILE env)")
 	cmd.PersistentFlags().StringVarP(&outputFmt, "output", "o", "json", "output format: table, json, csv, yaml, plain, xml (pretty), raw (classic commands default to xml)")
 	cmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "suppress non-error output")
-	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "show debug info")
+	cmd.PersistentFlags().CountVarP(&verboseLevel, "verbose", "v", "show HTTP requests/responses (-vv adds headers, -vvv adds bodies)")
 	cmd.PersistentFlags().BoolVar(&noInput, "no-input", false, "never prompt; fail if input required")
 	cmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "disable colored output")
 	cmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "n", false, "preview changes without executing")
@@ -913,7 +913,7 @@ func resolveProtectClient(cfg *config.Config, cliCtx *registry.CLIContext) error
 	rc.HTTPClient.Jar = jar
 
 	stdClient := rc.StandardClient()
-	if !quiet && !verbose {
+	if !quiet && verboseLevel == 0 {
 		stdClient.Transport = &spinnerTransport{inner: stdClient.Transport}
 	}
 
@@ -1020,7 +1020,7 @@ func resolveSchoolClient(cfg *config.Config, cliCtx *registry.CLIContext) error 
 	rc.HTTPClient.Jar = jar
 
 	stdClient := rc.StandardClient()
-	if !quiet && !verbose {
+	if !quiet && verboseLevel == 0 {
 		stdClient.Transport = &spinnerTransport{inner: stdClient.Transport}
 	}
 
@@ -1035,7 +1035,7 @@ func resolveSchoolClient(cfg *config.Config, cliCtx *registry.CLIContext) error 
 	if platformURL != "" && cid != "" && csecret != "" && tid != "" {
 		cliCtx.PlatformClient = newPlatformSDKClient(
 			platformURL, cid, csecret, tid,
-			!quiet && !verbose,
+			!quiet && verboseLevel == 0,
 		)
 	}
 

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -439,7 +439,7 @@ func resetGlobals() {
 	profile = ""
 	outputFmt = "json"
 	quiet = false
-	verbose = false
+	verboseLevel = 0
 	noInput = false
 	noColor = false
 	dryRun = false


### PR DESCRIPTION
## Summary

- Replaces single `-v` bool flag with a count flag — `-v` / `-vv` / `-vvv` are additive
- `-v` — existing behaviour: `-->` request lines and `<--` response lines
- `-vv` — adds sorted response/request headers (Authorization redacted)
- `-vvv` — adds request/response bodies (64 KB cap with truncation notice; upload requests show `[streaming body: N bytes, mime-type]` since the body cannot be buffered)
- All output goes to stderr
- Error response body read limit raised from 1 KB to 64 KB

## Test plan

- [x] `-v` still shows only request/response lines
- [x] `-vv` shows headers including trace/request-ID headers on errors (original motivation)
- [x] `-vvv` shows request and response bodies; confirm upload shows streaming note
- [x] All existing tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)