### PR TITLE
feat(output): hint on stderr when list output exceeds 50 rows

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -447,6 +447,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 				formatter.SetWriter(outFileHandle)
 			}
 			formatter.SetProjector(output.Projector{Compact: compact, Select: selectFields})
+			formatter.SetQuiet(quiet)
 			cliCtx.Output = &cliOutput{formatter}
 
 			// Skip auth for commands that don't need it. Most are matched

--- a/internal/output/list_hint_test.go
+++ b/internal/output/list_hint_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026, Jamf Software LLC
+
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func newTestFormatterWithStderr(format string) (*Formatter, *bytes.Buffer, *bytes.Buffer) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	f := &Formatter{
+		format:  Format(format),
+		writer:  stdout,
+		stderr:  stderr,
+		noColor: true,
+	}
+	return f, stdout, stderr
+}
+
+// makeRows builds n minimal rows for hint-threshold tests.
+func makeRows(n int) []map[string]any {
+	rows := make([]map[string]any, n)
+	for i := range rows {
+		rows[i] = map[string]any{"id": float64(i), "name": "row"}
+	}
+	return rows
+}
+
+func TestListHint_FiresAboveThresholdJSON(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("json")
+	rows := makeRows(listHintThreshold)
+	if err := f.Print(rows); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "results returned") {
+		t.Errorf("expected hint on stderr, got %q", stderr.String())
+	}
+}
+
+func TestListHint_SilentBelowThreshold(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("json")
+	rows := makeRows(listHintThreshold - 1)
+	if err := f.Print(rows); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("hint should not fire under threshold, got stderr=%q", stderr.String())
+	}
+}
+
+func TestListHint_SuppressedByQuiet(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("json")
+	f.SetQuiet(true)
+	rows := makeRows(listHintThreshold + 50)
+	if err := f.Print(rows); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("--quiet should suppress hint, got stderr=%q", stderr.String())
+	}
+}
+
+func TestListHint_SuppressedForTable(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("table")
+	rows := makeRows(listHintThreshold + 10)
+	if err := f.Print(rows); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("table format already shows count, hint should be skipped, got %q", stderr.String())
+	}
+}
+
+func TestListHint_FiresForCSVAndYAML(t *testing.T) {
+	for _, format := range []string{"csv", "yaml", "plain"} {
+		t.Run(format, func(t *testing.T) {
+			f, _, stderr := newTestFormatterWithStderr(format)
+			rows := makeRows(listHintThreshold)
+			if err := f.Print(rows); err != nil {
+				t.Fatalf("Print failed for %s: %v", format, err)
+			}
+			if !strings.Contains(stderr.String(), "results returned") {
+				t.Errorf("expected hint for %s, got %q", format, stderr.String())
+			}
+		})
+	}
+}
+
+func TestListHint_PrintRawJSONFastPath_TopLevelArray(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("json")
+	// Top-level JSON array of 60 items, no projector → fast path triggers.
+	var b bytes.Buffer
+	b.WriteString("[")
+	for i := 0; i < 60; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(`{"id":0}`)
+	}
+	b.WriteString("]")
+	if err := f.PrintRaw(b.Bytes()); err != nil {
+		t.Fatalf("PrintRaw failed: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "results returned") {
+		t.Errorf("expected hint on JSON fast path for top-level array, got %q", stderr.String())
+	}
+}
+
+func TestListHint_PrintRawJSONFastPath_WrappedObject_Skipped(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("json")
+	// Pro-style wrapped response — top level is an object, not an array.
+	// Hint cannot reliably size embedded results without API-specific
+	// knowledge, so it's skipped.
+	input := []byte(`{"totalCount":1000,"results":[{"id":1}]}`)
+	if err := f.PrintRaw(input); err != nil {
+		t.Fatalf("PrintRaw failed: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("hint should be skipped for wrapped objects, got %q", stderr.String())
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -58,8 +58,10 @@ var nowFunc = time.Now
 type Formatter struct {
 	format    Format
 	writer    io.Writer
+	stderr    io.Writer
 	noColor   bool
 	wide      bool
+	quiet     bool
 	projector Projector
 }
 
@@ -73,6 +75,17 @@ func (f *Formatter) SetWriter(w io.Writer) {
 func (f *Formatter) SetProjector(p Projector) {
 	f.projector = p
 }
+
+// SetQuiet suppresses advisory output written to stderr (e.g. the
+// list-size hint). Errors and primary output on stdout are unaffected.
+func (f *Formatter) SetQuiet(q bool) {
+	f.quiet = q
+}
+
+// listHintThreshold is the minimum row count that triggers the
+// "narrow output" hint on stderr. Below this, lists are short enough
+// that the hint is more noise than help.
+const listHintThreshold = 50
 
 // Format returns the current output format string.
 func (f *Formatter) Format() string {
@@ -137,18 +150,61 @@ func New(format string, noColor bool, wide bool) *Formatter {
 // Print outputs data in the configured format
 func (f *Formatter) Print(data any) error {
 	data = f.applyProjection(data)
+
+	rowCount := -1
+	if rows, ok := data.([]map[string]any); ok {
+		rowCount = len(rows)
+	}
+
+	var err error
 	switch f.format {
 	case FormatJSON:
-		return f.printJSON(data)
+		err = f.printJSON(data)
 	case FormatYAML:
-		return f.printYAML(data)
+		err = f.printYAML(data)
 	case FormatCSV:
-		return f.printCSV(data)
+		err = f.printCSV(data)
 	case FormatPlain:
-		return f.printPlain(data)
+		err = f.printPlain(data)
 	default:
-		return f.printTable(data)
+		err = f.printTable(data)
 	}
+
+	if err == nil {
+		f.maybePrintListHint(rowCount)
+	}
+	return err
+}
+
+// maybePrintListHint writes a one-line stderr hint suggesting how to
+// narrow large list output. Skipped in --quiet mode, when the count is
+// below threshold, and for table format (which already shows "(N total)"
+// in its summary header).
+func (f *Formatter) maybePrintListHint(rowCount int) {
+	if f.quiet || rowCount < listHintThreshold {
+		return
+	}
+	if f.format == FormatTable || f.format == "" {
+		return
+	}
+	w := f.stderr
+	if w == nil {
+		w = os.Stderr
+	}
+	_, _ = fmt.Fprintf(w,
+		"hint: %d results returned. Narrow with --select=<fields>, --compact, or command-specific filter flags.\n",
+		rowCount)
+}
+
+// topLevelArrayCount returns the element count when data is a JSON array
+// at the top level, or -1 otherwise. Used to size the list hint without
+// double-decoding into a typed value.
+func topLevelArrayCount(data []byte) int {
+	var arr []json.RawMessage
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return -1
+	}
+	return len(arr)
 }
 
 // applyProjection runs the configured Projector over rows when data is
@@ -352,8 +408,11 @@ func (f *Formatter) PrintRaw(data []byte) error {
 			return writeErr
 		}
 		buf.WriteByte('\n')
-		_, err := f.writer.Write(buf.Bytes())
-		return err
+		if _, err := f.writer.Write(buf.Bytes()); err != nil {
+			return err
+		}
+		f.maybePrintListHint(topLevelArrayCount(data))
+		return nil
 	}
 
 	// For non-JSON formats — and JSON output with projection — parse,


### PR DESCRIPTION
## Summary

- One-line stderr hint after list responses ≥ 50 rows: `hint: 100 results returned. Narrow with --select=<fields>, --compact, or command-specific filter flags.`
- Suppressed by `--quiet`
- Suppressed for table format (already shows `(N total)`)
- Fires for `json`/`yaml`/`csv`/`plain` and for JSON-fast-path top-level arrays
- Skipped for wrapped objects like Pro's `{"totalCount":N,"results":[…]}` (count isn't reliably accessible without API-specific decoding)

## Why

Once you have a 5000-row YAML or JSON dump in front of you, the time to discover narrowing flags is *before* they fly past, not after. Stderr keeps stdout clean for piping.

## Test plan

- [x] `go test ./internal/output/...` — 7 new test cases (above/below threshold, --quiet suppression, table suppression, csv/yaml/plain coverage, fast-path top-level array, fast-path wrapped object)
- [x] `go test ./...` — full suite green
- [x] `make lint` — 0 issues

## Stacking

Based on `feat/select-flag` (#190) which is in turn based on `feat/compact-flag` (#189). Hint text references `--select` and `--compact` which only exist after those merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)