### PR TITLE
fix: normalize and validate URLs at all entry points

### DIFF
--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -248,6 +248,12 @@ func newConfigAddProfileCmd() *cobra.Command {
 				return fmt.Errorf("invalid --auth-method %q: must be token, oauth2, or platform", authMethod)
 			}
 
+			// Validate and normalize URL before prompting for credentials.
+			normalizedURL, err := normalizeURL(profileURL)
+			if err != nil {
+				return fmt.Errorf("invalid --url: %w", err)
+			}
+
 			w := cmd.OutOrStdout()
 			reader := bufio.NewReader(os.Stdin)
 
@@ -314,7 +320,7 @@ func newConfigAddProfileCmd() *cobra.Command {
 			}
 
 			p := config.Profile{
-				URL:        profileURL,
+				URL:        normalizedURL,
 				AuthMethod: authMethod,
 				TenantID:   profileTenantID,
 			}

--- a/internal/commands/config_subcommands_test.go
+++ b/internal/commands/config_subcommands_test.go
@@ -459,6 +459,32 @@ profiles:
 
 // --- add-profile validation tests ---
 
+func TestAddProfile_HTTPURLRejected(t *testing.T) {
+	setupTempConfig(t)
+
+	oldNoInput := noInput
+	noInput = true
+	defer func() { noInput = oldNoInput }()
+
+	cmd := newConfigAddProfileCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{
+		"test-profile",
+		"--url", "http://example.jamfcloud.com",
+		"--auth-method", "token",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for http:// URL")
+	}
+	if !strings.Contains(err.Error(), "http://") {
+		t.Errorf("error = %q, want to mention http://", err.Error())
+	}
+}
+
 func TestAddProfile_ValidationErrors(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/commands/platform.go
+++ b/internal/commands/platform.go
@@ -96,7 +96,10 @@ Create API client credentials in the Jamf Account portal
 			if gatewayURL == "" {
 				return fmt.Errorf("gateway URL is required")
 			}
-			gatewayURL = normalizeURL(gatewayURL)
+			gatewayURL, err := normalizeURL(gatewayURL)
+			if err != nil {
+				return fmt.Errorf("invalid gateway URL: %w", err)
+			}
 
 			// 3. Client credentials (interactive only)
 			_, _ = fmt.Fprint(w, "\nClient ID: ")
@@ -127,7 +130,8 @@ Create API client credentials in the Jamf Account portal
 
 			// 5. Validate credentials
 			_, _ = fmt.Fprint(w, "\nValidating credentials... ")
-			pc := jamfplatform.NewClient(gatewayURL, clientID, clientSecret,
+			pc := jamfplatform.NewClient(
+				gatewayURL, clientID, clientSecret,
 				jamfplatform.WithTenantID(tenantID),
 			)
 			if err := pc.ValidateCredentials(context.Background()); err != nil {

--- a/internal/commands/pro_setup.go
+++ b/internal/commands/pro_setup.go
@@ -401,13 +401,26 @@ func applyPrivilegeFilter(all []string, opt scopeOption) []string {
 	return result
 }
 
-// normalizeURL ensures the URL has a scheme (defaults to https) and no trailing slash.
-func normalizeURL(rawURL string) string {
+// normalizeURL ensures the URL has an https scheme (added when absent) and no
+// trailing slash. Returns an error for explicit http:// — credentials must not
+// travel in plaintext.
+func normalizeURL(rawURL string) (string, error) {
 	rawURL = strings.TrimRight(rawURL, "/")
-	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
+	if !strings.Contains(rawURL, "://") {
 		rawURL = "https://" + rawURL
 	}
-	return rawURL
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+	switch parsed.Scheme {
+	case "https":
+		return rawURL, nil
+	case "http":
+		return "", fmt.Errorf("http:// is not allowed; use https:// to protect credentials in transit")
+	default:
+		return "", fmt.Errorf("URL scheme %q is not supported; use https://", parsed.Scheme)
+	}
 }
 
 // extractSubdomain returns the hostname portion before the first dot.
@@ -446,7 +459,10 @@ func readURLsFromFile(path string) ([]string, error) {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		normalized := normalizeURL(line)
+		normalized, err := normalizeURL(line)
+		if err != nil {
+			return nil, fmt.Errorf("invalid URL %q: %w", line, err)
+		}
 		if seen[normalized] {
 			continue
 		}
@@ -631,7 +647,11 @@ pro-<subdomain> (e.g., pro-school1 for school1.jamfcloud.com).`,
 
 			// Normalize all URLs
 			for i, u := range urls {
-				urls[i] = normalizeURL(u)
+				normalized, err := normalizeURL(u)
+				if err != nil {
+					return fmt.Errorf("invalid URL %q: %w", u, err)
+				}
+				urls[i] = normalized
 			}
 
 			// Gather credentials interactively — once for all instances.

--- a/internal/commands/pro_setup_test.go
+++ b/internal/commands/pro_setup_test.go
@@ -886,6 +886,26 @@ func TestReadURLsFromFile_NotFound(t *testing.T) {
 	}
 }
 
+func TestReadURLsFromFile_HTTPSchemeRejected(t *testing.T) {
+	f, err := os.CreateTemp("", "urls-http-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	_, _ = f.WriteString("https://school1.jamfcloud.com\n")
+	_, _ = f.WriteString("http://school2.jamfcloud.com\n")
+	_ = f.Close()
+
+	_, err = readURLsFromFile(f.Name())
+	if err == nil {
+		t.Fatal("expected error for http:// URL in file")
+	}
+	if !strings.Contains(err.Error(), "http://") {
+		t.Errorf("error = %q, want to mention http://", err.Error())
+	}
+}
+
 func TestEscapeRSQL(t *testing.T) {
 	tests := []struct {
 		input string
@@ -908,22 +928,38 @@ func TestEscapeRSQL(t *testing.T) {
 }
 
 func TestNormalizeURL(t *testing.T) {
-	tests := []struct {
+	okTests := []struct {
 		input string
 		want  string
 	}{
 		{"example.jamfcloud.com", "https://example.jamfcloud.com"},
 		{"https://example.jamfcloud.com", "https://example.jamfcloud.com"},
-		{"http://localhost:8080", "http://localhost:8080"},
 		{"example.jamfcloud.com/", "https://example.jamfcloud.com"},
 		{"https://example.jamfcloud.com/", "https://example.jamfcloud.com"},
+		{"example.jamfcloud.com:8443", "https://example.jamfcloud.com:8443"},
+		{"example.jamfcloud.com:8443/", "https://example.jamfcloud.com:8443"},
 	}
-
-	for _, tt := range tests {
+	for _, tt := range okTests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := normalizeURL(tt.input)
+			got, err := normalizeURL(tt.input)
+			if err != nil {
+				t.Fatalf("normalizeURL(%q) unexpected error: %v", tt.input, err)
+			}
 			if got != tt.want {
 				t.Errorf("normalizeURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+
+	errTests := []string{
+		"http://example.jamfcloud.com",
+		"http://localhost:8080",
+	}
+	for _, input := range errTests {
+		t.Run("err_"+input, func(t *testing.T) {
+			_, err := normalizeURL(input)
+			if err == nil {
+				t.Errorf("normalizeURL(%q) expected error, got nil", input)
 			}
 		})
 	}

--- a/internal/commands/protect_setup.go
+++ b/internal/commands/protect_setup.go
@@ -60,7 +60,10 @@ Settings > API Clients before running this command.`,
 			if setupURL == "" {
 				return fmt.Errorf("URL is required")
 			}
-			setupURL = normalizeURL(setupURL)
+			setupURL, err := normalizeURL(setupURL)
+			if err != nil {
+				return fmt.Errorf("invalid URL: %w", err)
+			}
 
 			// Credentials are always collected interactively to prevent
 			// exposure in shell history and process listings.

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -289,6 +289,13 @@ func ResolveAuthForProfile(cfg *config.Config, params AuthParams) (string, auth.
 		tok = strings.TrimSpace(string(data))
 	}
 
+	// Normalize: strip trailing slash (silently fixes profiles saved before this
+	// check was added) and add https:// to bare hostnames in env/flag inputs.
+	url = strings.TrimRight(url, "/")
+	if url != "" && !strings.Contains(url, "://") {
+		url = "https://" + url
+	}
+
 	// Validate
 	if url == "" {
 		return "", nil, exitcode.New(exitcode.Usage, "server URL is required: use --url, JAMF_URL env var, or jamf-cli config add-profile")

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -926,6 +926,64 @@ func TestResolveAuth_ProfileNotFound(t *testing.T) {
 	}
 }
 
+func TestResolveAuth_URLNormalization(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfgYaml string
+		envURL  string
+		wantURL string
+	}{
+		{
+			name: "trailing slash in stored profile stripped",
+			cfgYaml: `default-profile: test
+profiles:
+  test:
+    url: https://example.jamfcloud.com/
+    auth-method: token
+    token: "env:TEST_URL_NORM_TOKEN"
+`,
+			wantURL: "https://example.jamfcloud.com",
+		},
+		{
+			name:    "bare hostname in JAMF_URL gets https",
+			cfgYaml: `profiles: {}`,
+			envURL:  "example.jamfcloud.com",
+			wantURL: "https://example.jamfcloud.com",
+		},
+		{
+			name:    "JAMF_URL trailing slash stripped",
+			cfgYaml: `profiles: {}`,
+			envURL:  "https://example.jamfcloud.com/",
+			wantURL: "https://example.jamfcloud.com",
+		},
+	}
+
+	t.Setenv("TEST_URL_NORM_TOKEN", "test-token")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupConfigProfile(t, tt.cfgYaml)
+			if tt.envURL != "" {
+				t.Setenv("JAMF_URL", tt.envURL)
+				t.Setenv("JAMF_TOKEN", "tok")
+			}
+
+			cfg, err := config.Load()
+			if err != nil {
+				t.Fatalf("Load error: %v", err)
+			}
+
+			url, _, err := resolveAuth(cfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if url != tt.wantURL {
+				t.Errorf("url = %q, want %q", url, tt.wantURL)
+			}
+		})
+	}
+}
+
 // --- cliOutput.PrintResponse test ---
 
 func TestCLIOutputPrintResponse(t *testing.T) {

--- a/internal/commands/school_setup.go
+++ b/internal/commands/school_setup.go
@@ -64,7 +64,10 @@ portal (account.jamf.com).`,
 			if setupURL == "" {
 				return fmt.Errorf("URL is required")
 			}
-			setupURL = normalizeURL(setupURL)
+			setupURL, err := normalizeURL(setupURL)
+			if err != nil {
+				return fmt.Errorf("invalid URL: %w", err)
+			}
 
 			// Credentials are always collected interactively to prevent
 			// exposure in shell history and process listings.
@@ -187,7 +190,11 @@ func collectPlatformCredentials(w io.Writer, reader *bufio.Reader, store keychai
 	if gatewayURL == "" {
 		return prof, fmt.Errorf("gateway URL is required")
 	}
-	prof.PlatformURL = normalizeURL(gatewayURL)
+	gatewayURL, err := normalizeURL(gatewayURL)
+	if err != nil {
+		return prof, fmt.Errorf("invalid gateway URL: %w", err)
+	}
+	prof.PlatformURL = gatewayURL
 
 	// Tenant ID
 	_, _ = fmt.Fprint(w, "Tenant ID: ")


### PR DESCRIPTION
## Summary

- Fixes #179: trailing slash in stored profile URL caused classic API 404s — now stripped silently at runtime in `ResolveAuthForProfile`, so existing profiles need no migration
- Fixes #175: `http://` URLs accepted in setup flows, sending credentials in plaintext — now rejected with a clear error at all entry points (`pro setup`, `protect setup`, `school setup`, `platform add`, `config add-profile`)
- Bare hostnames (e.g. `instance.jamfcloud.com`) now accepted everywhere — `https://` added automatically

## Changes

- `normalizeURL`: upgraded from string prefix checks to `url.Parse` for scheme detection; signature changed to `(string, error)`; rejects `http://` explicitly
- `config add-profile`: URL validated and normalized before credential prompts (fail-fast UX improvement)
- `root.go` `ResolveAuthForProfile`: silently strips trailing slash and adds `https://` to bare hostnames — covers `JAMF_URL` env var, `--url` flag, and pre-existing profiles saved before this fix

## Note on http:// at runtime

Existing profiles with `http://` URLs are **not** blocked at runtime — only warned (existing behavior preserved for backward compatibility). The rejection applies only to setup/config entry points where credentials are about to be stored.

## Test plan

- [x] `TestNormalizeURL` — updated: removed passing `http://` case, added port+trailing-slash cases, added error cases
- [x] `TestReadURLsFromFile_HTTPSchemeRejected` — new: `http://` line in URL file returns error
- [x] `TestAddProfile_HTTPURLRejected` — new: `config add-profile --url http://...` returns error
- [x] `TestResolveAuth_URLNormalization` — new: stored profile trailing slash, bare `JAMF_URL`, `JAMF_URL` trailing slash all normalized correctly
- [x] Full test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)