### PR TITLE
feat(jcds): add download and sync commands

### DIFF
--- a/generator/parser/parser_test.go
+++ b/generator/parser/parser_test.go
@@ -2162,8 +2162,7 @@ func TestApplyCreateOpOverrides(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("target op not found after ApplyCreateOpOverrides")
-	}
-	if got.Name != "create" {
+	} else if got.Name != "create" {
 		t.Errorf("op name = %q, want %q", got.Name, "create")
 	}
 	// Untouched ops keep their names.

--- a/internal/commands/pro.go
+++ b/internal/commands/pro.go
@@ -78,6 +78,13 @@ func newProCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	// that the generated multipart template can't produce.
 	replaceSubcommand(cmd, []string{"packages"}, "upload", newPackagesUploadCmd(cliCtx))
 
+	// Add handwritten jcds commands to generated parent (multi-step orchestration).
+	addSubcommand(cmd, []string{"jcds"}, newJcdsDownloadCmd(cliCtx))
+	addSubcommand(cmd, []string{"jcds"}, newJcdsSyncCmd(cliCtx))
+
+	// Also expose sync under packages — JCDS is the backing store for packages.
+	addSubcommand(cmd, []string{"packages"}, newJcdsSyncCmd(cliCtx))
+
 	// Add device action subcommands to generated resource parents
 	addSubcommand(cmd, []string{"computers-inventory"}, newComputerEraseCmd(cliCtx))
 	addSubcommand(cmd, []string{"computers-inventory"}, newComputerRemoveMDMCmd(cliCtx))

--- a/internal/commands/pro_jcds.go
+++ b/internal/commands/pro_jcds.go
@@ -1,0 +1,459 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"context"
+	"crypto/sha3"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/spf13/cobra"
+)
+
+// File-status values used in jcdsSyncFileResult.
+const (
+	jcdsStatusDownloaded    = "downloaded"
+	jcdsStatusUpdated       = "updated"
+	jcdsStatusSkipped       = "skipped"
+	jcdsStatusDeleted       = "deleted"
+	jcdsStatusFailed        = "failed"
+	jcdsStatusWouldDownload = "would-download"
+	jcdsStatusWouldUpdate   = "would-update"
+	jcdsStatusWouldDelete   = "would-delete"
+)
+
+// jcdsSyncFileResult is the per-file entry in the sync report.
+type jcdsSyncFileResult struct {
+	FileName string `json:"fileName"`
+	Status   string `json:"status"` // see jcdsStatus* constants
+	Error    string `json:"error,omitempty"`
+}
+
+// jcdsSyncReport is the full structured output of jcds sync.
+type jcdsSyncReport struct {
+	DryRun  bool                 `json:"dryRun,omitempty"`
+	Summary jcdsSyncSummary      `json:"summary"`
+	Files   []jcdsSyncFileResult `json:"files"`
+}
+
+// jcdsSyncSummary holds the aggregate counts.
+type jcdsSyncSummary struct {
+	Downloaded int64 `json:"downloaded"`
+	Updated    int64 `json:"updated"`
+	Deleted    int64 `json:"deleted"`
+	UpToDate   int64 `json:"upToDate"`
+	Failed     int64 `json:"failed"`
+}
+
+// jcdsFileData matches the FileData schema from the JCDS API.
+type jcdsFileData struct {
+	FileName string `json:"fileName"`
+	Length   int64  `json:"length"`
+	MD5      string `json:"md5"`
+	Region   string `json:"region"`
+	SHA3     string `json:"sha3"`
+}
+
+// jcdsHTTPStatusError is returned by jcdsStreamToFile for non-2xx HTTP responses.
+type jcdsHTTPStatusError struct {
+	StatusCode int
+}
+
+func (e *jcdsHTTPStatusError) Error() string {
+	return fmt.Sprintf("HTTP %d", e.StatusCode)
+}
+
+// jcdsFetchPresignedURL fetches a fresh pre-signed download URL from the JCDS API.
+func jcdsFetchPresignedURL(ctx context.Context, client registry.HTTPClient, fileName string) (string, error) {
+	apiPath := "/v1/jcds/files/" + url.PathEscape(fileName)
+	resp, err := client.Do(ctx, "GET", apiPath, nil)
+	if err != nil {
+		return "", err
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		return "", fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("API error %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var result struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("parsing download URL response: %w", err)
+	}
+	if result.URI == "" {
+		return "", fmt.Errorf("API returned empty download URI")
+	}
+	return result.URI, nil
+}
+
+// jcdsDownloadFile fetches the pre-signed URL then streams the file to outPath.
+// Retries once with a fresh URL on HTTP 403 — CloudFront signed URLs have a short
+// TTL and can expire if the API response is slow or requests queue under concurrency.
+func jcdsDownloadFile(ctx context.Context, client registry.HTTPClient, fileName, outPath string) error {
+	uri, err := jcdsFetchPresignedURL(ctx, client, fileName)
+	if err != nil {
+		return err
+	}
+
+	n, err := jcdsStreamToFile(ctx, uri, outPath)
+	var httpErr *jcdsHTTPStatusError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusForbidden {
+		// Pre-signed URL expired — fetch a fresh one and retry once.
+		fmt.Fprintf(os.Stderr, "warning: %s pre-signed URL expired (403), retrying with fresh URL\n", fileName)
+		uri, err = jcdsFetchPresignedURL(ctx, client, fileName)
+		if err != nil {
+			return err
+		}
+		n, err = jcdsStreamToFile(ctx, uri, outPath)
+	}
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Saved %s (%d bytes)\n", outPath, n)
+	return nil
+}
+
+// jcdsStreamToFile downloads uri to outPath via a temp-file+rename.
+// Returns bytes written; non-2xx responses return a *jcdsHTTPStatusError.
+func jcdsStreamToFile(ctx context.Context, uri, outPath string) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
+	if err != nil {
+		return 0, fmt.Errorf("creating download request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("downloading file: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		// Drain body so the connection can be reused, then surface status to caller.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return 0, &jcdsHTTPStatusError{StatusCode: resp.StatusCode}
+	}
+
+	dir := filepath.Dir(outPath)
+	tmp, err := os.CreateTemp(dir, ".jcds-tmp-*")
+	if err != nil {
+		return 0, fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	buf := make([]byte, 4<<20) // 4MB — better throughput for large pkg files than default 32KB
+	n, err := io.CopyBuffer(tmp, resp.Body, buf)
+	if err != nil {
+		_ = tmp.Close()
+		return 0, fmt.Errorf("writing file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return 0, fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, outPath); err != nil {
+		return 0, fmt.Errorf("moving file into place: %w", err)
+	}
+
+	return n, nil
+}
+
+// jcdsFileSHA3 computes the hex SHA3-512 of a local file.
+func jcdsFileSHA3(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha3.New512()
+	buf := make([]byte, 4<<20) // 4MB — match download buffer size for large pkg files
+	if _, err := io.CopyBuffer(h, f, buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func newJcdsDownloadCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var (
+		flagName   string
+		flagOutput string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "download [<fileName>]",
+		Short: "Download a file from the Jamf Cloud Distribution Service",
+		Long:  "Retrieves a pre-signed download URL for the file and streams it to disk.",
+		Example: `  # Download by filename
+  jamf-cli pro jcds download MyPackage.pkg
+
+  # Download with explicit output path
+  jamf-cli pro jcds download MyPackage.pkg --output /tmp/MyPackage.pkg`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reqCtx := cmd.Context()
+
+			var fileName string
+			if flagName != "" {
+				fileName = flagName
+			} else if len(args) > 0 {
+				fileName = args[0]
+			} else {
+				return fmt.Errorf("provide a <fileName> argument or --name")
+			}
+
+			outPath := flagOutput
+			if outPath == "" {
+				outPath = filepath.Base(fileName)
+			}
+
+			return jcdsDownloadFile(reqCtx, cliCtx.Client, fileName, outPath)
+		},
+	}
+
+	cmd.Flags().StringVar(&flagName, "name", "", "Name of the file to download")
+	cmd.Flags().StringVarP(&flagOutput, "output", "O", "", "Output file path (default: <fileName>)")
+
+	return cmd
+}
+
+func newJcdsSyncCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var (
+		flagDir         string
+		flagDelete      bool
+		flagDryRun      bool
+		flagConcurrency int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Sync JCDS files to a local directory",
+		Long: `Syncs the Jamf Cloud Distribution Service to a local directory.
+
+  - Downloads files missing locally
+  - Re-downloads files whose SHA3-512 differs from JCDS (updated remotely)
+  - Optionally deletes local files not present on JCDS (--delete)
+
+Designed for scheduled runs on file-share distribution points.`,
+		Example: `  # Sync JCDS to /Volumes/Packages (safe — no deletion)
+  jamf-cli pro jcds sync --dir /Volumes/Packages
+
+  # Sync and remove local files not on JCDS
+  jamf-cli pro jcds sync --dir /Volumes/Packages --delete
+
+  # Preview what would change without doing anything
+  jamf-cli pro jcds sync --dir /Volumes/Packages --delete --dry-run`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reqCtx := cmd.Context()
+
+			if flagConcurrency < 1 {
+				return fmt.Errorf("--concurrency must be at least 1")
+			}
+			if err := os.MkdirAll(flagDir, 0o755); err != nil {
+				return fmt.Errorf("creating destination directory: %w", err)
+			}
+
+			// Fetch JCDS file list.
+			resp, err := cliCtx.Client.Do(reqCtx, "GET", "/v1/jcds/files", nil)
+			if err != nil {
+				return err
+			}
+			body, err := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if err != nil {
+				return fmt.Errorf("reading file list: %w", err)
+			}
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				return fmt.Errorf("API error %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+			}
+
+			var jcdsFiles []jcdsFileData
+			if err := json.Unmarshal(body, &jcdsFiles); err != nil {
+				return fmt.Errorf("parsing file list: %w", err)
+			}
+
+			// Build JCDS filename set for existence checks.
+			jcdsSet := make(map[string]struct{}, len(jcdsFiles))
+			for _, f := range jcdsFiles {
+				jcdsSet[f.FileName] = struct{}{}
+			}
+
+			// Scan local directory.
+			entries, err := os.ReadDir(flagDir)
+			if err != nil {
+				return fmt.Errorf("reading directory: %w", err)
+			}
+			localFiles := make(map[string]bool, len(entries))
+			for _, e := range entries {
+				if !e.IsDir() {
+					localFiles[e.Name()] = true
+				}
+			}
+
+			var downloaded, updated, deleted, skipped, failed atomic.Int64
+
+			// filesMu guards fileResults which is written by concurrent goroutines.
+			var filesMu sync.Mutex
+			fileResults := make([]jcdsSyncFileResult, 0, len(jcdsFiles)+len(localFiles))
+			addFileResult := func(r jcdsSyncFileResult) {
+				filesMu.Lock()
+				fileResults = append(fileResults, r)
+				filesMu.Unlock()
+			}
+
+			if flagDryRun {
+				// Dry run: report what would happen without modifying anything.
+				if flagDelete {
+					for name := range localFiles {
+						if _, onJCDS := jcdsSet[name]; !onJCDS {
+							localPath := filepath.Join(flagDir, name)
+							fmt.Fprintf(os.Stderr, "[dry-run] Would delete %s\n", localPath)
+							addFileResult(jcdsSyncFileResult{FileName: name, Status: jcdsStatusWouldDelete})
+							deleted.Add(1)
+						}
+					}
+				}
+				for _, f := range jcdsFiles {
+					localPath := filepath.Join(flagDir, f.FileName)
+					if !localFiles[f.FileName] {
+						fmt.Fprintf(os.Stderr, "[dry-run] Would download %s (missing)\n", f.FileName)
+						addFileResult(jcdsSyncFileResult{FileName: f.FileName, Status: jcdsStatusWouldDownload})
+						downloaded.Add(1)
+						continue
+					}
+					if f.SHA3 != "" {
+						localHash, err := jcdsFileSHA3(localPath)
+						if err != nil {
+							return fmt.Errorf("hashing %s: %w", localPath, err)
+						}
+						if !strings.EqualFold(localHash, f.SHA3) {
+							fmt.Fprintf(os.Stderr, "[dry-run] Would update %s (SHA3-512 mismatch)\n", f.FileName)
+							addFileResult(jcdsSyncFileResult{FileName: f.FileName, Status: jcdsStatusWouldUpdate})
+							updated.Add(1)
+							continue
+						}
+					}
+					addFileResult(jcdsSyncFileResult{FileName: f.FileName, Status: jcdsStatusSkipped})
+					skipped.Add(1)
+				}
+			} else {
+				// Live run: delete orphans then download/update in parallel.
+				if flagDelete {
+					for name := range localFiles {
+						if _, onJCDS := jcdsSet[name]; !onJCDS {
+							localPath := filepath.Join(flagDir, name)
+							if err := os.Remove(localPath); err != nil {
+								fmt.Fprintf(os.Stderr, "warning: could not delete %s: %v\n", localPath, err)
+								addFileResult(jcdsSyncFileResult{FileName: name, Status: jcdsStatusFailed, Error: err.Error()})
+								failed.Add(1)
+								continue
+							}
+							fmt.Fprintf(os.Stderr, "Deleted %s (not on JCDS)\n", localPath)
+							addFileResult(jcdsSyncFileResult{FileName: name, Status: jcdsStatusDeleted})
+							deleted.Add(1)
+						}
+					}
+				}
+
+				// Dispatch ALL work (hashing + downloading) into the worker pool
+				// so the main goroutine never blocks on large-file SHA3 computation.
+				sem := make(chan struct{}, flagConcurrency)
+				var g errgroup.Group
+
+				for _, f := range jcdsFiles {
+					localPath := filepath.Join(flagDir, f.FileName)
+					exists := localFiles[f.FileName]
+
+					sem <- struct{}{}
+
+					g.Go(func() error {
+						defer func() { <-sem }()
+
+						if !exists {
+							if err := jcdsDownloadFile(reqCtx, cliCtx.Client, f.FileName, localPath); err != nil {
+								fmt.Fprintf(os.Stderr, "warning: skipping %s: %v\n", f.FileName, err)
+								addFileResult(jcdsSyncFileResult{FileName: f.FileName, Status: jcdsStatusFailed, Error: err.Error()})
+								failed.Add(1)
+								return nil
+							}
+							addFileResult(jcdsSyncFileResult{FileName: f.FileName, Status: jcdsStatusDownloaded})
+							downloaded.Add(1)
+							return nil
+						}
+
+						if f.SHA3 != "" {
+							localHash, err := jcdsFileSHA3(localPath)
+							if err != nil {
+								fmt.Fprintf(os.Stderr, "warning: skipping %s (hash error): %v\n", f.FileName, err)
+								addFileResult(jcdsSyncFileResult{FileName: f.FileName, Status: jcdsStatusFailed, Error: err.Error()})
+								failed.Add(1)
+								return nil
+							}
+							if !strings.EqualFold(localHash, f.SHA3) {
+								fmt.Fprintf(os.Stderr, "Updating %s (SHA3-512 changed)\n", f.FileName)
+								if err := jcdsDownloadFile(reqCtx, cliCtx.Client, f.FileName, localPath); err != nil {
+									fmt.Fprintf(os.Stderr, "warning: skipping %s: %v\n", f.FileName, err)
+									addFileResult(jcdsSyncFileResult{FileName: f.FileName, Status: jcdsStatusFailed, Error: err.Error()})
+									failed.Add(1)
+									return nil
+								}
+								addFileResult(jcdsSyncFileResult{FileName: f.FileName, Status: jcdsStatusUpdated})
+								updated.Add(1)
+								return nil
+							}
+						}
+
+						addFileResult(jcdsSyncFileResult{FileName: f.FileName, Status: jcdsStatusSkipped})
+						skipped.Add(1)
+						return nil
+					})
+				}
+
+				if err := g.Wait(); err != nil {
+					return err
+				}
+			}
+
+			report := jcdsSyncReport{
+				DryRun: flagDryRun,
+				Summary: jcdsSyncSummary{
+					Downloaded: downloaded.Load(),
+					Updated:    updated.Load(),
+					Deleted:    deleted.Load(),
+					UpToDate:   skipped.Load(),
+					Failed:     failed.Load(),
+				},
+				Files: fileResults,
+			}
+			data, err := json.Marshal(report)
+			if err != nil {
+				return fmt.Errorf("marshalling sync report: %w", err)
+			}
+			return cliCtx.Output.PrintRaw(data)
+		},
+	}
+
+	cmd.Flags().StringVar(&flagDir, "dir", "", "Local directory to sync into (required)")
+	cmd.Flags().BoolVar(&flagDelete, "delete", false, "Delete local files not present on JCDS")
+	cmd.Flags().BoolVarP(&flagDryRun, "dry-run", "n", false, "Preview changes without executing")
+	cmd.Flags().IntVar(&flagConcurrency, "concurrency", 4, "Number of parallel downloads")
+	_ = cmd.MarkFlagRequired("dir")
+
+	return cmd
+}

--- a/internal/commands/pro_jcds_test.go
+++ b/internal/commands/pro_jcds_test.go
@@ -1,0 +1,515 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"context"
+	"crypto/sha3"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+)
+
+// jcdsTestClient implements registry.HTTPClient backed by an httptest.Server.
+type jcdsTestClient struct {
+	srv *httptest.Server
+}
+
+func (c *jcdsTestClient) Do(_ context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	url := c.srv.URL + path
+	var req *http.Request
+	var err error
+	if body != nil {
+		req, err = http.NewRequest(method, url, body)
+	} else {
+		req, err = http.NewRequest(method, url, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return http.DefaultClient.Do(req)
+}
+
+// sha3hex returns the SHA3-512 hex of data.
+func sha3hex(data []byte) string {
+	h := sha3.New512()
+	_, _ = h.Write(data)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func TestJcdsFileSHA3(t *testing.T) {
+	content := []byte("hello jcds package")
+	f, err := os.CreateTemp(t.TempDir(), "*.pkg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := jcdsFileSHA3(f.Name())
+	if err != nil {
+		t.Fatalf("jcdsFileSHA3: %v", err)
+	}
+	want := sha3hex(content)
+	if got != want {
+		t.Errorf("SHA3 mismatch: got %s, want %s", got, want)
+	}
+}
+
+func TestJcdsDownloadFile(t *testing.T) {
+	fileContent := []byte("fake package content")
+
+	// Serve the pre-signed URL file content.
+	fileSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(fileContent)
+	}))
+	defer fileSrv.Close()
+
+	// Serve the JCDS API returning the pre-signed URL.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/jcds/files/test.pkg", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"uri": fileSrv.URL + "/download"})
+	})
+	apiSrv := httptest.NewServer(mux)
+	defer apiSrv.Close()
+
+	client := &jcdsTestClient{srv: apiSrv}
+	outPath := filepath.Join(t.TempDir(), "test.pkg")
+
+	if err := jcdsDownloadFile(context.Background(), client, "test.pkg", outPath); err != nil {
+		t.Fatalf("jcdsDownloadFile: %v", err)
+	}
+
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	if string(got) != string(fileContent) {
+		t.Errorf("content mismatch: got %q, want %q", got, fileContent)
+	}
+}
+
+func TestJcdsDownloadFile_APIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/jcds/files/missing.pkg", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := &jcdsTestClient{srv: srv}
+	outPath := filepath.Join(t.TempDir(), "missing.pkg")
+	err := jcdsDownloadFile(context.Background(), client, "missing.pkg", outPath)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected 404 in error, got: %v", err)
+	}
+}
+
+func TestJcdsDownloadFile_403Retry(t *testing.T) {
+	fileContent := []byte("retry test content")
+
+	hits := 0
+	fileSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if hits == 1 {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(fileContent)
+	}))
+	defer fileSrv.Close()
+
+	apiCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/jcds/files/retry.pkg", func(w http.ResponseWriter, r *http.Request) {
+		apiCalls++
+		_ = json.NewEncoder(w).Encode(map[string]string{"uri": fileSrv.URL + "/file"})
+	})
+	apiSrv := httptest.NewServer(mux)
+	defer apiSrv.Close()
+
+	outPath := filepath.Join(t.TempDir(), "retry.pkg")
+	if err := jcdsDownloadFile(context.Background(), &jcdsTestClient{srv: apiSrv}, "retry.pkg", outPath); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// URL must be fetched twice — initial + after 403.
+	if apiCalls != 2 {
+		t.Errorf("expected 2 API calls (initial + retry), got %d", apiCalls)
+	}
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(fileContent) {
+		t.Errorf("got %q, want %q", got, fileContent)
+	}
+}
+
+func TestJcdsSyncCmd_Download(t *testing.T) {
+	fileContent := []byte("pkg content for sync test")
+	fileHash := sha3hex(fileContent)
+
+	fileSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(fileContent)
+	}))
+	defer fileSrv.Close()
+
+	mux := http.NewServeMux()
+	// List endpoint.
+	mux.HandleFunc("/v1/jcds/files", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]jcdsFileData{
+			{FileName: "pkg-a.pkg", SHA3: fileHash},
+		})
+	})
+	// Get pre-signed URL.
+	mux.HandleFunc("/v1/jcds/files/pkg-a.pkg", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"uri": fileSrv.URL + "/pkg-a.pkg"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	ctx := &registry.CLIContext{Client: &jcdsTestClient{srv: srv}, Output: &captureOutput{}}
+	cmd := newJcdsSyncCmd(ctx)
+	cmd.SetArgs([]string{"--dir", dir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "pkg-a.pkg"))
+	if err != nil {
+		t.Fatalf("reading downloaded file: %v", err)
+	}
+	if string(got) != string(fileContent) {
+		t.Errorf("content mismatch: got %q, want %q", got, fileContent)
+	}
+}
+
+func TestJcdsSyncCmd_SkipUpToDate(t *testing.T) {
+	fileContent := []byte("already correct content")
+	fileHash := sha3hex(fileContent)
+
+	dir := t.TempDir()
+	// Pre-populate local file with matching content.
+	if err := os.WriteFile(filepath.Join(dir, "pkg-b.pkg"), fileContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	downloadCalled := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/jcds/files", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]jcdsFileData{
+			{FileName: "pkg-b.pkg", SHA3: fileHash},
+		})
+	})
+	mux.HandleFunc("/v1/jcds/files/pkg-b.pkg", func(w http.ResponseWriter, r *http.Request) {
+		downloadCalled = true
+		_ = json.NewEncoder(w).Encode(map[string]string{"uri": "http://should-not-be-called"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx := &registry.CLIContext{Client: &jcdsTestClient{srv: srv}, Output: &captureOutput{}}
+	cmd := newJcdsSyncCmd(ctx)
+	cmd.SetArgs([]string{"--dir", dir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if downloadCalled {
+		t.Error("download endpoint called for up-to-date file — should have been skipped")
+	}
+}
+
+func TestJcdsSyncCmd_UpdateChanged(t *testing.T) {
+	oldContent := []byte("old package content")
+	newContent := []byte("new package content")
+	newHash := sha3hex(newContent)
+
+	dir := t.TempDir()
+	// Pre-populate with old content (different hash).
+	if err := os.WriteFile(filepath.Join(dir, "pkg-c.pkg"), oldContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fileSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(newContent)
+	}))
+	defer fileSrv.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/jcds/files", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]jcdsFileData{
+			{FileName: "pkg-c.pkg", SHA3: newHash},
+		})
+	})
+	mux.HandleFunc("/v1/jcds/files/pkg-c.pkg", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"uri": fileSrv.URL + "/pkg-c.pkg"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx := &registry.CLIContext{Client: &jcdsTestClient{srv: srv}, Output: &captureOutput{}}
+	cmd := newJcdsSyncCmd(ctx)
+	cmd.SetArgs([]string{"--dir", dir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "pkg-c.pkg"))
+	if err != nil {
+		t.Fatalf("reading updated file: %v", err)
+	}
+	if string(got) != string(newContent) {
+		t.Errorf("file not updated: got %q, want %q", got, newContent)
+	}
+}
+
+func TestJcdsSyncCmd_DeleteOrphans(t *testing.T) {
+	dir := t.TempDir()
+	// Local file not on JCDS.
+	orphanPath := filepath.Join(dir, "orphan.pkg")
+	if err := os.WriteFile(orphanPath, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/jcds/files", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]jcdsFileData{}) // empty — nothing on JCDS
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx := &registry.CLIContext{Client: &jcdsTestClient{srv: srv}, Output: &captureOutput{}}
+	cmd := newJcdsSyncCmd(ctx)
+	cmd.SetArgs([]string{"--dir", dir, "--delete"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	if _, err := os.Stat(orphanPath); !os.IsNotExist(err) {
+		t.Error("orphan file should have been deleted but still exists")
+	}
+}
+
+func TestJcdsSyncCmd_DeleteOrphans_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	orphanPath := filepath.Join(dir, "orphan.pkg")
+	if err := os.WriteFile(orphanPath, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/jcds/files", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]jcdsFileData{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx := &registry.CLIContext{Client: &jcdsTestClient{srv: srv}, Output: &captureOutput{}}
+	cmd := newJcdsSyncCmd(ctx)
+	cmd.SetArgs([]string{"--dir", dir, "--delete", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	if _, err := os.Stat(orphanPath); os.IsNotExist(err) {
+		t.Error("dry-run should not delete orphan file")
+	}
+}
+
+func TestJcdsSyncCmd_InvalidConcurrency(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/jcds/files", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]jcdsFileData{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx := &registry.CLIContext{Client: &jcdsTestClient{srv: srv}, Output: &captureOutput{}}
+	cmd := newJcdsSyncCmd(ctx)
+	cmd.SetArgs([]string{"--dir", t.TempDir(), "--concurrency", "0"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --concurrency 0, got nil")
+	}
+	if !strings.Contains(err.Error(), "concurrency") {
+		t.Errorf("expected concurrency error, got: %v", err)
+	}
+}
+
+func TestJcdsSyncCmd_NoSHA3_NoRedownload(t *testing.T) {
+	fileContent := []byte("existing content")
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pkg-d.pkg"), fileContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	downloadCalled := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/jcds/files", func(w http.ResponseWriter, r *http.Request) {
+		// SHA3 field absent — API didn't return a hash.
+		_ = json.NewEncoder(w).Encode([]jcdsFileData{
+			{FileName: "pkg-d.pkg", SHA3: ""},
+		})
+	})
+	mux.HandleFunc("/v1/jcds/files/pkg-d.pkg", func(w http.ResponseWriter, r *http.Request) {
+		downloadCalled = true
+		_, _ = fmt.Fprint(w, `{"uri":"http://should-not-be-called"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx := &registry.CLIContext{Client: &jcdsTestClient{srv: srv}, Output: &captureOutput{}}
+	cmd := newJcdsSyncCmd(ctx)
+	cmd.SetArgs([]string{"--dir", dir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if downloadCalled {
+		t.Error("should not download when JCDS returns no SHA3 hash")
+	}
+}
+
+func TestJcdsSyncCmd_FailedDownload(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/jcds/files", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]jcdsFileData{
+			{FileName: "bad.pkg", SHA3: "somehash"},
+		})
+	})
+	// Return an API error for the presigned-URL fetch so the download fails.
+	mux.HandleFunc("/v1/jcds/files/bad.pkg", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"server error"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	out := &captureOutput{}
+	ctx := &registry.CLIContext{Client: &jcdsTestClient{srv: srv}, Output: out}
+	cmd := newJcdsSyncCmd(ctx)
+	cmd.SetArgs([]string{"--dir", t.TempDir()})
+
+	// Sync must complete without error — failed files are skipped, not fatal.
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sync should not fail on download error (skip-on-failure): %v", err)
+	}
+
+	var report jcdsSyncReport
+	if err := json.Unmarshal(out.rawData, &report); err != nil {
+		t.Fatalf("parsing report: %v (raw: %s)", err, out.rawData)
+	}
+	if report.Summary.Failed != 1 {
+		t.Errorf("failed: got %d, want 1", report.Summary.Failed)
+	}
+	if len(report.Files) != 1 {
+		t.Fatalf("files: got %d, want 1", len(report.Files))
+	}
+	if report.Files[0].Status != jcdsStatusFailed {
+		t.Errorf("status: got %q, want %q", report.Files[0].Status, jcdsStatusFailed)
+	}
+	if report.Files[0].Error == "" {
+		t.Error("error field should be non-empty for failed file")
+	}
+}
+
+func TestJcdsSyncCmd_StructuredResult(t *testing.T) {
+	fileContent := []byte("structured result test content")
+	fileHash := sha3hex(fileContent)
+
+	fileSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(fileContent)
+	}))
+	defer fileSrv.Close()
+
+	dir := t.TempDir()
+	// One existing up-to-date file, one missing file to download.
+	if err := os.WriteFile(filepath.Join(dir, "existing.pkg"), fileContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/jcds/files", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]jcdsFileData{
+			{FileName: "existing.pkg", SHA3: fileHash},
+			{FileName: "new.pkg", SHA3: "irrelevant-for-missing"},
+		})
+	})
+	mux.HandleFunc("/v1/jcds/files/new.pkg", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"uri": fileSrv.URL + "/new.pkg"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	out := &captureOutput{}
+	ctx := &registry.CLIContext{Client: &jcdsTestClient{srv: srv}, Output: out}
+	cmd := newJcdsSyncCmd(ctx)
+	cmd.SetArgs([]string{"--dir", dir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	var report jcdsSyncReport
+	if err := json.Unmarshal(out.rawData, &report); err != nil {
+		t.Fatalf("parsing sync report: %v (raw: %s)", err, out.rawData)
+	}
+
+	// Check summary counts.
+	if report.Summary.Downloaded != 1 {
+		t.Errorf("downloaded: got %d, want 1", report.Summary.Downloaded)
+	}
+	if report.Summary.UpToDate != 1 {
+		t.Errorf("upToDate: got %d, want 1", report.Summary.UpToDate)
+	}
+	if report.Summary.Updated != 0 || report.Summary.Deleted != 0 || report.Summary.Failed != 0 {
+		t.Errorf("unexpected counts: updated=%d deleted=%d failed=%d", report.Summary.Updated, report.Summary.Deleted, report.Summary.Failed)
+	}
+
+	// Check per-file entries.
+	if len(report.Files) != 2 {
+		t.Fatalf("files: got %d entries, want 2", len(report.Files))
+	}
+	filesByName := make(map[string]jcdsSyncFileResult, len(report.Files))
+	for _, f := range report.Files {
+		filesByName[f.FileName] = f
+	}
+	if filesByName["existing.pkg"].Status != jcdsStatusSkipped {
+		t.Errorf("existing.pkg: got status %q, want %q", filesByName["existing.pkg"].Status, jcdsStatusSkipped)
+	}
+	if filesByName["new.pkg"].Status != jcdsStatusDownloaded {
+		t.Errorf("new.pkg: got status %q, want %q", filesByName["new.pkg"].Status, jcdsStatusDownloaded)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `pro jcds download <fileName>` — fetches a pre-signed CloudFront URL and streams a JCDS file to disk; retries once on HTTP 403 (signed URL TTL expiry)
- Adds `pro jcds sync --dir <path>` (also aliased as `pro packages sync`) — syncs JCDS to a local directory for file-share distribution points; downloads missing files, re-downloads on SHA3-512 mismatch, optionally deletes local orphans (`--delete`), supports `--dry-run` and `--concurrency`
- Structured JSON/YAML/CSV output via the standard output formatter with per-file status and summary counts

## Implementation notes

- `jcdsStreamToFile` returns `(int64, error)` with a typed `*jcdsHTTPStatusError`; 403-retry path uses `errors.As` (idiomatic vs. triple `(int64, int, error)` return)
- Status values are named constants (`jcdsStatus*`); dry-run uses `would-download`/`would-update`/`would-delete` to distinguish from live runs
- `fileResults` capacity accounts for both JCDS files and local files (covers deletion entries)
- Dry-run and live paths are fully separated in a single `if/else` block
- Fixes a staticcheck SA5011 false-positive in `parser_test.go`

## Test plan

- [x] `TestJcdsFileSHA3` — SHA3-512 hash correctness
- [x] `TestJcdsDownloadFile` — happy path download
- [x] `TestJcdsDownloadFile_APIError` — API 404 surfaces as error
- [x] `TestJcdsDownloadFile_403Retry` — 403 triggers fresh URL fetch and retries (2 API calls)
- [x] `TestJcdsSyncCmd_Download` — missing file downloaded
- [x] `TestJcdsSyncCmd_SkipUpToDate` — matching SHA3 skips download
- [x] `TestJcdsSyncCmd_UpdateChanged` — SHA3 mismatch triggers re-download
- [x] `TestJcdsSyncCmd_DeleteOrphans` — local-only file removed with `--delete`
- [x] `TestJcdsSyncCmd_DeleteOrphans_DryRun` — `--dry-run` leaves file intact
- [x] `TestJcdsSyncCmd_InvalidConcurrency` — `--concurrency 0` returns error
- [x] `TestJcdsSyncCmd_NoSHA3_NoRedownload` — no SHA3 from API = skip redownload
- [x] `TestJcdsSyncCmd_FailedDownload` — download error recorded in report, sync continues
- [x] `TestJcdsSyncCmd_StructuredResult` — summary counts and per-file statuses correct

🤖 Generated with [Claude Code](https://claude.ai/claude-code)