### PR TITLE
feat(output): add --compact flag for token-efficient agent output

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -41,6 +41,7 @@ var (
 	noColor      bool
 	dryRun       bool
 	wide         bool
+	compact      bool
 	outFile      string
 	fieldName    string
 	serverURL    string
@@ -444,6 +445,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 			if outFileHandle != nil {
 				formatter.SetWriter(outFileHandle)
 			}
+			formatter.SetProjector(output.Projector{Compact: compact})
 			cliCtx.Output = &cliOutput{formatter}
 
 			// Skip auth for commands that don't need it. Most are matched
@@ -564,6 +566,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 	cmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "disable colored output")
 	cmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "n", false, "preview changes without executing")
 	cmd.PersistentFlags().BoolVarP(&wide, "wide", "w", false, "show all columns in table output")
+	cmd.PersistentFlags().BoolVar(&compact, "compact", false, "drop arrays and nested objects, keep only scalar fields (smaller payloads for agents)")
 	cmd.PersistentFlags().StringVar(&outFile, "out-file", "", "write output to file instead of stdout")
 	cmd.PersistentFlags().StringVar(&fieldName, "field", "", "extract a single field from JSON response (e.g., --field id)")
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -566,7 +566,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 	cmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "disable colored output")
 	cmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "n", false, "preview changes without executing")
 	cmd.PersistentFlags().BoolVarP(&wide, "wide", "w", false, "show all columns in table output")
-	cmd.PersistentFlags().BoolVar(&compact, "compact", false, "drop arrays and nested objects, keep only scalar fields (smaller payloads for agents)")
+	cmd.PersistentFlags().BoolVar(&compact, "compact", false, "drop arrays and nested objects, keep only scalar fields (smaller payloads for agents; ignored when --field is set)")
 	cmd.PersistentFlags().StringVar(&outFile, "out-file", "", "write output to file instead of stdout")
 	cmd.PersistentFlags().StringVar(&fieldName, "field", "", "extract a single field from JSON response (e.g., --field id)")
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -56,15 +56,22 @@ var nowFunc = time.Now
 
 // Formatter handles output formatting
 type Formatter struct {
-	format  Format
-	writer  io.Writer
-	noColor bool
-	wide    bool
+	format    Format
+	writer    io.Writer
+	noColor   bool
+	wide      bool
+	projector Projector
 }
 
 // SetWriter replaces the output destination.
 func (f *Formatter) SetWriter(w io.Writer) {
 	f.writer = w
+}
+
+// SetProjector configures field-level projection (e.g. --compact) applied
+// before format-specific rendering. A zero-value projector is a no-op.
+func (f *Formatter) SetProjector(p Projector) {
+	f.projector = p
 }
 
 // Format returns the current output format string.
@@ -129,6 +136,7 @@ func New(format string, noColor bool, wide bool) *Formatter {
 
 // Print outputs data in the configured format
 func (f *Formatter) Print(data any) error {
+	data = f.applyProjection(data)
 	switch f.format {
 	case FormatJSON:
 		return f.printJSON(data)
@@ -141,6 +149,26 @@ func (f *Formatter) Print(data any) error {
 	default:
 		return f.printTable(data)
 	}
+}
+
+// applyProjection runs the configured Projector over rows when data is
+// shaped as a list/object of maps. Other shapes (scalars, mixed arrays)
+// pass through unchanged so projection never breaks unusual responses.
+func (f *Formatter) applyProjection(data any) any {
+	if f.projector.IsZero() {
+		return data
+	}
+	switch v := data.(type) {
+	case []map[string]any:
+		return f.projector.Apply(v)
+	case map[string]any:
+		projected := f.projector.Apply([]map[string]any{v})
+		if len(projected) == 1 {
+			return projected[0]
+		}
+		return data
+	}
+	return data
 }
 
 func (f *Formatter) printJSON(data any) error {
@@ -315,7 +343,7 @@ func (f *Formatter) PrintRaw(data []byte) error {
 		}
 	}
 
-	if f.format == FormatJSON || f.format == FormatJSONMulti {
+	if (f.format == FormatJSON || f.format == FormatJSONMulti) && f.projector.IsZero() {
 		// Pretty-print JSON so compact API responses become readable
 		var buf bytes.Buffer
 		if err := json.Indent(&buf, data, "", "  "); err != nil {
@@ -328,12 +356,22 @@ func (f *Formatter) PrintRaw(data []byte) error {
 		return err
 	}
 
-	// For non-JSON formats: parse, normalize, then format
+	// For non-JSON formats — and JSON output with projection — parse,
+	// normalize, then format. Projection in Print() applies before rendering.
 	var parsed any
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		// Not JSON, print as-is
 		_, writeErr := f.writer.Write(data)
 		return writeErr
+	}
+
+	// Shape-preserving JSON output: keep single objects as objects,
+	// arrays as arrays, instead of routing through normalizeJSON which
+	// always emits arrays.
+	if f.format == FormatJSON || f.format == FormatJSONMulti {
+		if obj, ok := parsed.(map[string]any); ok {
+			return f.printJSON(f.applyProjection(obj))
+		}
 	}
 
 	return f.Print(normalizeJSON(parsed))

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -154,6 +154,10 @@ func (f *Formatter) Print(data any) error {
 // applyProjection runs the configured Projector over rows when data is
 // shaped as a list/object of maps. Other shapes (scalars, mixed arrays)
 // pass through unchanged so projection never breaks unusual responses.
+//
+// Handles all three shapes that PrintRaw and direct Print callers produce:
+// pre-normalized []map[string]any, raw json.Unmarshal []any of maps, and
+// single map[string]any (preserved as object so JSON output stays an object).
 func (f *Formatter) applyProjection(data any) any {
 	if f.projector.IsZero() {
 		return data
@@ -167,6 +171,17 @@ func (f *Formatter) applyProjection(data any) any {
 			return projected[0]
 		}
 		return data
+	case []any:
+		rows := make([]map[string]any, 0, len(v))
+		for _, item := range v {
+			m, ok := item.(map[string]any)
+			if !ok {
+				// Mixed array — projection can't apply uniformly.
+				return data
+			}
+			rows = append(rows, m)
+		}
+		return f.projector.Apply(rows)
 	}
 	return data
 }
@@ -344,7 +359,9 @@ func (f *Formatter) PrintRaw(data []byte) error {
 	}
 
 	if (f.format == FormatJSON || f.format == FormatJSONMulti) && f.projector.IsZero() {
-		// Pretty-print JSON so compact API responses become readable
+		// Fast path: indent the wire bytes directly. This preserves the API's
+		// key ordering, which json.Encode on a parsed map[string]any would lose
+		// (Go encodes maps with alphabetically sorted keys).
 		var buf bytes.Buffer
 		if err := json.Indent(&buf, data, "", "  "); err != nil {
 			// Not valid JSON, print as-is
@@ -356,8 +373,6 @@ func (f *Formatter) PrintRaw(data []byte) error {
 		return err
 	}
 
-	// For non-JSON formats — and JSON output with projection — parse,
-	// normalize, then format. Projection in Print() applies before rendering.
 	var parsed any
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		// Not JSON, print as-is
@@ -365,21 +380,23 @@ func (f *Formatter) PrintRaw(data []byte) error {
 		return writeErr
 	}
 
-	// Shape-preserving JSON output: keep single objects as objects,
-	// arrays as arrays, instead of routing through normalizeJSON which
-	// always emits arrays.
-	if f.format == FormatJSON || f.format == FormatJSONMulti {
-		if obj, ok := parsed.(map[string]any); ok {
-			return f.printJSON(f.applyProjection(obj))
-		}
+	// JSON and YAML preserve the parsed shape natively (object stays object,
+	// array stays array). Tabular formats (table/csv/plain) require rows, so
+	// coerce via normalizeForTabular. Print's applyProjection handles both
+	// map[string]any and []map[string]any.
+	switch f.format {
+	case FormatJSON, FormatJSONMulti, FormatYAML:
+		return f.Print(parsed)
+	default:
+		return f.Print(normalizeForTabular(parsed))
 	}
-
-	return f.Print(normalizeJSON(parsed))
 }
 
-// normalizeJSON converts parsed JSON types into the []map[string]interface{}
-// form that table/csv/plain formatters expect.
-func normalizeJSON(data any) any {
+// normalizeForTabular converts parsed JSON types into the []map[string]any
+// form that table/csv/plain formatters expect. Single objects are wrapped
+// into a one-element slice. Not used for JSON/YAML output, which preserves
+// the parsed shape.
+func normalizeForTabular(data any) any {
 	switch v := data.(type) {
 	case []any:
 		// Convert []interface{} of objects to []map[string]interface{}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -596,14 +596,14 @@ func TestSortedKeys_NoIdNoName(t *testing.T) {
 	}
 }
 
-// --- normalizeJSON tests ---
+// --- normalizeForTabular tests ---
 
-func TestNormalizeJSON_SliceOfMaps(t *testing.T) {
+func TestNormalizeForTabular_SliceOfMaps(t *testing.T) {
 	input := []any{
 		map[string]any{"id": float64(1)},
 		map[string]any{"id": float64(2)},
 	}
-	result := normalizeJSON(input)
+	result := normalizeForTabular(input)
 	slice, ok := result.([]map[string]any)
 	if !ok {
 		t.Fatalf("expected []map[string]interface{}, got %T", result)
@@ -613,9 +613,9 @@ func TestNormalizeJSON_SliceOfMaps(t *testing.T) {
 	}
 }
 
-func TestNormalizeJSON_SingleMap(t *testing.T) {
+func TestNormalizeForTabular_SingleMap(t *testing.T) {
 	input := map[string]any{"id": float64(1), "name": "test"}
-	result := normalizeJSON(input)
+	result := normalizeForTabular(input)
 	slice, ok := result.([]map[string]any)
 	if !ok {
 		t.Fatalf("expected []map[string]interface{}, got %T", result)
@@ -625,9 +625,9 @@ func TestNormalizeJSON_SingleMap(t *testing.T) {
 	}
 }
 
-func TestNormalizeJSON_ScalarString(t *testing.T) {
+func TestNormalizeForTabular_ScalarString(t *testing.T) {
 	input := "hello"
-	result := normalizeJSON(input)
+	result := normalizeForTabular(input)
 	s, ok := result.(string)
 	if !ok {
 		t.Fatalf("expected string, got %T", result)
@@ -637,14 +637,14 @@ func TestNormalizeJSON_ScalarString(t *testing.T) {
 	}
 }
 
-func TestNormalizeJSON_MixedArray(t *testing.T) {
+func TestNormalizeForTabular_MixedArray(t *testing.T) {
 	// Mixed array should return raw data, not drop non-map items
 	input := []any{
 		map[string]any{"id": "1"},
 		"stray string",
 		map[string]any{"id": "2"},
 	}
-	result := normalizeJSON(input)
+	result := normalizeForTabular(input)
 	// Should return the original data unchanged (not []map[string]interface{})
 	arr, ok := result.([]any)
 	if !ok {
@@ -655,9 +655,9 @@ func TestNormalizeJSON_MixedArray(t *testing.T) {
 	}
 }
 
-func TestNormalizeJSON_EmptySlice(t *testing.T) {
+func TestNormalizeForTabular_EmptySlice(t *testing.T) {
 	input := []any{}
-	result := normalizeJSON(input)
+	result := normalizeForTabular(input)
 	slice, ok := result.([]map[string]any)
 	if !ok {
 		t.Fatalf("expected []map[string]interface{}, got %T", result)

--- a/internal/output/project.go
+++ b/internal/output/project.go
@@ -49,9 +49,11 @@ func projectCompact(rows []map[string]any) []map[string]any {
 }
 
 // isScalar reports whether v is a primitive worth keeping in --compact mode.
+// nil is excluded so null fields are dropped, matching flattenMap's behavior
+// for nested nulls and keeping compact output free of empty values.
 func isScalar(v any) bool {
 	switch v.(type) {
-	case nil, bool, string, float64, float32,
+	case bool, string, float64, float32,
 		int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64:
 		return true

--- a/internal/output/project.go
+++ b/internal/output/project.go
@@ -1,0 +1,60 @@
+// Copyright 2026, Jamf Software LLC
+
+package output
+
+// Projector applies field-level projection to flattened rows before
+// format-specific rendering. Compact keeps only scalar fields after
+// flattening, dropping arrays and nested remnants. The projector is shared
+// by every output format (json, table, csv, yaml, plain) so --compact
+// behaves consistently.
+type Projector struct {
+	Compact bool
+}
+
+// IsZero reports whether the projector has no rules configured.
+func (p Projector) IsZero() bool {
+	return !p.Compact
+}
+
+// Apply returns rows projected per the configured rules.
+// Always flattens nested objects to dot keys so projection sees a flat shape.
+// Empty rows pass through unchanged.
+func (p Projector) Apply(rows []map[string]any) []map[string]any {
+	if p.IsZero() || len(rows) == 0 {
+		return rows
+	}
+	flat := flattenRows(rows)
+	if p.Compact {
+		return projectCompact(flat)
+	}
+	return flat
+}
+
+// projectCompact keeps only scalar values from flattened rows.
+// flattenRows already lifts nested objects to dot keys, so what remains
+// non-scalar here is arrays — which are the bulk of the token cost in
+// Jamf Pro list responses.
+func projectCompact(rows []map[string]any) []map[string]any {
+	out := make([]map[string]any, len(rows))
+	for i, row := range rows {
+		compact := make(map[string]any, len(row))
+		for k, v := range row {
+			if isScalar(v) {
+				compact[k] = v
+			}
+		}
+		out[i] = compact
+	}
+	return out
+}
+
+// isScalar reports whether v is a primitive worth keeping in --compact mode.
+func isScalar(v any) bool {
+	switch v.(type) {
+	case nil, bool, string, float64, float32,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64:
+		return true
+	}
+	return false
+}

--- a/internal/output/project_test.go
+++ b/internal/output/project_test.go
@@ -5,6 +5,7 @@ package output
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -67,6 +68,23 @@ func TestProjector_Compact_FlattensNested(t *testing.T) {
 	}
 	if _, ok := got[0]["general"]; ok {
 		t.Errorf("compact should not retain nested object key, got %v", got[0])
+	}
+}
+
+func TestProjector_Compact_DropsNil(t *testing.T) {
+	rows := []map[string]any{{
+		"id":   1.0,
+		"name": "device-01",
+		// Top-level nil — without the fix this survived compact, while
+		// nested nils were dropped by flattenMap. Now both paths agree.
+		"description": nil,
+	}}
+	got := Projector{Compact: true}.Apply(rows)
+	if _, ok := got[0]["description"]; ok {
+		t.Errorf("compact should drop nil fields, got %v", got[0])
+	}
+	if got[0]["id"] != 1.0 || got[0]["name"] != "device-01" {
+		t.Errorf("compact should keep non-nil scalars, got %v", got[0])
 	}
 }
 
@@ -162,5 +180,50 @@ func TestFormatter_PrintRaw_JSON_Compact_Array(t *testing.T) {
 		if _, ok := row["id"]; !ok {
 			t.Errorf("row %d should keep id, got %v", i, row)
 		}
+	}
+}
+
+// Every output format runs through the same applyProjection hook in Print,
+// so --compact should drop arrays from rendered bytes regardless of format.
+func TestFormatter_Print_Compact_AllFormats(t *testing.T) {
+	rows := []map[string]any{{
+		"id":       1.0,
+		"name":     "device-01",
+		"profiles": []any{"a", "b"},
+	}}
+
+	cases := []struct {
+		format Format
+		// "name" is the column to confirm a row rendered; absence of
+		// "profiles" confirms the array was dropped.
+		mustContain    string
+		mustNotContain string
+	}{
+		{FormatTable, "device-01", "profiles"},
+		{FormatCSV, "device-01", "profiles"},
+		{FormatYAML, "device-01", "profiles"},
+		{FormatPlain, "device-01", "profiles"},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.format), func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			f := &Formatter{
+				format:    tc.format,
+				writer:    buf,
+				noColor:   true,
+				projector: Projector{Compact: true},
+			}
+			if err := f.Print(rows); err != nil {
+				t.Fatalf("Print failed: %v", err)
+			}
+			out := buf.String()
+			if !strings.Contains(out, tc.mustContain) {
+				t.Errorf("%s: expected output to contain %q, got %q", tc.format, tc.mustContain, out)
+			}
+			if strings.Contains(out, tc.mustNotContain) {
+				t.Errorf("%s: compact should drop %q, got %q", tc.format, tc.mustNotContain, out)
+			}
+		})
 	}
 }

--- a/internal/output/project_test.go
+++ b/internal/output/project_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026, Jamf Software LLC
+
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestProjector_IsZero(t *testing.T) {
+	if !(Projector{}).IsZero() {
+		t.Error("zero-value Projector should report IsZero")
+	}
+	if (Projector{Compact: true}).IsZero() {
+		t.Error("Compact=true should not report IsZero")
+	}
+}
+
+func TestProjector_Apply_NoOp(t *testing.T) {
+	rows := []map[string]any{{"id": 1.0, "name": "a"}}
+	got := Projector{}.Apply(rows)
+	if len(got) != 1 || got[0]["id"] != 1.0 || got[0]["name"] != "a" {
+		t.Errorf("zero projector should return rows unchanged, got %v", got)
+	}
+}
+
+func TestProjector_Apply_Empty(t *testing.T) {
+	got := Projector{Compact: true}.Apply(nil)
+	if got != nil {
+		t.Errorf("nil rows should pass through, got %v", got)
+	}
+}
+
+func TestProjector_Compact_DropsArrays(t *testing.T) {
+	rows := []map[string]any{{
+		"id":       1.0,
+		"name":     "device-01",
+		"profiles": []any{"a", "b", "c"},
+		"groups":   []any{},
+	}}
+	got := Projector{Compact: true}.Apply(rows)
+	if _, ok := got[0]["profiles"]; ok {
+		t.Errorf("compact should drop array fields, got %v", got[0])
+	}
+	if got[0]["id"] != 1.0 || got[0]["name"] != "device-01" {
+		t.Errorf("compact should keep scalars, got %v", got[0])
+	}
+}
+
+func TestProjector_Compact_FlattensNested(t *testing.T) {
+	rows := []map[string]any{{
+		"id": 1.0,
+		"general": map[string]any{
+			"name":     "device-01",
+			"platform": "Mac",
+		},
+	}}
+	got := Projector{Compact: true}.Apply(rows)
+	// Single-section nested object: only "general.*" keys, so
+	// stripCommonPrefix collapses to "name", "platform".
+	if got[0]["name"] != "device-01" {
+		t.Errorf("expected flattened name=device-01, got %v", got[0])
+	}
+	if got[0]["platform"] != "Mac" {
+		t.Errorf("expected flattened platform=Mac, got %v", got[0])
+	}
+	if _, ok := got[0]["general"]; ok {
+		t.Errorf("compact should not retain nested object key, got %v", got[0])
+	}
+}
+
+func TestProjector_Compact_PreservesScalarTypes(t *testing.T) {
+	rows := []map[string]any{{
+		"id":      1.0,
+		"managed": true,
+		"version": "10.15",
+	}}
+	got := Projector{Compact: true}.Apply(rows)
+	if got[0]["managed"] != true {
+		t.Errorf("expected managed=true, got %v", got[0]["managed"])
+	}
+	if got[0]["id"] != 1.0 {
+		t.Errorf("expected id=1.0, got %v", got[0]["id"])
+	}
+	if got[0]["version"] != "10.15" {
+		t.Errorf("expected version=10.15, got %v", got[0]["version"])
+	}
+}
+
+// Formatter integration: PrintRaw with --compact on JSON should drop arrays
+// in the actual output, not just in the parsed projection.
+func TestFormatter_PrintRaw_JSON_Compact(t *testing.T) {
+	buf := &bytes.Buffer{}
+	f := &Formatter{
+		format:    FormatJSON,
+		writer:    buf,
+		projector: Projector{Compact: true},
+	}
+
+	input := `{"id":1,"name":"d1","profiles":["a","b"]}`
+	if err := f.PrintRaw([]byte(input)); err != nil {
+		t.Fatalf("PrintRaw failed: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("output not valid JSON: %v\nOutput: %s", err, buf.String())
+	}
+	if _, ok := out["profiles"]; ok {
+		t.Errorf("compact should drop profiles array, got %v", out)
+	}
+	if out["id"] != 1.0 || out["name"] != "d1" {
+		t.Errorf("compact should keep id/name, got %v", out)
+	}
+}
+
+func TestFormatter_PrintRaw_JSON_NoProjector_Unchanged(t *testing.T) {
+	buf := &bytes.Buffer{}
+	f := &Formatter{
+		format: FormatJSON,
+		writer: buf,
+	}
+	input := `{"id":1,"profiles":["a"]}`
+	if err := f.PrintRaw([]byte(input)); err != nil {
+		t.Fatalf("PrintRaw failed: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	if _, ok := out["profiles"]; !ok {
+		t.Errorf("without projector, profiles should be retained, got %v", out)
+	}
+}
+
+// Array input with --compact should drop arrays from each row.
+func TestFormatter_PrintRaw_JSON_Compact_Array(t *testing.T) {
+	buf := &bytes.Buffer{}
+	f := &Formatter{
+		format:    FormatJSON,
+		writer:    buf,
+		projector: Projector{Compact: true},
+	}
+
+	input := `[{"id":1,"profiles":["a"]},{"id":2,"profiles":["b","c"]}]`
+	if err := f.PrintRaw([]byte(input)); err != nil {
+		t.Fatalf("PrintRaw failed: %v", err)
+	}
+
+	var out []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("output not valid JSON array: %v\nOutput: %s", err, buf.String())
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(out))
+	}
+	for i, row := range out {
+		if _, ok := row["profiles"]; ok {
+			t.Errorf("row %d should drop profiles, got %v", i, row)
+		}
+		if _, ok := row["id"]; !ok {
+			t.Errorf("row %d should keep id, got %v", i, row)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--compact` global flag that drops arrays and nested-object remnants from output, keeping only scalar fields (id, name, serial, timestamps, status, etc.)
- Inspired by [cli-printing-press](https://github.com/mvanhorn/cli-printing-press)'s `--compact` mode — designed for agents that call commands thousands of times a day and don't need full payload nesting
- All output formats (json/yaml/csv/table/plain) honor it via a single `output.Projector` plumbed through the existing `Formatter`
- JSON output preserves single-object vs array shape (a single resource stays a single resource)

## Why

Jamf Pro list responses are *huge* — a single computer record drags in policies, profiles, extension attributes, certificates, plugins. Agents calling `pro computers list` mostly want id+name+serial+lastContactTime to feed into the next command. `--compact` gives them that without forcing them to write `--field` once per scalar.

## Test plan

- [x] `go test ./internal/output/...` — projection unit tests + formatter integration tests
- [x] `go test ./...` — full suite green
- [x] `make lint` — 0 issues
- [x] `make verify-generated` — generated code unchanged
- [x] `bin/jamf-cli --help` shows `--compact` line

## Notes

This is the first of four "cheap wins" pulled from cli-printing-press; follow-up PRs will add `--select`, a list-narrowing hint, and a `doctor` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)