### PR TITLE
fix(multi): honour -o flag and match single-instance output format

### DIFF
--- a/internal/commands/multi.go
+++ b/internal/commands/multi.go
@@ -111,6 +111,8 @@ Examples:
 
 			if shouldAggregate {
 				// Aggregate mode: capture JSON from each child, merge, re-render
+				desiredFmt := extractOutputFlag(innerArgs)
+				captureArgs := stripOutputFlag(innerArgs)
 				results := make([]childResult, len(profiles))
 				for i, profileName := range profiles {
 					url := ""
@@ -120,9 +122,14 @@ Examples:
 
 					_, _ = fmt.Fprintf(w, "  [%d/%d] %s...\n", i+1, len(profiles), profileName)
 
-					// Force JSON output for capture — strip any user -o flag first
-					captureArgs := stripOutputFlag(innerArgs)
-					cmdArgs := append([]string{"--profile", profileName, "-o", "json"}, captureArgs...)
+					// For structured output (json/yaml) capture full data; for display formats
+					// capture with json-multi which applies column selection so re-rendered
+					// tables match the columns from a direct command.
+					captureFmt := "json-multi"
+					if desiredFmt == "json" || desiredFmt == "yaml" {
+						captureFmt = "json"
+					}
+					cmdArgs := append([]string{"--profile", profileName, "-o", captureFmt}, captureArgs...)
 					child := exec.Command(executable, cmdArgs...)
 					var stdout bytes.Buffer
 					child.Stdout = &stdout
@@ -146,7 +153,7 @@ Examples:
 				}
 
 				if aggregated := tryAggregate(results); aggregated != nil {
-					if err := printAggregated(cmd, aggregated); err != nil {
+					if err := printAggregated(cmd, aggregated, desiredFmt); err != nil {
 						return err
 					}
 				} else {
@@ -373,12 +380,17 @@ type childResult struct {
 	err         error
 }
 
-// printAggregated renders the merged report using the current output format.
-func printAggregated(cmd *cobra.Command, merged map[string]any) error {
-	// Default to table for aggregated reports (same as individual report commands)
-	renderFmt := outputFmt
-	if !cmd.Flags().Changed("output") {
-		renderFmt = "table"
+// printAggregated renders the merged report using the desired output format.
+// desiredFmt is extracted from the inner command args; empty string defaults to table.
+func printAggregated(cmd *cobra.Command, merged map[string]any, desiredFmt string) error {
+	renderFmt := desiredFmt
+	if renderFmt == "" {
+		// No -o in inner args — check if multi itself had -o set, else default to table
+		if cmd.Flags().Changed("output") {
+			renderFmt = outputFmt
+		} else {
+			renderFmt = "table"
+		}
 	}
 	formatter := output.New(renderFmt, noColor, wide)
 
@@ -394,6 +406,13 @@ func printAggregated(cmd *cobra.Command, merged map[string]any) error {
 				jsonMerged[k] = rows
 			} else {
 				jsonMerged[k] = v
+			}
+		}
+		// For plain list commands the merge wraps rows in {"results": [...]}.
+		// Unwrap to a flat array so json/yaml output matches single-instance output.
+		if len(jsonMerged) == 1 {
+			if results, ok := jsonMerged["results"]; ok {
+				return formatter.Print(results)
 			}
 		}
 		return formatter.Print([]map[string]any{jsonMerged})
@@ -500,8 +519,28 @@ func summaryFieldShouldSum(field string) bool {
 	return true
 }
 
+// extractOutputFlag returns the value of the -o/--output flag in args, or ""
+// if not present. Used to capture the user's desired render format before stripping.
+func extractOutputFlag(args []string) string {
+	for i, arg := range args {
+		if (arg == "-o" || arg == "--output") && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(arg, "-o=") {
+			return strings.TrimPrefix(arg, "-o=")
+		}
+		if strings.HasPrefix(arg, "--output=") {
+			return strings.TrimPrefix(arg, "--output=")
+		}
+		if strings.HasPrefix(arg, "-o") && len(arg) > 2 && !strings.HasPrefix(arg, "--") {
+			return arg[2:]
+		}
+	}
+	return ""
+}
+
 // stripOutputFlag removes -o/--output and its value from args so the forced
-// -o json for capture isn't overridden by the user's flag.
+// -o json-multi for capture isn't overridden by the user's flag.
 func stripOutputFlag(args []string) []string {
 	var result []string
 	skip := false

--- a/internal/commands/multi.go
+++ b/internal/commands/multi.go
@@ -111,8 +111,14 @@ Examples:
 
 			if shouldAggregate {
 				// Aggregate mode: capture JSON from each child, merge, re-render
-				desiredFmt := extractOutputFlag(innerArgs)
-				captureArgs := stripOutputFlag(innerArgs)
+				desiredFmt, captureArgs := parseOutputFlag(innerArgs)
+				// For structured output (json/yaml) capture full data; for display formats
+				// capture with json-multi which applies column selection so re-rendered
+				// tables match the columns from a direct command.
+				captureFmt := "json-multi"
+				if desiredFmt == "json" || desiredFmt == "yaml" {
+					captureFmt = "json"
+				}
 				results := make([]childResult, len(profiles))
 				for i, profileName := range profiles {
 					url := ""
@@ -122,13 +128,6 @@ Examples:
 
 					_, _ = fmt.Fprintf(w, "  [%d/%d] %s...\n", i+1, len(profiles), profileName)
 
-					// For structured output (json/yaml) capture full data; for display formats
-					// capture with json-multi which applies column selection so re-rendered
-					// tables match the columns from a direct command.
-					captureFmt := "json-multi"
-					if desiredFmt == "json" || desiredFmt == "yaml" {
-						captureFmt = "json"
-					}
 					cmdArgs := append([]string{"--profile", profileName, "-o", captureFmt}, captureArgs...)
 					child := exec.Command(executable, cmdArgs...)
 					var stdout bytes.Buffer
@@ -229,6 +228,10 @@ Examples:
 // Aggregation
 // ---------------------------------------------------------------------------
 
+// mergedListKey is the internal key used when wrapping a flat list result for
+// aggregation. Referenced in both tryAggregate (wrap) and printAggregated (unwrap).
+const mergedListKey = "results"
+
 // tryAggregate attempts to parse and merge JSON output from multiple children.
 // Returns nil if the output isn't aggregatable (non-JSON, or not a structured
 // report format).
@@ -273,7 +276,7 @@ func tryAggregate(results []childResult) map[string]any {
 				profileName string
 				profileURL  string
 				data        map[string]any
-			}{r.profileName, r.profileURL, map[string]any{"results": asAny}})
+			}{r.profileName, r.profileURL, map[string]any{mergedListKey: asAny}})
 			continue
 		}
 
@@ -408,10 +411,10 @@ func printAggregated(cmd *cobra.Command, merged map[string]any, desiredFmt strin
 				jsonMerged[k] = v
 			}
 		}
-		// For plain list commands the merge wraps rows in {"results": [...]}.
+		// For plain list commands the merge wraps rows in {mergedListKey: [...]}.
 		// Unwrap to a flat array so json/yaml output matches single-instance output.
 		if len(jsonMerged) == 1 {
-			if results, ok := jsonMerged["results"]; ok {
+			if results, ok := jsonMerged[mergedListKey]; ok {
 				return formatter.Print(results)
 			}
 		}
@@ -519,30 +522,10 @@ func summaryFieldShouldSum(field string) bool {
 	return true
 }
 
-// extractOutputFlag returns the value of the -o/--output flag in args, or ""
-// if not present. Used to capture the user's desired render format before stripping.
-func extractOutputFlag(args []string) string {
-	for i, arg := range args {
-		if (arg == "-o" || arg == "--output") && i+1 < len(args) {
-			return args[i+1]
-		}
-		if strings.HasPrefix(arg, "-o=") {
-			return strings.TrimPrefix(arg, "-o=")
-		}
-		if strings.HasPrefix(arg, "--output=") {
-			return strings.TrimPrefix(arg, "--output=")
-		}
-		if strings.HasPrefix(arg, "-o") && len(arg) > 2 && !strings.HasPrefix(arg, "--") {
-			return arg[2:]
-		}
-	}
-	return ""
-}
-
-// stripOutputFlag removes -o/--output and its value from args so the forced
-// -o json-multi for capture isn't overridden by the user's flag.
-func stripOutputFlag(args []string) []string {
-	var result []string
+// parseOutputFlag extracts the -o/--output value from args and returns it along
+// with a copy of args with all -o/--output occurrences removed. Handles all
+// flag forms: -o json, -o=json, -ojson, --output json, --output=json.
+func parseOutputFlag(args []string) (value string, stripped []string) {
 	skip := false
 	for i, arg := range args {
 		if skip {
@@ -550,21 +533,33 @@ func stripOutputFlag(args []string) []string {
 			continue
 		}
 		if arg == "-o" || arg == "--output" {
-			// Skip this flag and its next arg (the value)
+			if i+1 < len(args) && value == "" {
+				value = args[i+1]
+			}
 			skip = true
 			continue
 		}
-		if strings.HasPrefix(arg, "-o=") || strings.HasPrefix(arg, "--output=") {
+		if after, ok := strings.CutPrefix(arg, "-o="); ok {
+			if value == "" {
+				value = after
+			}
 			continue
 		}
-		// Handle -o<value> (no space)
-		if strings.HasPrefix(arg, "-o") && len(arg) > 2 && !strings.HasPrefix(arg, "--") {
+		if after, ok := strings.CutPrefix(arg, "--output="); ok {
+			if value == "" {
+				value = after
+			}
 			continue
 		}
-		_ = i
-		result = append(result, arg)
+		if !strings.HasPrefix(arg, "--") && strings.HasPrefix(arg, "-o") && len(arg) > 2 {
+			if value == "" {
+				value = arg[2:]
+			}
+			continue
+		}
+		stripped = append(stripped, arg)
 	}
-	return result
+	return
 }
 
 // hasAggregatableSections returns true if a single-object JSON response

--- a/internal/commands/multi.go
+++ b/internal/commands/multi.go
@@ -130,6 +130,7 @@ Examples:
 
 					cmdArgs := append([]string{"--profile", profileName, "-o", captureFmt}, captureArgs...)
 					child := exec.Command(executable, cmdArgs...)
+					child.Env = append(os.Environ(), "JAMF_CLI_MULTI_CAPTURE=1")
 					var stdout bytes.Buffer
 					child.Stdout = &stdout
 					child.Stderr = cmd.ErrOrStderr()

--- a/internal/commands/multi_aggregate_test.go
+++ b/internal/commands/multi_aggregate_test.go
@@ -248,27 +248,55 @@ func TestFormatSectionTitle(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// stripOutputFlag
+// parseOutputFlag
 // ---------------------------------------------------------------------------
 
-func TestStripOutputFlag(t *testing.T) {
+func TestParseOutputFlag(t *testing.T) {
 	tests := []struct {
-		name  string
-		input []string
-		want  int
+		name         string
+		input        []string
+		wantValue    string
+		wantStripped int
 	}{
-		{"no flag", []string{"pro", "comp", "list"}, 3},
-		{"-o json", []string{"pro", "comp", "list", "-o", "json"}, 3},
-		{"-o=json", []string{"pro", "comp", "list", "-o=json"}, 3},
-		{"-ojson", []string{"pro", "comp", "list", "-ojson"}, 3},
-		{"--output table", []string{"pro", "comp", "list", "--output", "table"}, 3},
-		{"--output=yaml", []string{"pro", "comp", "list", "--output=yaml"}, 3},
-		{"middle", []string{"pro", "-o", "csv", "comp", "list"}, 3},
+		{"no flag", []string{"pro", "comp", "list"}, "", 3},
+		{"-o json", []string{"pro", "comp", "list", "-o", "json"}, "json", 3},
+		{"-o=json", []string{"pro", "comp", "list", "-o=json"}, "json", 3},
+		{"-ojson", []string{"pro", "comp", "list", "-ojson"}, "json", 3},
+		{"--output table", []string{"pro", "comp", "list", "--output", "table"}, "table", 3},
+		{"--output=yaml", []string{"pro", "comp", "list", "--output=yaml"}, "yaml", 3},
+		{"middle", []string{"pro", "-o", "csv", "comp", "list"}, "csv", 3},
+		{"first wins", []string{"pro", "-o", "json", "list", "-o", "table"}, "json", 2},
 	}
 	for _, tc := range tests {
-		got := stripOutputFlag(tc.input)
-		if len(got) != tc.want {
-			t.Errorf("%s: stripOutputFlag(%v) = %d args, want %d: %v", tc.name, tc.input, len(got), tc.want, got)
+		val, stripped := parseOutputFlag(tc.input)
+		if val != tc.wantValue {
+			t.Errorf("%s: value = %q, want %q", tc.name, val, tc.wantValue)
 		}
+		if len(stripped) != tc.wantStripped {
+			t.Errorf("%s: stripped = %d args, want %d: %v", tc.name, len(stripped), tc.wantStripped, stripped)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mergedListKey unwrap (printAggregated JSON path)
+// ---------------------------------------------------------------------------
+
+func TestTryAggregate_FlatArray_UsesConstantKey(t *testing.T) {
+	results := []childResult{
+		{profileName: "pro-a", stdout: []byte(`[{"id":"1","name":"Mac"}]`)},
+	}
+	merged := tryAggregate(results)
+	if merged == nil {
+		t.Fatal("expected aggregation, got nil")
+	}
+	if _, ok := merged[mergedListKey]; !ok {
+		t.Errorf("expected key %q in merged map, got keys: %v", mergedListKey, func() []string {
+			var keys []string
+			for k := range merged {
+				keys = append(keys, k)
+			}
+			return keys
+		}())
 	}
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -419,7 +419,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 				outputFmt = cfg.DefaultOutput
 			}
 
-			if outputFmt == string(output.FormatJSONMulti) {
+			if outputFmt == string(output.FormatJSONMulti) && os.Getenv("JAMF_CLI_MULTI_CAPTURE") == "" {
 				return fmt.Errorf("output format %q is reserved for internal use", outputFmt)
 			}
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -419,6 +419,10 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 				outputFmt = cfg.DefaultOutput
 			}
 
+			if outputFmt == string(output.FormatJSONMulti) {
+				return fmt.Errorf("output format %q is reserved for internal use", outputFmt)
+			}
+
 			// Build output formatter (shared by all products and by skipped
 			// commands like config/completion/version).
 			if outFile != "" {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -41,13 +41,14 @@ const (
 type Format string
 
 const (
-	FormatTable Format = "table"
-	FormatJSON  Format = "json"
-	FormatCSV   Format = "csv"
-	FormatYAML  Format = "yaml"
-	FormatPlain Format = "plain"
-	FormatXML   Format = "xml" // Classic API native format — pretty-printed XML
-	FormatRaw   Format = "raw" // Exact wire bytes, no conversion or formatting
+	FormatTable     Format = "table"
+	FormatJSON      Format = "json"
+	FormatJSONMulti Format = "json-multi" // internal: like json but triggers column selection in selectTableColumns
+	FormatCSV       Format = "csv"
+	FormatYAML      Format = "yaml"
+	FormatPlain     Format = "plain"
+	FormatXML       Format = "xml" // Classic API native format — pretty-printed XML
+	FormatRaw       Format = "raw" // Exact wire bytes, no conversion or formatting
 )
 
 // nowFunc is the function used to get the current time. Override in tests.
@@ -314,7 +315,7 @@ func (f *Formatter) PrintRaw(data []byte) error {
 		}
 	}
 
-	if f.format == FormatJSON {
+	if f.format == FormatJSON || f.format == FormatJSONMulti {
 		// Pretty-print JSON so compact API responses become readable
 		var buf bytes.Buffer
 		if err := json.Indent(&buf, data, "", "  "); err != nil {


### PR DESCRIPTION
## Summary

- `multi -- pro computers list -o table` now shows the same columns (`ID NAME LASTCONTACTTIME MODEL OSVERSION SERIAL`) as a direct `pro computers list -o table`, instead of all nested dot-notation fields
- `multi -- pro computers list -o json` now outputs a flat JSON array matching single-instance output, instead of `[{"results": [...]}]` with column-selected objects
- All other formats (`csv`, `plain`, `yaml`) also propagate correctly

## How it works

**Table/csv/plain**: a new internal `json-multi` output format is used for capture. `selectTableColumns` already skips `json`/`yaml`/`xml`/`raw` — `json-multi` falls through to column selection, so the child outputs flat `{id, name, serial, ...}` JSON. `output.PrintRaw` handles `json-multi` identically to `json` (pretty-print). Multi re-renders the flat data as a table with clean columns.

**JSON/YAML**: capture uses `-o json` (full API response, no column selection). `printAggregated` detects when the merged result is a plain list (`{"results": [...]}` with a single key) and unwraps it to a flat array before printing.

**Output format propagation**: added `extractOutputFlag` to read the `-o` value from the inner command args before stripping. `printAggregated` now receives this as `desiredFmt` instead of reading the unreliable global `outputFmt` + `cmd.Flags().Changed("output")`.

## Test plan

- [x] `multi -- pro computers list -o table` shows `ID NAME LASTCONTACTTIME MODEL OSVERSION SERIAL` columns
- [x] `multi -- pro mobile-devices list -o json` outputs flat JSON array matching single-instance structure
- [x] `multi -- pro buildings list` (no `-o`) defaults to table
- [x] `multi -- pro report profile-status` (report command with multiple sections) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)