### PR TITLE
fix(device): guard nil scope/deploymentState/target in platform sections

### DIFF
--- a/internal/commands/pro_device.go
+++ b/internal/commands/pro_device.go
@@ -517,10 +517,14 @@ func fetchDevicePlatformSections(ctx context.Context, cliCtx *registry.CLIContex
 			if err != nil {
 				continue
 			}
-			if !scopeOverlaps(detail.Scope.DeviceGroups, groupIDs) {
+			if detail.Scope == nil || !scopeOverlaps(detail.Scope.DeviceGroups, groupIDs) {
 				continue
 			}
-			items = append(items, overviewItem{detail.Name, detail.DeploymentState.State, ""})
+			state := ""
+			if detail.DeploymentState != nil {
+				state = detail.DeploymentState.State
+			}
+			items = append(items, overviewItem{detail.Name, state, ""})
 		}
 		if len(items) == 0 {
 			items = []overviewItem{{Resource: "(none)", Value: ""}}
@@ -542,7 +546,7 @@ func fetchDevicePlatformSections(ctx context.Context, cliCtx *registry.CLIContex
 			if err != nil {
 				continue
 			}
-			if !scopeOverlaps(bm.Target.DeviceGroups, groupIDs) {
+			if bm.Target == nil || !scopeOverlaps(bm.Target.DeviceGroups, groupIDs) {
 				continue
 			}
 			items = append(items, overviewItem{bm.Title, bm.EnforcementMode, ""})

--- a/internal/commands/pro_device_platform_test.go
+++ b/internal/commands/pro_device_platform_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+)
+
+// registerDevicePlatformFixtures registers the shared device-resolution and
+// device-groups endpoints used by all fetchDevicePlatformSections tests.
+// Device grp-a is always returned as the device's group membership.
+func registerDevicePlatformFixtures(mux *http.ServeMux) {
+	mux.HandleFunc("/api/devices/v1/tenant/"+testTenantID+"/devices", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"results":    []map[string]any{{"id": "dev-1", "serialNumber": "SN001"}},
+			"totalCount": 1,
+		})
+	})
+	mux.HandleFunc("/api/device-groups/v1/tenant/"+testTenantID+"/devices/dev-1/device-groups", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"results":    []map[string]any{{"groupId": "grp-a"}},
+			"totalCount": 1,
+		})
+	})
+	mux.HandleFunc("/api/ddm/report/v1/tenant/"+testTenantID+"/devices/dev-1", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"channels": []any{}})
+	})
+}
+
+// TestFetchDevicePlatformSections_NilBlueprintScope verifies that a blueprint
+// whose scope field is absent from the API response does not panic, and that
+// it is excluded from the output (nil scope never overlaps).
+func TestFetchDevicePlatformSections_NilBlueprintScope(t *testing.T) {
+	sdk, mux := newTestPlatformSDK(t)
+	registerDevicePlatformFixtures(mux)
+
+	mux.HandleFunc("/api/blueprints/v1/tenant/"+testTenantID+"/blueprints", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"results":    []map[string]any{{"id": "bp-1", "name": "Blueprint A"}},
+			"totalCount": 1,
+		})
+	})
+	// scope field absent — SDK deserialises Scope to nil *BlueprintScope
+	mux.HandleFunc("/api/blueprints/v1/tenant/"+testTenantID+"/blueprints/bp-1", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"id": "bp-1", "name": "Blueprint A"})
+	})
+	mux.HandleFunc("/api/compliance-benchmarks/v1/tenant/"+testTenantID+"/benchmarks", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"benchmarks": []any{}})
+	})
+
+	sections := fetchDevicePlatformSections(context.Background(), &registry.CLIContext{PlatformSDKClient: sdk}, "SN001")
+
+	bpSection := findPlatformSection(sections, "Platform Blueprints")
+	if bpSection == nil {
+		t.Fatal("Platform Blueprints section missing")
+	}
+	for _, item := range bpSection.Items {
+		if item.Resource == "Blueprint A" {
+			t.Error("blueprint with nil scope should be excluded from output")
+		}
+	}
+}
+
+// TestFetchDevicePlatformSections_NilDeploymentState verifies that a blueprint
+// with a scope that matches the device's group but an absent deploymentState
+// does not panic, and appears with an empty state string.
+func TestFetchDevicePlatformSections_NilDeploymentState(t *testing.T) {
+	sdk, mux := newTestPlatformSDK(t)
+	registerDevicePlatformFixtures(mux)
+
+	mux.HandleFunc("/api/blueprints/v1/tenant/"+testTenantID+"/blueprints", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"results":    []map[string]any{{"id": "bp-2", "name": "Blueprint B"}},
+			"totalCount": 1,
+		})
+	})
+	// scope includes grp-a (device's group); deploymentState absent → nil *DeploymentState
+	mux.HandleFunc("/api/blueprints/v1/tenant/"+testTenantID+"/blueprints/bp-2", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"id":    "bp-2",
+			"name":  "Blueprint B",
+			"scope": map[string]any{"deviceGroups": []string{"grp-a"}},
+		})
+	})
+	mux.HandleFunc("/api/compliance-benchmarks/v1/tenant/"+testTenantID+"/benchmarks", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"benchmarks": []any{}})
+	})
+
+	sections := fetchDevicePlatformSections(context.Background(), &registry.CLIContext{PlatformSDKClient: sdk}, "SN001")
+
+	bpSection := findPlatformSection(sections, "Platform Blueprints")
+	if bpSection == nil {
+		t.Fatal("Platform Blueprints section missing")
+	}
+	for _, item := range bpSection.Items {
+		if item.Resource == "Blueprint B" {
+			if item.Value != "" {
+				t.Errorf("nil deploymentState: state = %q, want empty string", item.Value)
+			}
+			return
+		}
+	}
+	t.Error("Blueprint B not found in Platform Blueprints section")
+}
+
+// TestFetchDevicePlatformSections_NilBenchmarkTarget verifies that a benchmark
+// whose target field is absent from the API response does not panic, and that
+// it is excluded from the output (nil target never overlaps).
+func TestFetchDevicePlatformSections_NilBenchmarkTarget(t *testing.T) {
+	sdk, mux := newTestPlatformSDK(t)
+	registerDevicePlatformFixtures(mux)
+
+	mux.HandleFunc("/api/blueprints/v1/tenant/"+testTenantID+"/blueprints", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"results": []any{}, "totalCount": 0})
+	})
+	mux.HandleFunc("/api/compliance-benchmarks/v1/tenant/"+testTenantID+"/benchmarks", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"benchmarks": []map[string]any{{"id": "cb-1", "title": "Benchmark X"}},
+		})
+	})
+	// target field absent — SDK deserialises Target to nil *TargetV2
+	mux.HandleFunc("/api/compliance-benchmarks/v1/tenant/"+testTenantID+"/benchmarks/cb-1", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"id": "cb-1", "title": "Benchmark X"})
+	})
+
+	sections := fetchDevicePlatformSections(context.Background(), &registry.CLIContext{PlatformSDKClient: sdk}, "SN001")
+
+	cbSection := findPlatformSection(sections, "Platform Compliance")
+	if cbSection == nil {
+		t.Fatal("Compliance Benchmarks section missing")
+	}
+	for _, item := range cbSection.Items {
+		if item.Resource == "Benchmark X" {
+			t.Error("benchmark with nil target should be excluded from output")
+		}
+	}
+}
+
+func findPlatformSection(sections []overviewSection, name string) *overviewSection {
+	for i := range sections {
+		if sections[i].Name == name {
+			return &sections[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #184

## Summary

- `BlueprintDetail.Scope`, `BlueprintDetail.DeploymentState`, and `BenchmarkResponseV2.Target` are `omitempty` pointer fields that can be `nil` when absent from API responses
- Dereferencing them without a nil check caused a nil pointer panic in `fetchDevicePlatformSections` goroutines (reported as `pro device <serial>` crashing in v1.10.0)
- Add nil guards before each dereference; nil scope/target → blueprint/benchmark excluded (no overlap); nil deploymentState → empty state string

## Test plan

- [x] `TestFetchDevicePlatformSections_NilBlueprintScope` — blueprint with absent scope field does not panic, is excluded from output
- [x] `TestFetchDevicePlatformSections_NilDeploymentState` — blueprint with matching scope but absent deploymentState does not panic, appears with empty state
- [x] `TestFetchDevicePlatformSections_NilBenchmarkTarget` — benchmark with absent target field does not panic, is excluded from output
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)