### PR TITLE
feat(output): add --select flag for multi-field projection

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -41,6 +41,7 @@ var (
 	noColor      bool
 	dryRun       bool
 	wide         bool
+	compact      bool
 	outFile      string
 	fieldName    string
 	serverURL    string
@@ -444,6 +445,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 			if outFileHandle != nil {
 				formatter.SetWriter(outFileHandle)
 			}
+			formatter.SetProjector(output.Projector{Compact: compact})
 			cliCtx.Output = &cliOutput{formatter}
 
 			// Skip auth for commands that don't need it. Most are matched
@@ -564,6 +566,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 	cmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "disable colored output")
 	cmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "n", false, "preview changes without executing")
 	cmd.PersistentFlags().BoolVarP(&wide, "wide", "w", false, "show all columns in table output")
+	cmd.PersistentFlags().BoolVar(&compact, "compact", false, "drop arrays and nested objects, keep only scalar fields (smaller payloads for agents)")
 	cmd.PersistentFlags().StringVar(&outFile, "out-file", "", "write output to file instead of stdout")
 	cmd.PersistentFlags().StringVar(&fieldName, "field", "", "extract a single field from JSON response (e.g., --field id)")
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -447,6 +447,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 				formatter.SetWriter(outFileHandle)
 			}
 			formatter.SetProjector(output.Projector{Compact: compact, Select: selectFields})
+			formatter.SetQuiet(quiet)
 			cliCtx.Output = &cliOutput{formatter}
 
 			// Skip auth for commands that don't need it. Most are matched

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -42,6 +42,7 @@ var (
 	dryRun       bool
 	wide         bool
 	compact      bool
+	selectFields []string
 	outFile      string
 	fieldName    string
 	serverURL    string
@@ -445,7 +446,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 			if outFileHandle != nil {
 				formatter.SetWriter(outFileHandle)
 			}
-			formatter.SetProjector(output.Projector{Compact: compact})
+			formatter.SetProjector(output.Projector{Compact: compact, Select: selectFields})
 			cliCtx.Output = &cliOutput{formatter}
 
 			// Skip auth for commands that don't need it. Most are matched
@@ -567,6 +568,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 	cmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "n", false, "preview changes without executing")
 	cmd.PersistentFlags().BoolVarP(&wide, "wide", "w", false, "show all columns in table output")
 	cmd.PersistentFlags().BoolVar(&compact, "compact", false, "drop arrays and nested objects, keep only scalar fields (smaller payloads for agents)")
+	cmd.PersistentFlags().StringSliceVar(&selectFields, "select", nil, "project output to these dot-path fields only (e.g., --select id,general.name,udid)")
 	cmd.PersistentFlags().StringVar(&outFile, "out-file", "", "write output to file instead of stdout")
 	cmd.PersistentFlags().StringVar(&fieldName, "field", "", "extract a single field from JSON response (e.g., --field id)")
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -566,7 +566,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 	cmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "disable colored output")
 	cmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "n", false, "preview changes without executing")
 	cmd.PersistentFlags().BoolVarP(&wide, "wide", "w", false, "show all columns in table output")
-	cmd.PersistentFlags().BoolVar(&compact, "compact", false, "drop arrays and nested objects, keep only scalar fields (smaller payloads for agents)")
+	cmd.PersistentFlags().BoolVar(&compact, "compact", false, "drop arrays and nested objects, keep only scalar fields (smaller payloads for agents; ignored when --field is set)")
 	cmd.PersistentFlags().StringVar(&outFile, "out-file", "", "write output to file instead of stdout")
 	cmd.PersistentFlags().StringVar(&fieldName, "field", "", "extract a single field from JSON response (e.g., --field id)")
 

--- a/internal/output/list_hint_test.go
+++ b/internal/output/list_hint_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026, Jamf Software LLC
+
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func newTestFormatterWithStderr(format string) (*Formatter, *bytes.Buffer, *bytes.Buffer) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	f := &Formatter{
+		format:  Format(format),
+		writer:  stdout,
+		stderr:  stderr,
+		noColor: true,
+	}
+	return f, stdout, stderr
+}
+
+// makeRows builds n minimal rows for hint-threshold tests.
+func makeRows(n int) []map[string]any {
+	rows := make([]map[string]any, n)
+	for i := range rows {
+		rows[i] = map[string]any{"id": float64(i), "name": "row"}
+	}
+	return rows
+}
+
+func TestListHint_FiresAboveThresholdJSON(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("json")
+	rows := makeRows(listHintThreshold)
+	if err := f.Print(rows); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "results returned") {
+		t.Errorf("expected hint on stderr, got %q", stderr.String())
+	}
+}
+
+func TestListHint_SilentBelowThreshold(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("json")
+	rows := makeRows(listHintThreshold - 1)
+	if err := f.Print(rows); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("hint should not fire under threshold, got stderr=%q", stderr.String())
+	}
+}
+
+func TestListHint_SuppressedByQuiet(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("json")
+	f.SetQuiet(true)
+	rows := makeRows(listHintThreshold + 50)
+	if err := f.Print(rows); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("--quiet should suppress hint, got stderr=%q", stderr.String())
+	}
+}
+
+func TestListHint_SuppressedForTable(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("table")
+	rows := makeRows(listHintThreshold + 10)
+	if err := f.Print(rows); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("table format already shows count, hint should be skipped, got %q", stderr.String())
+	}
+}
+
+func TestListHint_FiresForCSVAndYAML(t *testing.T) {
+	for _, format := range []string{"csv", "yaml", "plain"} {
+		t.Run(format, func(t *testing.T) {
+			f, _, stderr := newTestFormatterWithStderr(format)
+			rows := makeRows(listHintThreshold)
+			if err := f.Print(rows); err != nil {
+				t.Fatalf("Print failed for %s: %v", format, err)
+			}
+			if !strings.Contains(stderr.String(), "results returned") {
+				t.Errorf("expected hint for %s, got %q", format, stderr.String())
+			}
+		})
+	}
+}
+
+func TestListHint_PrintRawJSONFastPath_TopLevelArray(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("json")
+	// Top-level JSON array of 60 items, no projector → fast path triggers.
+	var b bytes.Buffer
+	b.WriteString("[")
+	for i := 0; i < 60; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(`{"id":0}`)
+	}
+	b.WriteString("]")
+	if err := f.PrintRaw(b.Bytes()); err != nil {
+		t.Fatalf("PrintRaw failed: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "results returned") {
+		t.Errorf("expected hint on JSON fast path for top-level array, got %q", stderr.String())
+	}
+}
+
+func TestListHint_PrintRawJSONFastPath_WrappedObject_Skipped(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("json")
+	// Pro-style wrapped response — top level is an object, not an array.
+	// Hint cannot reliably size embedded results without API-specific
+	// knowledge, so it's skipped.
+	input := []byte(`{"totalCount":1000,"results":[{"id":1}]}`)
+	if err := f.PrintRaw(input); err != nil {
+		t.Fatalf("PrintRaw failed: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("hint should be skipped for wrapped objects, got %q", stderr.String())
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -56,15 +56,22 @@ var nowFunc = time.Now
 
 // Formatter handles output formatting
 type Formatter struct {
-	format  Format
-	writer  io.Writer
-	noColor bool
-	wide    bool
+	format    Format
+	writer    io.Writer
+	noColor   bool
+	wide      bool
+	projector Projector
 }
 
 // SetWriter replaces the output destination.
 func (f *Formatter) SetWriter(w io.Writer) {
 	f.writer = w
+}
+
+// SetProjector configures field-level projection (e.g. --compact) applied
+// before format-specific rendering. A zero-value projector is a no-op.
+func (f *Formatter) SetProjector(p Projector) {
+	f.projector = p
 }
 
 // Format returns the current output format string.
@@ -129,6 +136,7 @@ func New(format string, noColor bool, wide bool) *Formatter {
 
 // Print outputs data in the configured format
 func (f *Formatter) Print(data any) error {
+	data = f.applyProjection(data)
 	switch f.format {
 	case FormatJSON:
 		return f.printJSON(data)
@@ -141,6 +149,26 @@ func (f *Formatter) Print(data any) error {
 	default:
 		return f.printTable(data)
 	}
+}
+
+// applyProjection runs the configured Projector over rows when data is
+// shaped as a list/object of maps. Other shapes (scalars, mixed arrays)
+// pass through unchanged so projection never breaks unusual responses.
+func (f *Formatter) applyProjection(data any) any {
+	if f.projector.IsZero() {
+		return data
+	}
+	switch v := data.(type) {
+	case []map[string]any:
+		return f.projector.Apply(v)
+	case map[string]any:
+		projected := f.projector.Apply([]map[string]any{v})
+		if len(projected) == 1 {
+			return projected[0]
+		}
+		return data
+	}
+	return data
 }
 
 func (f *Formatter) printJSON(data any) error {
@@ -315,7 +343,7 @@ func (f *Formatter) PrintRaw(data []byte) error {
 		}
 	}
 
-	if f.format == FormatJSON || f.format == FormatJSONMulti {
+	if (f.format == FormatJSON || f.format == FormatJSONMulti) && f.projector.IsZero() {
 		// Pretty-print JSON so compact API responses become readable
 		var buf bytes.Buffer
 		if err := json.Indent(&buf, data, "", "  "); err != nil {
@@ -328,12 +356,22 @@ func (f *Formatter) PrintRaw(data []byte) error {
 		return err
 	}
 
-	// For non-JSON formats: parse, normalize, then format
+	// For non-JSON formats — and JSON output with projection — parse,
+	// normalize, then format. Projection in Print() applies before rendering.
 	var parsed any
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		// Not JSON, print as-is
 		_, writeErr := f.writer.Write(data)
 		return writeErr
+	}
+
+	// Shape-preserving JSON output: keep single objects as objects,
+	// arrays as arrays, instead of routing through normalizeJSON which
+	// always emits arrays.
+	if f.format == FormatJSON || f.format == FormatJSONMulti {
+		if obj, ok := parsed.(map[string]any); ok {
+			return f.printJSON(f.applyProjection(obj))
+		}
 	}
 
 	return f.Print(normalizeJSON(parsed))

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -588,6 +588,38 @@ func flattenRows(rows []map[string]any) []map[string]any {
 	return stripCommonPrefix(result)
 }
 
+// flattenRowsRaw flattens nested objects to dot keys WITHOUT calling
+// stripCommonPrefix. Used by --select so user-supplied dot paths match
+// faithfully even when every dotted key shares a single top-level
+// segment (e.g. a singleton GET shaped as {"general": {...}}).
+//
+// Mirrors flattenRows' zero-allocation fast path: if no row contains a
+// nested object, the input slice is returned unchanged.
+func flattenRowsRaw(rows []map[string]any) []map[string]any {
+	needsFlatten := false
+	for _, row := range rows {
+		for _, v := range row {
+			if m, ok := v.(map[string]any); ok && len(m) > 0 {
+				needsFlatten = true
+				break
+			}
+		}
+		if needsFlatten {
+			break
+		}
+	}
+	if !needsFlatten {
+		return rows
+	}
+	result := make([]map[string]any, len(rows))
+	for i, row := range rows {
+		flat := make(map[string]any)
+		flattenMap(flat, "", row)
+		result[i] = flat
+	}
+	return result
+}
+
 // flattenMap recursively flattens nested maps into dot-notation keys.
 func flattenMap(dst map[string]any, prefix string, src map[string]any) {
 	for k, v := range src {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -58,8 +58,10 @@ var nowFunc = time.Now
 type Formatter struct {
 	format    Format
 	writer    io.Writer
+	stderr    io.Writer
 	noColor   bool
 	wide      bool
+	quiet     bool
 	projector Projector
 }
 
@@ -73,6 +75,17 @@ func (f *Formatter) SetWriter(w io.Writer) {
 func (f *Formatter) SetProjector(p Projector) {
 	f.projector = p
 }
+
+// SetQuiet suppresses advisory output written to stderr (e.g. the
+// list-size hint). Errors and primary output on stdout are unaffected.
+func (f *Formatter) SetQuiet(q bool) {
+	f.quiet = q
+}
+
+// listHintThreshold is the minimum row count that triggers the
+// "narrow output" hint on stderr. Below this, lists are short enough
+// that the hint is more noise than help.
+const listHintThreshold = 50
 
 // Format returns the current output format string.
 func (f *Formatter) Format() string {
@@ -137,18 +150,61 @@ func New(format string, noColor bool, wide bool) *Formatter {
 // Print outputs data in the configured format
 func (f *Formatter) Print(data any) error {
 	data = f.applyProjection(data)
+
+	rowCount := -1
+	if rows, ok := data.([]map[string]any); ok {
+		rowCount = len(rows)
+	}
+
+	var err error
 	switch f.format {
 	case FormatJSON:
-		return f.printJSON(data)
+		err = f.printJSON(data)
 	case FormatYAML:
-		return f.printYAML(data)
+		err = f.printYAML(data)
 	case FormatCSV:
-		return f.printCSV(data)
+		err = f.printCSV(data)
 	case FormatPlain:
-		return f.printPlain(data)
+		err = f.printPlain(data)
 	default:
-		return f.printTable(data)
+		err = f.printTable(data)
 	}
+
+	if err == nil {
+		f.maybePrintListHint(rowCount)
+	}
+	return err
+}
+
+// maybePrintListHint writes a one-line stderr hint suggesting how to
+// narrow large list output. Skipped in --quiet mode, when the count is
+// below threshold, and for table format (which already shows "(N total)"
+// in its summary header).
+func (f *Formatter) maybePrintListHint(rowCount int) {
+	if f.quiet || rowCount < listHintThreshold {
+		return
+	}
+	if f.format == FormatTable || f.format == "" {
+		return
+	}
+	w := f.stderr
+	if w == nil {
+		w = os.Stderr
+	}
+	_, _ = fmt.Fprintf(w,
+		"hint: %d results returned. Narrow with --select=<fields>, --compact, or command-specific filter flags.\n",
+		rowCount)
+}
+
+// topLevelArrayCount returns the element count when data is a JSON array
+// at the top level, or -1 otherwise. Used to size the list hint without
+// double-decoding into a typed value.
+func topLevelArrayCount(data []byte) int {
+	var arr []json.RawMessage
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return -1
+	}
+	return len(arr)
 }
 
 // applyProjection runs the configured Projector over rows when data is
@@ -369,8 +425,11 @@ func (f *Formatter) PrintRaw(data []byte) error {
 			return writeErr
 		}
 		buf.WriteByte('\n')
-		_, err := f.writer.Write(buf.Bytes())
-		return err
+		if _, err := f.writer.Write(buf.Bytes()); err != nil {
+			return err
+		}
+		f.maybePrintListHint(topLevelArrayCount(data))
+		return nil
 	}
 
 	var parsed any

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -154,6 +154,10 @@ func (f *Formatter) Print(data any) error {
 // applyProjection runs the configured Projector over rows when data is
 // shaped as a list/object of maps. Other shapes (scalars, mixed arrays)
 // pass through unchanged so projection never breaks unusual responses.
+//
+// Handles all three shapes that PrintRaw and direct Print callers produce:
+// pre-normalized []map[string]any, raw json.Unmarshal []any of maps, and
+// single map[string]any (preserved as object so JSON output stays an object).
 func (f *Formatter) applyProjection(data any) any {
 	if f.projector.IsZero() {
 		return data
@@ -167,6 +171,17 @@ func (f *Formatter) applyProjection(data any) any {
 			return projected[0]
 		}
 		return data
+	case []any:
+		rows := make([]map[string]any, 0, len(v))
+		for _, item := range v {
+			m, ok := item.(map[string]any)
+			if !ok {
+				// Mixed array — projection can't apply uniformly.
+				return data
+			}
+			rows = append(rows, m)
+		}
+		return f.projector.Apply(rows)
 	}
 	return data
 }
@@ -344,7 +359,9 @@ func (f *Formatter) PrintRaw(data []byte) error {
 	}
 
 	if (f.format == FormatJSON || f.format == FormatJSONMulti) && f.projector.IsZero() {
-		// Pretty-print JSON so compact API responses become readable
+		// Fast path: indent the wire bytes directly. This preserves the API's
+		// key ordering, which json.Encode on a parsed map[string]any would lose
+		// (Go encodes maps with alphabetically sorted keys).
 		var buf bytes.Buffer
 		if err := json.Indent(&buf, data, "", "  "); err != nil {
 			// Not valid JSON, print as-is
@@ -356,8 +373,6 @@ func (f *Formatter) PrintRaw(data []byte) error {
 		return err
 	}
 
-	// For non-JSON formats — and JSON output with projection — parse,
-	// normalize, then format. Projection in Print() applies before rendering.
 	var parsed any
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		// Not JSON, print as-is
@@ -365,21 +380,23 @@ func (f *Formatter) PrintRaw(data []byte) error {
 		return writeErr
 	}
 
-	// Shape-preserving JSON output: keep single objects as objects,
-	// arrays as arrays, instead of routing through normalizeJSON which
-	// always emits arrays.
-	if f.format == FormatJSON || f.format == FormatJSONMulti {
-		if obj, ok := parsed.(map[string]any); ok {
-			return f.printJSON(f.applyProjection(obj))
-		}
+	// JSON and YAML preserve the parsed shape natively (object stays object,
+	// array stays array). Tabular formats (table/csv/plain) require rows, so
+	// coerce via normalizeForTabular. Print's applyProjection handles both
+	// map[string]any and []map[string]any.
+	switch f.format {
+	case FormatJSON, FormatJSONMulti, FormatYAML:
+		return f.Print(parsed)
+	default:
+		return f.Print(normalizeForTabular(parsed))
 	}
-
-	return f.Print(normalizeJSON(parsed))
 }
 
-// normalizeJSON converts parsed JSON types into the []map[string]interface{}
-// form that table/csv/plain formatters expect.
-func normalizeJSON(data any) any {
+// normalizeForTabular converts parsed JSON types into the []map[string]any
+// form that table/csv/plain formatters expect. Single objects are wrapped
+// into a one-element slice. Not used for JSON/YAML output, which preserves
+// the parsed shape.
+func normalizeForTabular(data any) any {
 	switch v := data.(type) {
 	case []any:
 		// Convert []interface{} of objects to []map[string]interface{}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -596,14 +596,14 @@ func TestSortedKeys_NoIdNoName(t *testing.T) {
 	}
 }
 
-// --- normalizeJSON tests ---
+// --- normalizeForTabular tests ---
 
-func TestNormalizeJSON_SliceOfMaps(t *testing.T) {
+func TestNormalizeForTabular_SliceOfMaps(t *testing.T) {
 	input := []any{
 		map[string]any{"id": float64(1)},
 		map[string]any{"id": float64(2)},
 	}
-	result := normalizeJSON(input)
+	result := normalizeForTabular(input)
 	slice, ok := result.([]map[string]any)
 	if !ok {
 		t.Fatalf("expected []map[string]interface{}, got %T", result)
@@ -613,9 +613,9 @@ func TestNormalizeJSON_SliceOfMaps(t *testing.T) {
 	}
 }
 
-func TestNormalizeJSON_SingleMap(t *testing.T) {
+func TestNormalizeForTabular_SingleMap(t *testing.T) {
 	input := map[string]any{"id": float64(1), "name": "test"}
-	result := normalizeJSON(input)
+	result := normalizeForTabular(input)
 	slice, ok := result.([]map[string]any)
 	if !ok {
 		t.Fatalf("expected []map[string]interface{}, got %T", result)
@@ -625,9 +625,9 @@ func TestNormalizeJSON_SingleMap(t *testing.T) {
 	}
 }
 
-func TestNormalizeJSON_ScalarString(t *testing.T) {
+func TestNormalizeForTabular_ScalarString(t *testing.T) {
 	input := "hello"
-	result := normalizeJSON(input)
+	result := normalizeForTabular(input)
 	s, ok := result.(string)
 	if !ok {
 		t.Fatalf("expected string, got %T", result)
@@ -637,14 +637,14 @@ func TestNormalizeJSON_ScalarString(t *testing.T) {
 	}
 }
 
-func TestNormalizeJSON_MixedArray(t *testing.T) {
+func TestNormalizeForTabular_MixedArray(t *testing.T) {
 	// Mixed array should return raw data, not drop non-map items
 	input := []any{
 		map[string]any{"id": "1"},
 		"stray string",
 		map[string]any{"id": "2"},
 	}
-	result := normalizeJSON(input)
+	result := normalizeForTabular(input)
 	// Should return the original data unchanged (not []map[string]interface{})
 	arr, ok := result.([]any)
 	if !ok {
@@ -655,9 +655,9 @@ func TestNormalizeJSON_MixedArray(t *testing.T) {
 	}
 }
 
-func TestNormalizeJSON_EmptySlice(t *testing.T) {
+func TestNormalizeForTabular_EmptySlice(t *testing.T) {
 	input := []any{}
-	result := normalizeJSON(input)
+	result := normalizeForTabular(input)
 	slice, ok := result.([]map[string]any)
 	if !ok {
 		t.Fatalf("expected []map[string]interface{}, got %T", result)

--- a/internal/output/project.go
+++ b/internal/output/project.go
@@ -23,18 +23,22 @@ func (p Projector) IsZero() bool {
 // Apply returns rows projected per the configured rules.
 // Always flattens nested objects to dot keys so projection sees a flat shape.
 // Empty rows pass through unchanged.
+//
+// Select uses flattenRowsRaw (no common-prefix stripping) so user-supplied
+// dot paths like "general.name" still match on single-section responses
+// where stripCommonPrefix would otherwise rewrite "general.name" → "name"
+// and silently produce empty projections.
 func (p Projector) Apply(rows []map[string]any) []map[string]any {
 	if p.IsZero() || len(rows) == 0 {
 		return rows
 	}
-	flat := flattenRows(rows)
 	switch {
 	case len(p.Select) > 0:
-		return projectSelect(flat, p.Select)
+		return projectSelect(flattenRowsRaw(rows), p.Select)
 	case p.Compact:
-		return projectCompact(flat)
+		return projectCompact(flattenRows(rows))
 	}
-	return flat
+	return flattenRows(rows)
 }
 
 // projectSelect keeps only the requested dot paths.

--- a/internal/output/project.go
+++ b/internal/output/project.go
@@ -49,9 +49,11 @@ func projectCompact(rows []map[string]any) []map[string]any {
 }
 
 // isScalar reports whether v is a primitive worth keeping in --compact mode.
+// nil is excluded so null fields are dropped, matching flattenMap's behavior
+// for nested nulls and keeping compact output free of empty values.
 func isScalar(v any) bool {
 	switch v.(type) {
-	case nil, bool, string, float64, float32,
+	case bool, string, float64, float32,
 		int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64:
 		return true

--- a/internal/output/project.go
+++ b/internal/output/project.go
@@ -2,18 +2,22 @@
 
 package output
 
+import "strings"
+
 // Projector applies field-level projection to flattened rows before
 // format-specific rendering. Compact keeps only scalar fields after
-// flattening, dropping arrays and nested remnants. The projector is shared
-// by every output format (json, table, csv, yaml, plain) so --compact
+// flattening, dropping arrays and nested remnants. Select keeps only the
+// listed dot paths. When both are set, Select wins. The projector is shared
+// by every output format (json, table, csv, yaml, plain) so projection
 // behaves consistently.
 type Projector struct {
 	Compact bool
+	Select  []string
 }
 
 // IsZero reports whether the projector has no rules configured.
 func (p Projector) IsZero() bool {
-	return !p.Compact
+	return !p.Compact && len(p.Select) == 0
 }
 
 // Apply returns rows projected per the configured rules.
@@ -24,10 +28,49 @@ func (p Projector) Apply(rows []map[string]any) []map[string]any {
 		return rows
 	}
 	flat := flattenRows(rows)
-	if p.Compact {
+	switch {
+	case len(p.Select) > 0:
+		return projectSelect(flat, p.Select)
+	case p.Compact:
 		return projectCompact(flat)
 	}
 	return flat
+}
+
+// projectSelect keeps only the requested dot paths.
+// A path matches a flattened key directly OR a flattened key prefixed with
+// "<path>." — so --select general returns every general.* field, and
+// --select general.name returns just that one. Missing paths are silently
+// omitted (a row may end up empty if no path matched).
+func projectSelect(rows []map[string]any, paths []string) []map[string]any {
+	cleaned := make([]string, 0, len(paths))
+	for _, p := range paths {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			cleaned = append(cleaned, p)
+		}
+	}
+	if len(cleaned) == 0 {
+		return rows
+	}
+	out := make([]map[string]any, len(rows))
+	for i, row := range rows {
+		projected := make(map[string]any, len(cleaned))
+		for _, p := range cleaned {
+			if v, ok := row[p]; ok {
+				projected[p] = v
+				continue
+			}
+			prefix := p + "."
+			for k, v := range row {
+				if strings.HasPrefix(k, prefix) {
+					projected[k] = v
+				}
+			}
+		}
+		out[i] = projected
+	}
+	return out
 }
 
 // projectCompact keeps only scalar values from flattened rows.

--- a/internal/output/project.go
+++ b/internal/output/project.go
@@ -1,0 +1,60 @@
+// Copyright 2026, Jamf Software LLC
+
+package output
+
+// Projector applies field-level projection to flattened rows before
+// format-specific rendering. Compact keeps only scalar fields after
+// flattening, dropping arrays and nested remnants. The projector is shared
+// by every output format (json, table, csv, yaml, plain) so --compact
+// behaves consistently.
+type Projector struct {
+	Compact bool
+}
+
+// IsZero reports whether the projector has no rules configured.
+func (p Projector) IsZero() bool {
+	return !p.Compact
+}
+
+// Apply returns rows projected per the configured rules.
+// Always flattens nested objects to dot keys so projection sees a flat shape.
+// Empty rows pass through unchanged.
+func (p Projector) Apply(rows []map[string]any) []map[string]any {
+	if p.IsZero() || len(rows) == 0 {
+		return rows
+	}
+	flat := flattenRows(rows)
+	if p.Compact {
+		return projectCompact(flat)
+	}
+	return flat
+}
+
+// projectCompact keeps only scalar values from flattened rows.
+// flattenRows already lifts nested objects to dot keys, so what remains
+// non-scalar here is arrays — which are the bulk of the token cost in
+// Jamf Pro list responses.
+func projectCompact(rows []map[string]any) []map[string]any {
+	out := make([]map[string]any, len(rows))
+	for i, row := range rows {
+		compact := make(map[string]any, len(row))
+		for k, v := range row {
+			if isScalar(v) {
+				compact[k] = v
+			}
+		}
+		out[i] = compact
+	}
+	return out
+}
+
+// isScalar reports whether v is a primitive worth keeping in --compact mode.
+func isScalar(v any) bool {
+	switch v.(type) {
+	case nil, bool, string, float64, float32,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64:
+		return true
+	}
+	return false
+}

--- a/internal/output/project_test.go
+++ b/internal/output/project_test.go
@@ -15,6 +15,112 @@ func TestProjector_IsZero(t *testing.T) {
 	if (Projector{Compact: true}).IsZero() {
 		t.Error("Compact=true should not report IsZero")
 	}
+	if (Projector{Select: []string{"id"}}).IsZero() {
+		t.Error("Select set should not report IsZero")
+	}
+}
+
+func TestProjector_Select_KeepsExactPaths(t *testing.T) {
+	rows := []map[string]any{{
+		"id":     1.0,
+		"name":   "device-01",
+		"serial": "ABC123",
+		"udid":   "uuid-1",
+	}}
+	got := Projector{Select: []string{"id", "serial"}}.Apply(rows)
+	if len(got[0]) != 2 {
+		t.Errorf("expected 2 fields, got %d: %v", len(got[0]), got[0])
+	}
+	if got[0]["id"] != 1.0 || got[0]["serial"] != "ABC123" {
+		t.Errorf("expected id and serial only, got %v", got[0])
+	}
+	if _, ok := got[0]["name"]; ok {
+		t.Errorf("name should be dropped, got %v", got[0])
+	}
+}
+
+func TestProjector_Select_PrefixMatch(t *testing.T) {
+	// Multiple top-level sections so flattenRows keeps "general." prefix.
+	rows := []map[string]any{{
+		"id": 1.0,
+		"general": map[string]any{
+			"name":     "device-01",
+			"platform": "Mac",
+		},
+		"location": map[string]any{
+			"username": "alice",
+		},
+	}}
+	got := Projector{Select: []string{"general"}}.Apply(rows)
+	if got[0]["general.name"] != "device-01" {
+		t.Errorf("expected general.name, got %v", got[0])
+	}
+	if got[0]["general.platform"] != "Mac" {
+		t.Errorf("expected general.platform, got %v", got[0])
+	}
+	if _, ok := got[0]["location.username"]; ok {
+		t.Errorf("location should be dropped, got %v", got[0])
+	}
+	if _, ok := got[0]["id"]; ok {
+		t.Errorf("id was not selected, should be dropped, got %v", got[0])
+	}
+}
+
+func TestProjector_Select_DotPath(t *testing.T) {
+	rows := []map[string]any{{
+		"id": 1.0,
+		"general": map[string]any{
+			"name":     "device-01",
+			"platform": "Mac",
+		},
+		"location": map[string]any{
+			"username": "alice",
+		},
+	}}
+	got := Projector{Select: []string{"general.name", "id"}}.Apply(rows)
+	if got[0]["general.name"] != "device-01" {
+		t.Errorf("expected general.name, got %v", got[0])
+	}
+	if got[0]["id"] != 1.0 {
+		t.Errorf("expected id, got %v", got[0])
+	}
+	if _, ok := got[0]["general.platform"]; ok {
+		t.Errorf("general.platform was not selected, got %v", got[0])
+	}
+}
+
+func TestProjector_Select_MissingPath_OmitsSilently(t *testing.T) {
+	rows := []map[string]any{{"id": 1.0, "name": "a"}}
+	got := Projector{Select: []string{"id", "nonexistent"}}.Apply(rows)
+	if got[0]["id"] != 1.0 {
+		t.Errorf("expected id, got %v", got[0])
+	}
+	if _, ok := got[0]["nonexistent"]; ok {
+		t.Errorf("missing path should be omitted, got %v", got[0])
+	}
+}
+
+func TestProjector_Select_EmptyAfterTrim_ReturnsRows(t *testing.T) {
+	rows := []map[string]any{{"id": 1.0, "name": "a"}}
+	got := Projector{Select: []string{"  ", ""}}.Apply(rows)
+	if len(got) != 1 || got[0]["id"] != 1.0 || got[0]["name"] != "a" {
+		t.Errorf("all-whitespace select should pass through, got %v", got)
+	}
+}
+
+func TestProjector_SelectAndCompact_SelectWins(t *testing.T) {
+	rows := []map[string]any{{
+		"id":       1.0,
+		"name":     "a",
+		"profiles": []any{"p1"},
+	}}
+	got := Projector{Compact: true, Select: []string{"profiles"}}.Apply(rows)
+	if _, ok := got[0]["profiles"]; !ok {
+		t.Errorf("Select should override Compact and keep profiles, got %v", got[0])
+	}
+	if _, ok := got[0]["id"]; ok {
+		t.Errorf("Select should drop unselected fields, got %v", got[0])
+	}
 }
 
 func TestProjector_Apply_NoOp(t *testing.T) {

--- a/internal/output/project_test.go
+++ b/internal/output/project_test.go
@@ -5,6 +5,7 @@ package output
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -67,6 +68,23 @@ func TestProjector_Compact_FlattensNested(t *testing.T) {
 	}
 	if _, ok := got[0]["general"]; ok {
 		t.Errorf("compact should not retain nested object key, got %v", got[0])
+	}
+}
+
+func TestProjector_Compact_DropsNil(t *testing.T) {
+	rows := []map[string]any{{
+		"id":   1.0,
+		"name": "device-01",
+		// Top-level nil — without the fix this survived compact, while
+		// nested nils were dropped by flattenMap. Now both paths agree.
+		"description": nil,
+	}}
+	got := Projector{Compact: true}.Apply(rows)
+	if _, ok := got[0]["description"]; ok {
+		t.Errorf("compact should drop nil fields, got %v", got[0])
+	}
+	if got[0]["id"] != 1.0 || got[0]["name"] != "device-01" {
+		t.Errorf("compact should keep non-nil scalars, got %v", got[0])
 	}
 }
 
@@ -162,5 +180,50 @@ func TestFormatter_PrintRaw_JSON_Compact_Array(t *testing.T) {
 		if _, ok := row["id"]; !ok {
 			t.Errorf("row %d should keep id, got %v", i, row)
 		}
+	}
+}
+
+// Every output format runs through the same applyProjection hook in Print,
+// so --compact should drop arrays from rendered bytes regardless of format.
+func TestFormatter_Print_Compact_AllFormats(t *testing.T) {
+	rows := []map[string]any{{
+		"id":       1.0,
+		"name":     "device-01",
+		"profiles": []any{"a", "b"},
+	}}
+
+	cases := []struct {
+		format Format
+		// "name" is the column to confirm a row rendered; absence of
+		// "profiles" confirms the array was dropped.
+		mustContain    string
+		mustNotContain string
+	}{
+		{FormatTable, "device-01", "profiles"},
+		{FormatCSV, "device-01", "profiles"},
+		{FormatYAML, "device-01", "profiles"},
+		{FormatPlain, "device-01", "profiles"},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.format), func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			f := &Formatter{
+				format:    tc.format,
+				writer:    buf,
+				noColor:   true,
+				projector: Projector{Compact: true},
+			}
+			if err := f.Print(rows); err != nil {
+				t.Fatalf("Print failed: %v", err)
+			}
+			out := buf.String()
+			if !strings.Contains(out, tc.mustContain) {
+				t.Errorf("%s: expected output to contain %q, got %q", tc.format, tc.mustContain, out)
+			}
+			if strings.Contains(out, tc.mustNotContain) {
+				t.Errorf("%s: compact should drop %q, got %q", tc.format, tc.mustNotContain, out)
+			}
+		})
 	}
 }

--- a/internal/output/project_test.go
+++ b/internal/output/project_test.go
@@ -90,6 +90,49 @@ func TestProjector_Select_DotPath(t *testing.T) {
 	}
 }
 
+// Regression: a singleton GET shaped as {"general": {...}} (single
+// top-level section) used to return empty rows because stripCommonPrefix
+// rewrote "general.name" → "name" before projectSelect ran. The Select
+// path now uses flattenRowsRaw (no stripping) so user-supplied dot paths
+// like "general.name" continue to match in this shape.
+func TestProjector_Select_SingleSection_KeepsDottedKeys(t *testing.T) {
+	rows := []map[string]any{{
+		"general": map[string]any{
+			"name":     "MacBook",
+			"id":       float64(123),
+			"platform": "Mac",
+		},
+	}}
+	got := Projector{Select: []string{"general.name"}}.Apply(rows)
+	if got[0]["general.name"] != "MacBook" {
+		t.Errorf("expected general.name=MacBook, got %v", got[0])
+	}
+	if _, ok := got[0]["general.id"]; ok {
+		t.Errorf("general.id was not selected, got %v", got[0])
+	}
+	if _, ok := got[0]["name"]; ok {
+		t.Errorf("Select must not strip prefix; got bare 'name': %v", got[0])
+	}
+}
+
+// Selecting a parent path on a single-section response should still match
+// every child via the prefix-match branch — used to return empty.
+func TestProjector_Select_SingleSection_ParentPath(t *testing.T) {
+	rows := []map[string]any{{
+		"general": map[string]any{
+			"name":     "MacBook",
+			"platform": "Mac",
+		},
+	}}
+	got := Projector{Select: []string{"general"}}.Apply(rows)
+	if got[0]["general.name"] != "MacBook" {
+		t.Errorf("expected general.name=MacBook, got %v", got[0])
+	}
+	if got[0]["general.platform"] != "Mac" {
+		t.Errorf("expected general.platform=Mac, got %v", got[0])
+	}
+}
+
 func TestProjector_Select_MissingPath_OmitsSilently(t *testing.T) {
 	rows := []map[string]any{{"id": 1.0, "name": "a"}}
 	got := Projector{Select: []string{"id", "nonexistent"}}.Apply(rows)

--- a/internal/output/project_test.go
+++ b/internal/output/project_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026, Jamf Software LLC
+
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestProjector_IsZero(t *testing.T) {
+	if !(Projector{}).IsZero() {
+		t.Error("zero-value Projector should report IsZero")
+	}
+	if (Projector{Compact: true}).IsZero() {
+		t.Error("Compact=true should not report IsZero")
+	}
+}
+
+func TestProjector_Apply_NoOp(t *testing.T) {
+	rows := []map[string]any{{"id": 1.0, "name": "a"}}
+	got := Projector{}.Apply(rows)
+	if len(got) != 1 || got[0]["id"] != 1.0 || got[0]["name"] != "a" {
+		t.Errorf("zero projector should return rows unchanged, got %v", got)
+	}
+}
+
+func TestProjector_Apply_Empty(t *testing.T) {
+	got := Projector{Compact: true}.Apply(nil)
+	if got != nil {
+		t.Errorf("nil rows should pass through, got %v", got)
+	}
+}
+
+func TestProjector_Compact_DropsArrays(t *testing.T) {
+	rows := []map[string]any{{
+		"id":       1.0,
+		"name":     "device-01",
+		"profiles": []any{"a", "b", "c"},
+		"groups":   []any{},
+	}}
+	got := Projector{Compact: true}.Apply(rows)
+	if _, ok := got[0]["profiles"]; ok {
+		t.Errorf("compact should drop array fields, got %v", got[0])
+	}
+	if got[0]["id"] != 1.0 || got[0]["name"] != "device-01" {
+		t.Errorf("compact should keep scalars, got %v", got[0])
+	}
+}
+
+func TestProjector_Compact_FlattensNested(t *testing.T) {
+	rows := []map[string]any{{
+		"id": 1.0,
+		"general": map[string]any{
+			"name":     "device-01",
+			"platform": "Mac",
+		},
+	}}
+	got := Projector{Compact: true}.Apply(rows)
+	// Single-section nested object: only "general.*" keys, so
+	// stripCommonPrefix collapses to "name", "platform".
+	if got[0]["name"] != "device-01" {
+		t.Errorf("expected flattened name=device-01, got %v", got[0])
+	}
+	if got[0]["platform"] != "Mac" {
+		t.Errorf("expected flattened platform=Mac, got %v", got[0])
+	}
+	if _, ok := got[0]["general"]; ok {
+		t.Errorf("compact should not retain nested object key, got %v", got[0])
+	}
+}
+
+func TestProjector_Compact_PreservesScalarTypes(t *testing.T) {
+	rows := []map[string]any{{
+		"id":      1.0,
+		"managed": true,
+		"version": "10.15",
+	}}
+	got := Projector{Compact: true}.Apply(rows)
+	if got[0]["managed"] != true {
+		t.Errorf("expected managed=true, got %v", got[0]["managed"])
+	}
+	if got[0]["id"] != 1.0 {
+		t.Errorf("expected id=1.0, got %v", got[0]["id"])
+	}
+	if got[0]["version"] != "10.15" {
+		t.Errorf("expected version=10.15, got %v", got[0]["version"])
+	}
+}
+
+// Formatter integration: PrintRaw with --compact on JSON should drop arrays
+// in the actual output, not just in the parsed projection.
+func TestFormatter_PrintRaw_JSON_Compact(t *testing.T) {
+	buf := &bytes.Buffer{}
+	f := &Formatter{
+		format:    FormatJSON,
+		writer:    buf,
+		projector: Projector{Compact: true},
+	}
+
+	input := `{"id":1,"name":"d1","profiles":["a","b"]}`
+	if err := f.PrintRaw([]byte(input)); err != nil {
+		t.Fatalf("PrintRaw failed: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("output not valid JSON: %v\nOutput: %s", err, buf.String())
+	}
+	if _, ok := out["profiles"]; ok {
+		t.Errorf("compact should drop profiles array, got %v", out)
+	}
+	if out["id"] != 1.0 || out["name"] != "d1" {
+		t.Errorf("compact should keep id/name, got %v", out)
+	}
+}
+
+func TestFormatter_PrintRaw_JSON_NoProjector_Unchanged(t *testing.T) {
+	buf := &bytes.Buffer{}
+	f := &Formatter{
+		format: FormatJSON,
+		writer: buf,
+	}
+	input := `{"id":1,"profiles":["a"]}`
+	if err := f.PrintRaw([]byte(input)); err != nil {
+		t.Fatalf("PrintRaw failed: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	if _, ok := out["profiles"]; !ok {
+		t.Errorf("without projector, profiles should be retained, got %v", out)
+	}
+}
+
+// Array input with --compact should drop arrays from each row.
+func TestFormatter_PrintRaw_JSON_Compact_Array(t *testing.T) {
+	buf := &bytes.Buffer{}
+	f := &Formatter{
+		format:    FormatJSON,
+		writer:    buf,
+		projector: Projector{Compact: true},
+	}
+
+	input := `[{"id":1,"profiles":["a"]},{"id":2,"profiles":["b","c"]}]`
+	if err := f.PrintRaw([]byte(input)); err != nil {
+		t.Fatalf("PrintRaw failed: %v", err)
+	}
+
+	var out []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("output not valid JSON array: %v\nOutput: %s", err, buf.String())
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(out))
+	}
+	for i, row := range out {
+		if _, ok := row["profiles"]; ok {
+			t.Errorf("row %d should drop profiles, got %v", i, row)
+		}
+		if _, ok := row["id"]; !ok {
+			t.Errorf("row %d should keep id, got %v", i, row)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--select id,general.name,udid` for jq-style multi-field projection on any command
- Supports prefix-matching: `--select general` returns every `general.*` field after flattening
- Builds on the `output.Projector` scaffold from #189 (compact)
- When both `--select` and `--compact` are set, `--select` wins

## Why

`--field` extracts a single scalar (great for shell pipelines: `--field id | xargs ...`). `--select` is the JSON-shaped sibling: keep the structure, drop everything you don't need. Together they cover the two ways agents narrow Jamf Pro's enormous responses.

## Examples

```bash
# Single device with just id, name, serial
jamf-cli pro computers get --name "MacBook Pro" --select id,general.name,general.serial_number

# List everything in a record's general section
jamf-cli pro computers get --name "MacBook Pro" --select general

# Combine: --select wins over --compact
jamf-cli pro computers list --compact --select profiles  # returns profiles arrays
```

## Test plan

- [x] `go test ./internal/output/...` — 7 new test cases for select (exact, prefix, dot-path, missing, whitespace, select+compact)
- [x] `go test ./...` — full suite green
- [x] `make lint` — 0 issues
- [x] `bin/jamf-cli --help` shows `--select` line

## Stacking

Based on `feat/compact-flag` (#189). Once that lands, this PR's diff will only show the select-specific additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)