### PR TITLE
fix(ci): override generator + groups.go alongside docs/site on deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,5 +40,11 @@ jobs:
       - name: Verify site supports all products
         run: ./scripts/verify-site-products.sh
 
+      - name: Verify site JS files parse
+        run: |
+          for f in docs/site/*.js; do
+            node --check "$f" || { echo "JS syntax error in $f"; exit 1; }
+          done
+
       - name: Verify site output (generator runs, artifacts well-formed, pillar coverage)
         run: make verify-site-output

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -32,7 +32,21 @@ jobs:
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0)
           git checkout "$LATEST_TAG"
-          git checkout ${{ github.sha }} -- docs/site
+          # Build the CLI from the latest release tag (so deployed catalog
+          # reflects the released CLI), but pull these from main so site-only
+          # changes ship without waiting for a release:
+          #   docs/site/             — site UI, llms.txt seed, robots/sitemap
+          #   generator/site/        — generator must know about flags this
+          #                            workflow invokes (e.g. --llms-output)
+          #   internal/commands/groups.go — group taxonomy used when rendering
+          #                            commands.json. Pure data + apply-funcs;
+          #                            safe to override on top of older binary
+          #                            code. Entries for commands that don't
+          #                            exist in the tag silently no-op.
+          git checkout ${{ github.sha }} -- \
+            docs/site \
+            generator/site \
+            internal/commands/groups.go
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -82,3 +82,26 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+      - name: Smoke test deployed site
+        # Post-deploy assertion that everything we promised got served.
+        # Catches regressions like a broken upload step, missing assets,
+        # or a Pages config that swallowed our llms.txt / sitemap.xml.
+        run: |
+          URL="${{ steps.deployment.outputs.page_url }}"
+          URL="${URL%/}"
+          fail=0
+          for path in "" /commands.json /llms.txt /llms-full.txt /robots.txt /sitemap.xml; do
+            target="${URL}${path}"
+            if curl -fsSLI --retry 3 --retry-delay 2 -o /dev/null "$target"; then
+              echo "  OK   $target"
+            else
+              echo "  FAIL $target"
+              fail=1
+            fi
+          done
+          if [ $fail -ne 0 ]; then
+            echo "One or more deployed artifacts returned non-2xx."
+            exit 1
+          fi
+          echo "All deployed artifacts return 200."

--- a/.github/workflows/site-preflight.yaml
+++ b/.github/workflows/site-preflight.yaml
@@ -1,0 +1,66 @@
+name: Site Preflight
+
+# Simulates the deploy-site workflow's "build CLI from latest release tag,
+# overlay docs/site + generator/site + internal/commands/groups.go from
+# current SHA" strategy at PR time. Catches the failure class where the
+# workflow YAML invokes a generator flag that the older tag's binary code
+# doesn't recognise (PR #186 → #187 was the canonical example).
+#
+# Triggers only when files that would actually be overlaid are touched —
+# no point running this on README-only PRs.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/site/**'
+      - 'generator/site/**'
+      - 'internal/commands/groups.go'
+      - '.github/workflows/site-preflight.yaml'
+      - '.github/workflows/deploy-site.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Simulate deploy-site overlay (build from latest tag, overlay PR head)
+        run: |
+          PR_SHA=$(git rev-parse HEAD)
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          echo "PR HEAD:    $PR_SHA"
+          echo "Latest tag: $LATEST_TAG"
+          git checkout "$LATEST_TAG"
+          # Same overlay set as deploy-site.yaml. Keep this list in sync.
+          git checkout "$PR_SHA" -- \
+            docs/site \
+            generator/site \
+            internal/commands/groups.go
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build CLI (from overlaid working tree)
+        run: make build
+
+      - name: Generate site artifacts (deploy-parity invocation)
+        run: |
+          go run ./generator/site/main.go \
+            --binary ./bin/jamf-cli \
+            --output ./docs/site/commands.json \
+            --llms-output ./docs/site/llms.txt \
+            --llms-full-output ./docs/site/llms-full.txt
+
+      - name: Verify site supports all products
+        run: ./scripts/verify-site-products.sh
+
+      - name: Verify site output (artifacts well-formed, pillar coverage)
+        run: make verify-site-output

--- a/.github/workflows/site-preflight.yaml
+++ b/.github/workflows/site-preflight.yaml
@@ -37,11 +37,15 @@ jobs:
           echo "PR HEAD:    $PR_SHA"
           echo "Latest tag: $LATEST_TAG"
           git checkout "$LATEST_TAG"
-          # Same overlay set as deploy-site.yaml. Keep this list in sync.
+          # Same overlay set as deploy-site.yaml — keep this list in sync —
+          # PLUS scripts/verify-site-output.sh, which is post-v1.16.1 and
+          # so doesn't exist on the tag we just checked out. (deploy-site
+          # itself doesn't need it.)
           git checkout "$PR_SHA" -- \
             docs/site \
             generator/site \
-            internal/commands/groups.go
+            internal/commands/groups.go \
+            scripts/verify-site-output.sh
 
       - uses: actions/setup-go@v6
         with:
@@ -63,4 +67,13 @@ jobs:
         run: ./scripts/verify-site-products.sh
 
       - name: Verify site output (artifacts well-formed, pillar coverage)
-        run: make verify-site-output
+        # Call the script directly against the artifacts we generated above,
+        # rather than `make verify-site-output` — the make target was added
+        # after v1.16.1 and so isn't available in the tag's Makefile (and
+        # we don't overlay the Makefile, only the site/generator surface).
+        run: |
+          ./scripts/verify-site-output.sh \
+            --commands-json docs/site/commands.json \
+            --llms-txt docs/site/llms.txt \
+            --llms-full-txt docs/site/llms-full.txt \
+            --site-dir docs/site


### PR DESCRIPTION
## Summary

Two layers in this PR — the immediate fix that unblocks the failing deploy, plus three defense-in-depth safeguards so the next regression in this class fails at PR time instead of production-deploy time.

### The fix (commit 1)

After PR #186 merged, the next push-to-`main` deploy failed with `flag provided but not defined: -llms-output`. Root cause:

- The deploy workflow checks out the latest release tag (`v1.16.1`) for the binary build (so the deployed catalog reflects released CLI behaviour) and overlays current `main`'s content on top.
- The overlay was scoped to `docs/site/` only.
- PR #186 added `--llms-output` and `--llms-full-output` flags to `generator/site/main.go`, and updated the deploy workflow YAML to invoke them — but `v1.16.1`'s generator code doesn't know those flags.

Fix: expand the deploy overlay to also pull `generator/site/` and `internal/commands/groups.go` from current `main`. The CLI is still built from the latest release tag's binary code; only the generator that runs and the group taxonomy embedded in the binary at compile time come from `main`. `groups.go` is pure data plus apply-funcs over cobra — entries for commands that don't exist in the tag silently no-op, so nothing breaks.

Failing run: https://github.com/Jamf-Concepts/jamf-cli/actions/runs/25515591769

### Defense in depth (commits 2–3)

Three additive guardrails covering the failure modes around this kind of change:

1. **`.github/workflows/site-preflight.yaml` (NEW)** — runs on every PR that touches `docs/site/**`, `generator/site/**`, `internal/commands/groups.go`, or either deploy-related workflow. Simulates the exact "build CLI from latest tag, overlay PR head" strategy the deploy uses, then runs the same generator invocation plus `verify-site-products.sh` and `verify-site-output.sh`. **Would have caught PR #186's bug at PR review time** instead of waiting for deploy.
2. **`.github/workflows/ci.yaml`** — adds a `node --check` step over `docs/site/*.js`. Catches syntax errors in `palette.js`, `catalog.js`, or `terminal.js` that today's CI would miss (the existing checks grep for product-marker patterns but never parse the JS).
3. **`.github/workflows/deploy-site.yaml`** — appends a post-deploy smoke test that `curl`s `/`, `commands.json`, `llms.txt`, `llms-full.txt`, `robots.txt`, and `sitemap.xml` against the deployed Pages URL. Fails the workflow on any non-2xx — catches missing-asset / upload-step / Pages-config regressions that the deploy step itself would silently green-light.

### Self-validation

The preflight workflow caught a real bug on its first run — `make verify-site-output` failed in the simulated environment because the Makefile target and the script behind it were both added after `v1.16.1` and weren't in the overlay set (commit 3 fixes this). That's exactly the failure class the preflight was designed to catch — workflow code on PR head invoking machinery the tag's binary code doesn't know about. The safeguard worked as intended; the bug was in my own overlay set, surfaced at PR time. Confidence-builder.

## Test plan

- [x] Preflight workflow passes on this branch (just ran green: https://github.com/Jamf-Concepts/jamf-cli/actions/runs/25516946836)
- [x] CI passes on this branch including the new `node --check` step (just ran green: https://github.com/Jamf-Concepts/jamf-cli/actions/runs/25516946816)
- [ ] On merge: deploy succeeds (the original failure case)
- [ ] On merge: post-deploy smoke test reports all 6 artifacts returning 200
- [ ] After deploy: visit https://jamf-concepts.github.io/jamf-cli/ — pillar dividers (`QUICK ACCESS`, `DEVICES`, `SOFTWARE & CONTENT`, etc.) appear in the Pro tab
- [ ] `https://jamf-concepts.github.io/jamf-cli/llms.txt` returns 200
- [ ] `https://jamf-concepts.github.io/jamf-cli/llms-full.txt` returns 200 with the full command catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)
