### PR TITLE
feat(commands): annotate destructive commands with jamf:destructive

### DIFF
--- a/generator/classic/generator.go
+++ b/generator/classic/generator.go
@@ -823,6 +823,7 @@ func new{{ .GoName }}DeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 {{ else }}		Use:   "delete <id>",
 {{ end }}		Short: "Delete a {{ .Singular }}",
 		Example: ` + "`" + `{{ classicExample . "delete" }}` + "`" + `,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 {{ if hasDeleteByName . }}		Args:  cobra.MaximumNArgs(1),
 {{ else }}		Args:  cobra.ExactArgs(1),
 {{ end }}		RunE: func(cmd *cobra.Command, args []string) error {

--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -1450,6 +1450,9 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 		Example: ` + "`" + `{{ $ex }}` + "`" + `,
 {{- end }}
 {{- end }}
+{{- if .IsDestructive }}
+		Annotations: map[string]string{"jamf:destructive": "true"},
+{{- end }}
 {{- if hasPathParam .Path }}
 {{- if or (and (isPatchOp .) (patchHasLookup $)) (and (not (isPatchOp .)) (opHasNameLookup . $)) }}
 		Args:  cobra.MaximumNArgs(1),

--- a/generator/platform/emitter.go
+++ b/generator/platform/emitter.go
@@ -74,7 +74,7 @@ type templateOp struct {
 	Use                string        // cobra Use string, includes <param> placeholders for path params
 	PathParams         []string      // path parameter names in order of appearance in Path
 	HasBody            bool          // operation accepts a request body — emit --file/--set flags
-	NeedsConfirm       bool          // destructive op — emit --yes flag and ConfirmAction guard
+	IsDestructive      bool          // destructive op — emit --yes flag, ConfirmAction guard, and jamf:destructive annotation
 	UsesMergePatch     bool          // PATCH with application/merge-patch+json content type
 	SuccessCode        int           // success HTTP status code (200 default; 201 for create, 204 for delete/patch, etc.)
 	HasResult          bool          // operation returns a JSON response body to unmarshal/print
@@ -228,7 +228,7 @@ func buildTemplateResource(r *parser.Resource) templateResource {
 			Use:            buildUse(opCopy.Name, userParams),
 			PathParams:     userParams,
 			HasBody:        opCopy.RequestBody != nil,
-			NeedsConfirm:   opCopy.IsDestructive,
+			IsDestructive:  opCopy.IsDestructive,
 			UsesMergePatch: opCopy.RequestBody != nil && opCopy.RequestBody.IsMergePatch,
 			SuccessCode:    successCode,
 			HasResult:      hasResult,

--- a/generator/platform/template.go
+++ b/generator/platform/template.go
@@ -67,7 +67,7 @@ func new{{$.GoName}}{{.GoName}}Cmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var setFlags []string
 	var scaffoldFlag bool
 {{- end }}
-{{- if .NeedsConfirm }}
+{{- if .IsDestructive }}
 	var yes bool
 {{- end }}
 {{- if .SupportsNameLookup }}
@@ -90,7 +90,7 @@ func new{{$.GoName}}{{.GoName}}Cmd(cliCtx *registry.CLIContext) *cobra.Command {
 {{- if .Long }}
 		Long:  {{printf "%q" .Long}},
 {{- end }}
-{{- if .NeedsConfirm }}
+{{- if .IsDestructive }}
 		Annotations: map[string]string{"jamf:destructive": "true"},
 {{- end }}
 {{- if and .PathParams (not .SupportsNameLookup) }}
@@ -134,7 +134,7 @@ func new{{$.GoName}}{{.GoName}}Cmd(cliCtx *registry.CLIContext) *cobra.Command {
 				return fmt.Errorf("provide a positional ID or --name")
 			}
 {{- end }}
-{{- if .NeedsConfirm }}
+{{- if .IsDestructive }}
 			if err := platform.ConfirmAction("{{.Name}}", {{if .SupportsNameLookup}}resolvedID{{else if .PathParams}}args[0]{{else}}"{{.Name}}"{{end}}, yes); err != nil {
 				return err
 			}
@@ -268,7 +268,7 @@ func new{{$.GoName}}{{.GoName}}Cmd(cliCtx *registry.CLIContext) *cobra.Command {
 	cmd.Flags().StringArrayVar(&setFlags, "set", nil, "Override body values (key=value, repeatable, supports nested.keys)")
 	cmd.Flags().BoolVar(&scaffoldFlag, "scaffold", false, "Print an example request body and exit")
 {{- end }}
-{{- if .NeedsConfirm }}
+{{- if .IsDestructive }}
 	cmd.Flags().BoolVar(&yes, "yes", false, "Skip confirmation prompt")
 {{- end }}
 {{- if .SupportsNameLookup }}

--- a/generator/platform/template.go
+++ b/generator/platform/template.go
@@ -90,6 +90,9 @@ func new{{$.GoName}}{{.GoName}}Cmd(cliCtx *registry.CLIContext) *cobra.Command {
 {{- if .Long }}
 		Long:  {{printf "%q" .Long}},
 {{- end }}
+{{- if .NeedsConfirm }}
+		Annotations: map[string]string{"jamf:destructive": "true"},
+{{- end }}
 {{- if and .PathParams (not .SupportsNameLookup) }}
 {{- if .HasBody }}
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/internal/commands/destructive_annotations_test.go
+++ b/internal/commands/destructive_annotations_test.go
@@ -15,17 +15,31 @@ import (
 // whose verb appears here MUST carry the `jamf:destructive` annotation
 // (enforced by TestDestructiveVerbCommandsAreAnnotated below).
 //
+// This set must stay in lockstep with the generator's `isDestructiveAction`
+// predicate (generator/parser/parser.go) so the contract is symmetric across
+// generated (Platform device-actions) and hand-written (pro_device_actions.go)
+// surfaces — otherwise the same verb ends up annotated on one side and
+// silently exempt on the other, which is the exact gap the verifier exists
+// to catch.
+//
 // Add new verbs here when introducing a destructive operation pattern. Do not
 // add verbs that are merely *named* with a destructive word but operate on
 // scope/policy/etc. without actually destroying user data — e.g. a `delete-rule`
 // subcommand that edits a config file is not destructive in the MDM sense.
 var destructiveVerbs = map[string]bool{
-	"delete":         true,
-	"bulk-delete":    true,
-	"wipe":           true,
-	"erase":          true,
-	"flush-commands": true,
-	"remove-mdm":     true,
+	"delete":            true,
+	"delete-multiple":   true,
+	"delete-user":       true,
+	"bulk-delete":       true,
+	"wipe":              true,
+	"erase":             true,
+	"flush-commands":    true,
+	"remove-mdm":        true,
+	"lock":              true,
+	"restart":           true,
+	"shutdown":          true,
+	"unmanage":          true,
+	"disable-lost-mode": true,
 }
 
 // hasYesFlag reports whether the command exposes a `--yes` confirmation flag
@@ -67,14 +81,15 @@ func commandPath(cmd *cobra.Command) string {
 	return strings.Join(parts, " ")
 }
 
-// walkCommands invokes fn on every command in the tree rooted at root,
-// including the root itself. Skips hidden commands because the verifier
-// contract applies to user-reachable surface.
+// walkCommands invokes fn on every visible command in the tree rooted at
+// root, including the root itself. Hidden commands are skipped from
+// inspection but their children are still descended into — cobra lets a
+// hidden parent's subcommands execute, so the destructive-annotation
+// contract still applies to those subcommands.
 func walkCommands(root *cobra.Command, fn func(*cobra.Command)) {
-	if root.Hidden {
-		return
+	if !root.Hidden {
+		fn(root)
 	}
-	fn(root)
 	for _, child := range root.Commands() {
 		walkCommands(child, fn)
 	}
@@ -88,15 +103,32 @@ func walkCommands(root *cobra.Command, fn func(*cobra.Command)) {
 func TestDestructiveCommandsHaveYesFlag(t *testing.T) {
 	root := NewRootCmd("test", "abc123", "2024-01-01")
 
-	var violations []string
+	// minDestructiveCommands is a floor sanity check — if the count ever
+	// drops below this, the generator template's annotation emission likely
+	// regressed (typo in key, predicate stopped firing, etc.) and the
+	// "no violations" pass would be silent. Current count is ~280 across
+	// generated delete operations + Platform action verbs + hand-written
+	// destructive Pro/Protect/School commands; 100 leaves room for resource
+	// churn without being so low that a major regression slips through.
+	const minDestructiveCommands = 100
+
+	var (
+		violations []string
+		annotated  int
+	)
 	walkCommands(root, func(cmd *cobra.Command) {
 		if cmd.Annotations["jamf:destructive"] != "true" {
 			return
 		}
+		annotated++
 		if !hasYesFlag(cmd) {
 			violations = append(violations, commandPath(cmd))
 		}
 	})
+
+	if annotated < minDestructiveCommands {
+		t.Errorf("only %d commands carry jamf:destructive annotation (expected >= %d) — the template emission likely regressed", annotated, minDestructiveCommands)
+	}
 
 	if len(violations) > 0 {
 		sort.Strings(violations)

--- a/internal/commands/destructive_annotations_test.go
+++ b/internal/commands/destructive_annotations_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// destructiveVerbs maps the first whitespace-separated token of a command's
+// `Use` field to whether the command is inherently destructive. Any command
+// whose verb appears here MUST carry the `jamf:destructive` annotation
+// (enforced by TestDestructiveVerbCommandsAreAnnotated below).
+//
+// Add new verbs here when introducing a destructive operation pattern. Do not
+// add verbs that are merely *named* with a destructive word but operate on
+// scope/policy/etc. without actually destroying user data — e.g. a `delete-rule`
+// subcommand that edits a config file is not destructive in the MDM sense.
+var destructiveVerbs = map[string]bool{
+	"delete":         true,
+	"bulk-delete":    true,
+	"wipe":           true,
+	"erase":          true,
+	"flush-commands": true,
+	"remove-mdm":     true,
+}
+
+// hasYesFlag reports whether the command exposes a `--yes` confirmation flag
+// via its own FlagSet, its inherited persistent flags, or a parent's
+// persistent flags. The `--yes` convention is jamf-cli's established gate for
+// suppressing the interactive confirmation prompt on destructive operations.
+func hasYesFlag(cmd *cobra.Command) bool {
+	if cmd.Flags().Lookup("yes") != nil {
+		return true
+	}
+	if cmd.PersistentFlags().Lookup("yes") != nil {
+		return true
+	}
+	if cmd.InheritedFlags().Lookup("yes") != nil {
+		return true
+	}
+	return false
+}
+
+// firstWord extracts the leading token of a cobra `Use` string. `"delete <id>"`
+// → `"delete"`. Used for verb-based destructive detection so commands declared
+// as `"delete [name]"` or `"delete <id> [flags]"` all match consistently.
+func firstWord(use string) string {
+	use = strings.TrimSpace(use)
+	if idx := strings.IndexAny(use, " \t"); idx > 0 {
+		return use[:idx]
+	}
+	return use
+}
+
+// commandPath builds a space-separated path from the root down to cmd, e.g.
+// "jamf-cli pro computers delete". Used in violation reports so a failing
+// test names a path the developer can paste into their shell to reproduce.
+func commandPath(cmd *cobra.Command) string {
+	parts := []string{}
+	for c := cmd; c != nil; c = c.Parent() {
+		parts = append([]string{firstWord(c.Use)}, parts...)
+	}
+	return strings.Join(parts, " ")
+}
+
+// walkCommands invokes fn on every command in the tree rooted at root,
+// including the root itself. Skips hidden commands because the verifier
+// contract applies to user-reachable surface.
+func walkCommands(root *cobra.Command, fn func(*cobra.Command)) {
+	if root.Hidden {
+		return
+	}
+	fn(root)
+	for _, child := range root.Commands() {
+		walkCommands(child, fn)
+	}
+}
+
+// TestDestructiveCommandsHaveYesFlag asserts the load-bearing half of the
+// `jamf:destructive` annotation contract: any command marked destructive must
+// expose `--yes` somewhere in its flag hierarchy so callers can suppress the
+// interactive confirmation. A failure here means the annotation is decorative
+// and the command's destructive action isn't gated against accidental use.
+func TestDestructiveCommandsHaveYesFlag(t *testing.T) {
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+
+	var violations []string
+	walkCommands(root, func(cmd *cobra.Command) {
+		if cmd.Annotations["jamf:destructive"] != "true" {
+			return
+		}
+		if !hasYesFlag(cmd) {
+			violations = append(violations, commandPath(cmd))
+		}
+	})
+
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Errorf("%d destructive command(s) missing --yes flag:\n  %s\n\nFix by adding a --yes flag to each, or remove the jamf:destructive annotation if the command isn't actually destructive.",
+			len(violations), strings.Join(violations, "\n  "))
+	}
+}
+
+// TestDestructiveVerbCommandsAreAnnotated asserts the inverse half: any
+// command whose verb implies destruction (per destructiveVerbs) must carry
+// the `jamf:destructive` annotation. A failure here means the command name
+// promises destruction but the metadata that future verifiers (MCP host
+// destructiveHint, future structural checks) consume isn't set — the
+// command will be treated as benign by tooling that reads the annotation.
+func TestDestructiveVerbCommandsAreAnnotated(t *testing.T) {
+	root := NewRootCmd("test", "abc123", "2024-01-01")
+
+	var violations []string
+	walkCommands(root, func(cmd *cobra.Command) {
+		verb := firstWord(cmd.Use)
+		if !destructiveVerbs[verb] {
+			return
+		}
+		if cmd.Annotations["jamf:destructive"] != "true" {
+			violations = append(violations, commandPath(cmd))
+		}
+	})
+
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Errorf("%d destructive-verb command(s) missing jamf:destructive annotation:\n  %s\n\nFix by adding Annotations: map[string]string{\"jamf:destructive\": \"true\"} to each cobra.Command. If a name collision (e.g. \"delete\" used on a non-destructive subcommand) is intentional, broaden the destructiveVerbs map exception list instead.",
+			len(violations), strings.Join(violations, "\n  "))
+	}
+}

--- a/internal/commands/platform/generated/benchmarks.go
+++ b/internal/commands/platform/generated/benchmarks.go
@@ -130,10 +130,11 @@ func newBenchmarksDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	var nameFlag string
 	cmd := &cobra.Command{
-		Use:   "delete <id>",
-		Short: "Remove benchmark with given benchmark ID",
-		Long:  "Remove benchmark with given benchmark ID and remove associated draft (if any) and artifacts from the MDM",
-		Args:  cobra.MaximumNArgs(1),
+		Use:         "delete <id>",
+		Short:       "Remove benchmark with given benchmark ID",
+		Long:        "Remove benchmark with given benchmark ID and remove associated draft (if any) and artifacts from the MDM",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := platform.RequirePlatformClient(cliCtx.PlatformSDKClient); err != nil {
 				return err

--- a/internal/commands/platform/generated/blueprints.go
+++ b/internal/commands/platform/generated/blueprints.go
@@ -153,10 +153,11 @@ func newBlueprintsDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	var nameFlag string
 	cmd := &cobra.Command{
-		Use:   "delete <blueprintId>",
-		Short: "Delete a blueprint",
-		Long:  "Delete a blueprint",
-		Args:  cobra.MaximumNArgs(1),
+		Use:         "delete <blueprintId>",
+		Short:       "Delete a blueprint",
+		Long:        "Delete a blueprint",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := platform.RequirePlatformClient(cliCtx.PlatformSDKClient); err != nil {
 				return err

--- a/internal/commands/platform/generated/device-actions.go
+++ b/internal/commands/platform/generated/device-actions.go
@@ -66,9 +66,10 @@ func newDeviceActionsEraseCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var scaffoldFlag bool
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "erase <id>",
-		Short: "Erase a device",
-		Long:  "Requests that a device erase its content and settings",
+		Use:         "erase <id>",
+		Short:       "Erase a device",
+		Long:        "Requests that a device erase its content and settings",
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if scaffoldFlag {
 				return nil
@@ -123,10 +124,11 @@ func newDeviceActionsEraseCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newDeviceActionsRestartCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "restart <id>",
-		Short: "Restart a device",
-		Long:  "Requests that a device restart",
-		Args:  cobra.ExactArgs(1),
+		Use:         "restart <id>",
+		Short:       "Restart a device",
+		Long:        "Requests that a device restart",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := platform.RequirePlatformClient(cliCtx.PlatformSDKClient); err != nil {
 				return err
@@ -163,10 +165,11 @@ func newDeviceActionsRestartCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newDeviceActionsShutdownCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "shutdown <id>",
-		Short: "Shut down a device",
-		Long:  "Requests that a device shut down",
-		Args:  cobra.ExactArgs(1),
+		Use:         "shutdown <id>",
+		Short:       "Shut down a device",
+		Long:        "Requests that a device shut down",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := platform.RequirePlatformClient(cliCtx.PlatformSDKClient); err != nil {
 				return err
@@ -203,10 +206,11 @@ func newDeviceActionsShutdownCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newDeviceActionsUnmanageCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "unmanage <id>",
-		Short: "Unmanage a device",
-		Long:  "Removes remote management from a device",
-		Args:  cobra.ExactArgs(1),
+		Use:         "unmanage <id>",
+		Short:       "Unmanage a device",
+		Long:        "Removes remote management from a device",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := platform.RequirePlatformClient(cliCtx.PlatformSDKClient); err != nil {
 				return err

--- a/internal/commands/platform/generated/device-groups.go
+++ b/internal/commands/platform/generated/device-groups.go
@@ -152,10 +152,11 @@ func newDeviceGroupsDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	var nameFlag string
 	cmd := &cobra.Command{
-		Use:   "delete <id>",
-		Short: "Delete a device group",
-		Long:  "Delete an existing device group",
-		Args:  cobra.MaximumNArgs(1),
+		Use:         "delete <id>",
+		Short:       "Delete a device group",
+		Long:        "Delete an existing device group",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := platform.RequirePlatformClient(cliCtx.PlatformSDKClient); err != nil {
 				return err

--- a/internal/commands/platform/generated/devices.go
+++ b/internal/commands/platform/generated/devices.go
@@ -154,10 +154,11 @@ func newDevicesDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	var nameFlag string
 	cmd := &cobra.Command{
-		Use:   "delete <id>",
-		Short: "Delete a device",
-		Long:  "Delete an existing device",
-		Args:  cobra.MaximumNArgs(1),
+		Use:         "delete <id>",
+		Short:       "Delete a device",
+		Long:        "Delete an existing device",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := platform.RequirePlatformClient(cliCtx.PlatformSDKClient); err != nil {
 				return err

--- a/internal/commands/pro/generated/adcs_settings.go
+++ b/internal/commands/pro/generated/adcs_settings.go
@@ -195,7 +195,8 @@ func newAdcsSettingsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro adcs-settings delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/advanced_mobile_device_searches.go
+++ b/internal/commands/pro/generated/advanced_mobile_device_searches.go
@@ -321,7 +321,8 @@ func newAdvancedMobileDeviceSearchesDeleteCmd(ctx *registry.CLIContext) *cobra.C
 
   # Delete without confirmation prompt
   jamf-cli pro advanced-mobile-device-searches delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -513,6 +514,7 @@ func newAdvancedMobileDeviceSearchesDeleteMultipleCmd(ctx *registry.CLIContext) 
 		Long:  "Removes specified Advanced Search Objects",
 		Example: `  # Delete multiple advanced-mobile-device-searches by IDs
   jamf-cli pro advanced-mobile-device-searches delete-multiple --ids 1,2,3 --yes`,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/advanced_user_content_searches.go
+++ b/internal/commands/pro/generated/advanced_user_content_searches.go
@@ -318,7 +318,8 @@ func newAdvancedUserContentSearchesDeleteCmd(ctx *registry.CLIContext) *cobra.Co
 
   # Delete without confirmation prompt
   jamf-cli pro advanced-user-content-searches delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/api_integrations.go
+++ b/internal/commands/pro/generated/api_integrations.go
@@ -412,7 +412,8 @@ func newApiIntegrationsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro api-integrations delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/api_roles.go
+++ b/internal/commands/pro/generated/api_roles.go
@@ -401,7 +401,8 @@ func newApiRolesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro api-roles delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/app_installer_deployments.go
+++ b/internal/commands/pro/generated/app_installer_deployments.go
@@ -329,7 +329,8 @@ func newAppInstallerDeploymentsDeleteCmd(ctx *registry.CLIContext) *cobra.Comman
 
   # Delete without confirmation prompt
   jamf-cli pro app-installer-deployments delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/app_requests.go
+++ b/internal/commands/pro/generated/app_requests.go
@@ -279,7 +279,8 @@ func newAppRequestsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro app-requests delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/buildings.go
+++ b/internal/commands/pro/generated/buildings.go
@@ -416,7 +416,8 @@ func newBuildingsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro buildings delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -608,6 +609,7 @@ func newBuildingsDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.Command {
 		Long:  "multiple many Buildings by their ids",
 		Example: `  # Delete multiple buildings by IDs
   jamf-cli pro buildings delete-multiple --ids 1,2,3 --yes`,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/categories.go
+++ b/internal/commands/pro/generated/categories.go
@@ -404,7 +404,8 @@ func newCategoriesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro categories delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -596,6 +597,7 @@ func newCategoriesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.Command {
 		Long:  "Delete multiple Categories by their IDs",
 		Example: `  # Delete multiple categories by IDs
   jamf-cli pro categories delete-multiple --ids 1,2,3 --yes`,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_account_groups.go
+++ b/internal/commands/pro/generated/classic_account_groups.go
@@ -224,7 +224,8 @@ func newClassicAccountGroupsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-account-groups delete 1 --yes`,
-		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_account_users.go
+++ b/internal/commands/pro/generated/classic_account_users.go
@@ -224,7 +224,8 @@ func newClassicAccountUsersDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-account-users delete 1 --yes`,
-		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_advanced_computer_searches.go
+++ b/internal/commands/pro/generated/classic_advanced_computer_searches.go
@@ -250,7 +250,8 @@ func newClassicAdvancedComputerSearchesDeleteCmd(ctx *registry.CLIContext) *cobr
 
   # Delete without confirmation prompt
   jamf-cli pro classic-advanced-computer-searches delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_allowed_file_extensions.go
+++ b/internal/commands/pro/generated/classic_allowed_file_extensions.go
@@ -192,7 +192,8 @@ func newClassicAllowedFileExtensionsDeleteCmd(ctx *registry.CLIContext) *cobra.C
 
   # Delete without confirmation prompt
   jamf-cli pro classic-allowed-file-extensions delete 1 --yes`,
-		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_classes.go
+++ b/internal/commands/pro/generated/classic_classes.go
@@ -250,7 +250,8 @@ func newClassicClassesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-classes delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_computer_configs.go
+++ b/internal/commands/pro/generated/classic_computer_configs.go
@@ -250,7 +250,8 @@ func newClassicComputerConfigsDeleteCmd(ctx *registry.CLIContext) *cobra.Command
 
   # Delete without confirmation prompt
   jamf-cli pro classic-computer-configs delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_computer_ext_attrs.go
+++ b/internal/commands/pro/generated/classic_computer_ext_attrs.go
@@ -250,7 +250,8 @@ func newClassicComputerExtAttrsDeleteCmd(ctx *registry.CLIContext) *cobra.Comman
 
   # Delete without confirmation prompt
   jamf-cli pro classic-computer-ext-attrs delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_computer_invitations.go
+++ b/internal/commands/pro/generated/classic_computer_invitations.go
@@ -204,7 +204,8 @@ func newClassicComputerInvitationsDeleteCmd(ctx *registry.CLIContext) *cobra.Com
 
   # Delete without confirmation prompt
   jamf-cli pro classic-computer-invitations delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_directory_bindings.go
+++ b/internal/commands/pro/generated/classic_directory_bindings.go
@@ -250,7 +250,8 @@ func newClassicDirectoryBindingsDeleteCmd(ctx *registry.CLIContext) *cobra.Comma
 
   # Delete without confirmation prompt
   jamf-cli pro classic-directory-bindings delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_disk_encryption_configs.go
+++ b/internal/commands/pro/generated/classic_disk_encryption_configs.go
@@ -250,7 +250,8 @@ func newClassicDiskEncryptionConfigsDeleteCmd(ctx *registry.CLIContext) *cobra.C
 
   # Delete without confirmation prompt
   jamf-cli pro classic-disk-encryption-configs delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_distribution_points.go
+++ b/internal/commands/pro/generated/classic_distribution_points.go
@@ -250,7 +250,8 @@ func newClassicDistributionPointsDeleteCmd(ctx *registry.CLIContext) *cobra.Comm
 
   # Delete without confirmation prompt
   jamf-cli pro classic-distribution-points delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_dock_items.go
+++ b/internal/commands/pro/generated/classic_dock_items.go
@@ -250,7 +250,8 @@ func newClassicDockItemsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-dock-items delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_ebooks.go
+++ b/internal/commands/pro/generated/classic_ebooks.go
@@ -256,7 +256,8 @@ func newClassicEbooksDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-ebooks delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_ibeacons.go
+++ b/internal/commands/pro/generated/classic_ibeacons.go
@@ -250,7 +250,8 @@ func newClassicIbeaconsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-ibeacons delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_jwt_configs.go
+++ b/internal/commands/pro/generated/classic_jwt_configs.go
@@ -215,7 +215,8 @@ func newClassicJwtConfigsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-jwt-configs delete 1 --yes`,
-		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_licensed_software.go
+++ b/internal/commands/pro/generated/classic_licensed_software.go
@@ -250,7 +250,8 @@ func newClassicLicensedSoftwareDeleteCmd(ctx *registry.CLIContext) *cobra.Comman
 
   # Delete without confirmation prompt
   jamf-cli pro classic-licensed-software delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_mac_apps.go
+++ b/internal/commands/pro/generated/classic_mac_apps.go
@@ -325,7 +325,8 @@ func newClassicMacAppsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-mac-apps delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_macos_config_profiles.go
+++ b/internal/commands/pro/generated/classic_macos_config_profiles.go
@@ -353,7 +353,8 @@ func newClassicMacosConfigProfilesDeleteCmd(ctx *registry.CLIContext) *cobra.Com
 
   # Delete without confirmation prompt
   jamf-cli pro classic-macos-config-profiles delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_mobile_apps.go
+++ b/internal/commands/pro/generated/classic_mobile_apps.go
@@ -325,7 +325,8 @@ func newClassicMobileAppsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-mobile-apps delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_mobile_config_profiles.go
+++ b/internal/commands/pro/generated/classic_mobile_config_profiles.go
@@ -307,7 +307,8 @@ func newClassicMobileConfigProfilesDeleteCmd(ctx *registry.CLIContext) *cobra.Co
 
   # Delete without confirmation prompt
   jamf-cli pro classic-mobile-config-profiles delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_mobile_devices.go
+++ b/internal/commands/pro/generated/classic_mobile_devices.go
@@ -263,7 +263,8 @@ func newClassicMobileDevicesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-mobile-devices delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_mobile_invitations.go
+++ b/internal/commands/pro/generated/classic_mobile_invitations.go
@@ -192,7 +192,8 @@ func newClassicMobileInvitationsDeleteCmd(ctx *registry.CLIContext) *cobra.Comma
 
   # Delete without confirmation prompt
   jamf-cli pro classic-mobile-invitations delete 1 --yes`,
-		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_mobile_provisioning_profiles.go
+++ b/internal/commands/pro/generated/classic_mobile_provisioning_profiles.go
@@ -250,7 +250,8 @@ func newClassicMobileProvisioningProfilesDeleteCmd(ctx *registry.CLIContext) *co
 
   # Delete without confirmation prompt
   jamf-cli pro classic-mobile-provisioning-profiles delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_network_segments.go
+++ b/internal/commands/pro/generated/classic_network_segments.go
@@ -250,7 +250,8 @@ func newClassicNetworkSegmentsDeleteCmd(ctx *registry.CLIContext) *cobra.Command
 
   # Delete without confirmation prompt
   jamf-cli pro classic-network-segments delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_packages.go
+++ b/internal/commands/pro/generated/classic_packages.go
@@ -250,7 +250,8 @@ func newClassicPackagesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-packages delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_patch_external_sources.go
+++ b/internal/commands/pro/generated/classic_patch_external_sources.go
@@ -250,7 +250,8 @@ func newClassicPatchExternalSourcesDeleteCmd(ctx *registry.CLIContext) *cobra.Co
 
   # Delete without confirmation prompt
   jamf-cli pro classic-patch-external-sources delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_patch_policies.go
+++ b/internal/commands/pro/generated/classic_patch_policies.go
@@ -215,7 +215,8 @@ func newClassicPatchPoliciesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-patch-policies delete 1 --yes`,
-		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_patch_titles.go
+++ b/internal/commands/pro/generated/classic_patch_titles.go
@@ -250,7 +250,8 @@ func newClassicPatchTitlesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-patch-titles delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_policies.go
+++ b/internal/commands/pro/generated/classic_policies.go
@@ -256,7 +256,8 @@ func newClassicPoliciesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-policies delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_printers.go
+++ b/internal/commands/pro/generated/classic_printers.go
@@ -250,7 +250,8 @@ func newClassicPrintersDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-printers delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_removable_mac_addresses.go
+++ b/internal/commands/pro/generated/classic_removable_mac_addresses.go
@@ -250,7 +250,8 @@ func newClassicRemovableMacAddressesDeleteCmd(ctx *registry.CLIContext) *cobra.C
 
   # Delete without confirmation prompt
   jamf-cli pro classic-removable-mac-addresses delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_restricted_software.go
+++ b/internal/commands/pro/generated/classic_restricted_software.go
@@ -257,7 +257,8 @@ func newClassicRestrictedSoftwareDeleteCmd(ctx *registry.CLIContext) *cobra.Comm
 
   # Delete without confirmation prompt
   jamf-cli pro classic-restricted-software delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_software_update_servers.go
+++ b/internal/commands/pro/generated/classic_software_update_servers.go
@@ -250,7 +250,8 @@ func newClassicSoftwareUpdateServersDeleteCmd(ctx *registry.CLIContext) *cobra.C
 
   # Delete without confirmation prompt
   jamf-cli pro classic-software-update-servers delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_user_ext_attrs.go
+++ b/internal/commands/pro/generated/classic_user_ext_attrs.go
@@ -250,7 +250,8 @@ func newClassicUserExtAttrsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-user-ext-attrs delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_user_groups.go
+++ b/internal/commands/pro/generated/classic_user_groups.go
@@ -250,7 +250,8 @@ func newClassicUserGroupsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-user-groups delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_vpp_accounts.go
+++ b/internal/commands/pro/generated/classic_vpp_accounts.go
@@ -215,7 +215,8 @@ func newClassicVppAccountsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-vpp-accounts delete 1 --yes`,
-		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_vpp_assignments.go
+++ b/internal/commands/pro/generated/classic_vpp_assignments.go
@@ -223,7 +223,8 @@ func newClassicVppAssignmentsDeleteCmd(ctx *registry.CLIContext) *cobra.Command 
 
   # Delete without confirmation prompt
   jamf-cli pro classic-vpp-assignments delete 1 --yes`,
-		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_vpp_invitations.go
+++ b/internal/commands/pro/generated/classic_vpp_invitations.go
@@ -186,7 +186,8 @@ func newClassicVppInvitationsDeleteCmd(ctx *registry.CLIContext) *cobra.Command 
 
   # Delete without confirmation prompt
   jamf-cli pro classic-vpp-invitations delete 1 --yes`,
-		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/classic_webhooks.go
+++ b/internal/commands/pro/generated/classic_webhooks.go
@@ -250,7 +250,8 @@ func newClassicWebhooksDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro classic-webhooks delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/cloud_azures.go
+++ b/internal/commands/pro/generated/cloud_azures.go
@@ -269,7 +269,8 @@ func newCloudAzuresDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro cloud-azures delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/cloud_distribution_points.go
+++ b/internal/commands/pro/generated/cloud_distribution_points.go
@@ -135,6 +135,7 @@ func newCloudDistributionPointsDeleteCmd(ctx *registry.CLIContext) *cobra.Comman
 
   # Delete without confirmation prompt
   jamf-cli pro cloud-distribution-points delete 1 --yes`,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/cloud_ldaps.go
+++ b/internal/commands/pro/generated/cloud_ldaps.go
@@ -271,7 +271,8 @@ func newCloudLdapsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro cloud-ldaps delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/computer_extension_attributes.go
+++ b/internal/commands/pro/generated/computer_extension_attributes.go
@@ -459,7 +459,8 @@ func newComputerExtensionAttributesDeleteCmd(ctx *registry.CLIContext) *cobra.Co
 
   # Delete without confirmation prompt
   jamf-cli pro computer-extension-attributes delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -651,6 +652,7 @@ func newComputerExtensionAttributesDeleteMultipleCmd(ctx *registry.CLIContext) *
 		Long:  "IDs of the Computer Extension Attribute to be deleted.",
 		Example: `  # Delete multiple computer-extension-attributes by IDs
   jamf-cli pro computer-extension-attributes delete-multiple --ids 1,2,3 --yes`,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/computer_inventory_collection_settings.go
+++ b/internal/commands/pro/generated/computer_inventory_collection_settings.go
@@ -158,7 +158,8 @@ func newComputerInventoryCollectionSettingsDeleteCmd(ctx *registry.CLIContext) *
 
   # Delete without confirmation prompt
   jamf-cli pro computer-inventory-collection-settings delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/computer_prestage_scopes.go
+++ b/internal/commands/pro/generated/computer_prestage_scopes.go
@@ -85,7 +85,8 @@ func newComputerPrestageScopesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra
 		Long:  "Remove device scope for a specific computer prestage",
 		Example: `  # Delete multiple computer-prestage-scopes by IDs
   jamf-cli pro computer-prestage-scopes delete-multiple --ids 1,2,3 --yes`,
-		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/computer_prestages.go
+++ b/internal/commands/pro/generated/computer_prestages.go
@@ -489,7 +489,8 @@ func newComputerPrestagesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro computer-prestages delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/computers_inventory.go
+++ b/internal/commands/pro/generated/computers_inventory.go
@@ -384,7 +384,8 @@ func newComputersInventoryDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro computers-inventory delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/csas.go
+++ b/internal/commands/pro/generated/csas.go
@@ -43,6 +43,7 @@ func newCsasDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro csas delete 1 --yes`,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/departments.go
+++ b/internal/commands/pro/generated/departments.go
@@ -402,7 +402,8 @@ func newDepartmentsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro departments delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -594,6 +595,7 @@ func newDepartmentsDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.Command {
 		Long:  "Deletes all departments by ids passed in body",
 		Example: `  # Delete multiple departments by IDs
   jamf-cli pro departments delete-multiple --ids 1,2,3 --yes`,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/device_enrollment_instances.go
+++ b/internal/commands/pro/generated/device_enrollment_instances.go
@@ -485,7 +485,8 @@ func newDeviceEnrollmentInstancesDeleteCmd(ctx *registry.CLIContext) *cobra.Comm
 
   # Delete without confirmation prompt
   jamf-cli pro device-enrollment-instances delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/digi_cert_settings.go
+++ b/internal/commands/pro/generated/digi_cert_settings.go
@@ -187,7 +187,8 @@ func newDigiCertSettingsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro digi-cert-settings delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/distribution_points.go
+++ b/internal/commands/pro/generated/distribution_points.go
@@ -445,7 +445,8 @@ func newDistributionPointsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro distribution-points delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -637,6 +638,7 @@ func newDistributionPointsDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.Com
 		Long:  "Delete multiple distribution points at once",
 		Example: `  # Delete multiple distribution-points by IDs
   jamf-cli pro distribution-points delete-multiple --ids 1,2,3 --yes`,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/dock_items.go
+++ b/internal/commands/pro/generated/dock_items.go
@@ -271,7 +271,8 @@ func newDockItemsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro dock-items delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/enrollment_customization_panels.go
+++ b/internal/commands/pro/generated/enrollment_customization_panels.go
@@ -202,7 +202,8 @@ func newEnrollmentCustomizationPanelsDeleteCmd(ctx *registry.CLIContext) *cobra.
 
   # Delete without confirmation prompt
   jamf-cli pro enrollment-customization-panels delete 1 2 --yes`,
-		Args: cobra.ExactArgs(2),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/enrollment_customizations.go
+++ b/internal/commands/pro/generated/enrollment_customizations.go
@@ -406,7 +406,8 @@ func newEnrollmentCustomizationsDeleteCmd(ctx *registry.CLIContext) *cobra.Comma
 
   # Delete without confirmation prompt
   jamf-cli pro enrollment-customizations delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/enrollment_languages.go
+++ b/internal/commands/pro/generated/enrollment_languages.go
@@ -367,7 +367,8 @@ func newEnrollmentLanguagesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro enrollment-languages delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -559,6 +560,7 @@ func newEnrollmentLanguagesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.Co
 		Long:  "Delete multiple configured languages from User-Initiated Enrollment settings",
 		Example: `  # Delete multiple enrollment-languages by IDs
   jamf-cli pro enrollment-languages delete-multiple --ids 1,2,3 --yes`,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/enrollment_settings.go
+++ b/internal/commands/pro/generated/enrollment_settings.go
@@ -418,7 +418,8 @@ func newEnrollmentSettingsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro enrollment-settings delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/erase_device_computers.go
+++ b/internal/commands/pro/generated/erase_device_computers.go
@@ -36,10 +36,11 @@ func newEraseDeviceComputersEraseCmd(ctx *registry.CLIContext) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "erase <id>",
-		Short: "Erase a computer",
-		Long:  "Erase a computer",
-		Args:  cobra.ExactArgs(1),
+		Use:         "erase <id>",
+		Short:       "Erase a computer",
+		Long:        "Erase a computer",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/erase_device_mobiles.go
+++ b/internal/commands/pro/generated/erase_device_mobiles.go
@@ -36,10 +36,11 @@ func newEraseDeviceMobilesEraseCmd(ctx *registry.CLIContext) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "erase <id>",
-		Short: "Erase a Mobile Device",
-		Long:  "Erase a Mobile Device",
-		Args:  cobra.ExactArgs(1),
+		Use:         "erase <id>",
+		Short:       "Erase a Mobile Device",
+		Long:        "Erase a Mobile Device",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/groups.go
+++ b/internal/commands/pro/generated/groups.go
@@ -244,7 +244,8 @@ func newGroupsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro groups delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/inventory_preloads.go
+++ b/internal/commands/pro/generated/inventory_preloads.go
@@ -455,7 +455,8 @@ func newInventoryPreloadsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro inventory-preloads delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -1035,9 +1036,10 @@ func newInventoryPreloadsDeleteAllCmd(ctx *registry.CLIContext) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "delete-all",
-		Short: "Delete all Inventory Preload records",
-		Long:  "Deletes all Inventory Preload records.",
+		Use:         "delete-all",
+		Short:       "Delete all Inventory Preload records",
+		Long:        "Deletes all Inventory Preload records.",
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/jamf_protect.go
+++ b/internal/commands/pro/generated/jamf_protect.go
@@ -221,6 +221,7 @@ func newJamfProtectDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro jamf-protect delete 1 --yes`,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/jcds.go
+++ b/internal/commands/pro/generated/jcds.go
@@ -153,7 +153,8 @@ func newJcdsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro jcds delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/log_flushings.go
+++ b/internal/commands/pro/generated/log_flushings.go
@@ -152,7 +152,8 @@ func newLogFlushingsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro log-flushings delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/mdm_renewals.go
+++ b/internal/commands/pro/generated/mdm_renewals.go
@@ -112,7 +112,8 @@ func newMdmRenewalsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro mdm-renewals delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/mobile_device_extension_attributes.go
+++ b/internal/commands/pro/generated/mobile_device_extension_attributes.go
@@ -422,7 +422,8 @@ func newMobileDeviceExtensionAttributesDeleteCmd(ctx *registry.CLIContext) *cobr
 
   # Delete without confirmation prompt
   jamf-cli pro mobile-device-extension-attributes delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/mobile_device_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups.go
@@ -161,10 +161,11 @@ func newMobileDeviceGroupsEraseCmd(ctx *registry.CLIContext) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "erase [<id>]",
-		Short: "Erase all devices in the group",
-		Long:  "Erase all devices in the group",
-		Args:  cobra.MaximumNArgs(1),
+		Use:         "erase [<id>]",
+		Short:       "Erase all devices in the group",
+		Long:        "Erase all devices in the group",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
@@ -410,7 +410,8 @@ func newMobileDeviceGroupsSmartGroupsDeleteCmd(ctx *registry.CLIContext) *cobra.
 
   # Delete without confirmation prompt
   jamf-cli pro mobile-device-groups-smart-groups delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/mobile_device_groups_static_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_static_groups.go
@@ -321,7 +321,8 @@ func newMobileDeviceGroupsStaticGroupsDeleteCmd(ctx *registry.CLIContext) *cobra
 
   # Delete without confirmation prompt
   jamf-cli pro mobile-device-groups-static-groups delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/mobile_device_prestage_scopes.go
+++ b/internal/commands/pro/generated/mobile_device_prestage_scopes.go
@@ -85,7 +85,8 @@ func newMobileDevicePrestageScopesDeleteMultipleCmd(ctx *registry.CLIContext) *c
 		Long:  "Remove device scope for a specific mobile device prestage",
 		Example: `  # Delete multiple mobile-device-prestage-scopes by IDs
   jamf-cli pro mobile-device-prestage-scopes delete-multiple --ids 1,2,3 --yes`,
-		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/mobile_device_prestages.go
+++ b/internal/commands/pro/generated/mobile_device_prestages.go
@@ -509,7 +509,8 @@ func newMobileDevicePrestagesDeleteCmd(ctx *registry.CLIContext) *cobra.Command 
 
   # Delete without confirmation prompt
   jamf-cli pro mobile-device-prestages delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -703,7 +704,8 @@ func newMobileDevicePrestagesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.
 		Long:  "Remove an attachment for a Mobile Device Prestage",
 		Example: `  # Delete multiple mobile-device-prestages by IDs
   jamf-cli pro mobile-device-prestages delete-multiple --ids 1,2,3 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/notifications.go
+++ b/internal/commands/pro/generated/notifications.go
@@ -83,7 +83,8 @@ func newNotificationsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro notifications delete 1 2 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/packages.go
+++ b/internal/commands/pro/generated/packages.go
@@ -468,7 +468,8 @@ func newPackagesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro packages delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 
@@ -660,6 +661,7 @@ func newPackagesDeleteMultipleCmd(ctx *registry.CLIContext) *cobra.Command {
 		Long:  "IDs of the packages to be deleted",
 		Example: `  # Delete multiple packages by IDs
   jamf-cli pro packages delete-multiple --ids 1,2,3 --yes`,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/patch_policies.go
+++ b/internal/commands/pro/generated/patch_policies.go
@@ -184,7 +184,8 @@ func newPatchPoliciesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro patch-policies delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/patch_software_title_configurations.go
+++ b/internal/commands/pro/generated/patch_software_title_configurations.go
@@ -238,7 +238,8 @@ func newPatchSoftwareTitleConfigurationsDeleteCmd(ctx *registry.CLIContext) *cob
 
   # Delete without confirmation prompt
   jamf-cli pro patch-software-title-configurations delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/remove_computer_mdm_profiles.go
+++ b/internal/commands/pro/generated/remove_computer_mdm_profiles.go
@@ -35,10 +35,11 @@ func newRemoveComputerMdmProfilesRemoveMdmProfileCmd(ctx *registry.CLIContext) *
 	)
 
 	cmd := &cobra.Command{
-		Use:   "remove-mdm-profile <id>",
-		Short: "Remove a computer's MDM profile",
-		Long:  "Remove a computer's MDM profile",
-		Args:  cobra.ExactArgs(1),
+		Use:         "remove-mdm-profile <id>",
+		Short:       "Remove a computer's MDM profile",
+		Long:        "Remove a computer's MDM profile",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/remove_mobile_device_mdm_profiles.go
+++ b/internal/commands/pro/generated/remove_mobile_device_mdm_profiles.go
@@ -35,10 +35,11 @@ func newRemoveMobileDeviceMdmProfilesUnmanageCmd(ctx *registry.CLIContext) *cobr
 	)
 
 	cmd := &cobra.Command{
-		Use:   "unmanage <id>",
-		Short: "Unmanage a Mobile Device",
-		Long:  "Unmanage a Mobile Device",
-		Args:  cobra.ExactArgs(1),
+		Use:         "unmanage <id>",
+		Short:       "Unmanage a Mobile Device",
+		Long:        "Unmanage a Mobile Device",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/return_to_service_configurations.go
+++ b/internal/commands/pro/generated/return_to_service_configurations.go
@@ -308,7 +308,8 @@ func newReturnToServiceConfigurationsDeleteCmd(ctx *registry.CLIContext) *cobra.
 
   # Delete without confirmation prompt
   jamf-cli pro return-to-service-configurations delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/scripts.go
+++ b/internal/commands/pro/generated/scripts.go
@@ -459,7 +459,8 @@ func newScriptsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro scripts delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/self_service_branding_ios_resource.go
+++ b/internal/commands/pro/generated/self_service_branding_ios_resource.go
@@ -404,7 +404,8 @@ func newSelfServiceBrandingIosDeleteCmd(ctx *registry.CLIContext) *cobra.Command
 
   # Delete without confirmation prompt
   jamf-cli pro self-service-branding-ios delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/self_service_branding_macos.go
+++ b/internal/commands/pro/generated/self_service_branding_macos.go
@@ -406,7 +406,8 @@ func newSelfServiceBrandingMacosDeleteCmd(ctx *registry.CLIContext) *cobra.Comma
 
   # Delete without confirmation prompt
   jamf-cli pro self-service-branding-macos delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/smart_computer_groups.go
+++ b/internal/commands/pro/generated/smart_computer_groups.go
@@ -410,7 +410,8 @@ func newSmartComputerGroupsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro smart-computer-groups delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/sso_settings_cert.go
+++ b/internal/commands/pro/generated/sso_settings_cert.go
@@ -157,6 +157,7 @@ func newSsoSettingsCertDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro sso-settings-cert delete 1 --yes`,
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/static_computer_groups.go
+++ b/internal/commands/pro/generated/static_computer_groups.go
@@ -410,7 +410,8 @@ func newStaticComputerGroupsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro static-computer-groups delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/supervision_identities.go
+++ b/internal/commands/pro/generated/supervision_identities.go
@@ -405,7 +405,8 @@ func newSupervisionIdentitiesDeleteCmd(ctx *registry.CLIContext) *cobra.Command 
 
   # Delete without confirmation prompt
   jamf-cli pro supervision-identities delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/team_viewer_remote_administrations.go
+++ b/internal/commands/pro/generated/team_viewer_remote_administrations.go
@@ -190,7 +190,8 @@ func newTeamViewerRemoteAdministrationsDeleteCmd(ctx *registry.CLIContext) *cobr
 
   # Delete without confirmation prompt
   jamf-cli pro team-viewer-remote-administrations delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/user_accounts.go
+++ b/internal/commands/pro/generated/user_accounts.go
@@ -423,7 +423,8 @@ func newUserAccountsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro user-accounts delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/user_preferences.go
+++ b/internal/commands/pro/generated/user_preferences.go
@@ -190,7 +190,8 @@ func newUserPreferencesDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro user-preferences delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/users.go
+++ b/internal/commands/pro/generated/users.go
@@ -428,7 +428,8 @@ func newUsersDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro users delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/venafis.go
+++ b/internal/commands/pro/generated/venafis.go
@@ -193,7 +193,8 @@ func newVenafisDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro venafis delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/vpp_locations.go
+++ b/internal/commands/pro/generated/vpp_locations.go
@@ -343,7 +343,8 @@ func newVppLocationsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro vpp-locations delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro/generated/vpp_subscriptions.go
+++ b/internal/commands/pro/generated/vpp_subscriptions.go
@@ -408,7 +408,8 @@ func newVppSubscriptionsDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
   # Delete without confirmation prompt
   jamf-cli pro vpp-subscriptions delete 1 --yes`,
-		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reqCtx := cmd.Context()
 

--- a/internal/commands/pro_command_flush.go
+++ b/internal/commands/pro_command_flush.go
@@ -30,8 +30,9 @@ func newComputerFlushCommandsCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "flush-commands",
-		Short: "Flush pending and/or failed MDM commands from a computer's queue",
+		Use:         "flush-commands",
+		Short:       "Flush pending and/or failed MDM commands from a computer's queue",
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		Long: `Flush pending and/or failed MDM commands from the MDM command queue for a
 computer or computer group.
 
@@ -154,8 +155,9 @@ func newMobileFlushCommandsCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "flush-commands",
-		Short: "Flush pending and/or failed MDM commands from a mobile device's queue",
+		Use:         "flush-commands",
+		Short:       "Flush pending and/or failed MDM commands from a mobile device's queue",
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		Long: `Flush pending and/or failed MDM commands from the MDM command queue for a
 mobile device or mobile device group.
 

--- a/internal/commands/pro_device_actions.go
+++ b/internal/commands/pro_device_actions.go
@@ -18,6 +18,39 @@ import (
 	"github.com/Jamf-Concepts/jamf-cli/internal/resolve"
 )
 
+// destructiveAnnotation returns the standard jamf:destructive Cobra
+// annotation map when the command is inherently destructive in the MCP
+// destructiveHint sense — either explicitly marked by the caller, or
+// recognized by name as a verb the codebase always treats as destructive.
+//
+// The two arguments express different semantics: `destructive` drives the
+// caller's bulk-confirm gating (whether to emit --confirm-destructive and
+// require it in bulk paths). Verb-name detection is broader — shutdown
+// and restart are user-confirm-worthy (and get the existing --yes flag)
+// but the codebase deliberately does not gate them with --confirm-destructive
+// because they aren't data-destructive. Both still want the annotation so
+// future MCP destructiveHint exposure treats them uniformly with the
+// generated Platform device-actions for the same verbs.
+//
+// Keep destructiveByVerb in lockstep with destructiveVerbs in
+// destructive_annotations_test.go.
+func destructiveAnnotation(name string, destructive bool) map[string]string {
+	if destructive || destructiveByVerb[name] {
+		return map[string]string{"jamf:destructive": "true"}
+	}
+	return nil
+}
+
+// destructiveByVerb is the verb-name allowlist consulted by
+// destructiveAnnotation. Commands whose Use is one of these names get the
+// annotation regardless of the caller's `destructive` flag. Mirrors the
+// generator's isDestructiveAction predicate so Platform-generated and
+// hand-written commands stay symmetric for the same verb.
+var destructiveByVerb = map[string]bool{
+	"shutdown": true,
+	"restart":  true,
+}
+
 // deviceTarget holds the mutually exclusive targeting flags shared by all
 // device action commands.
 type deviceTarget struct {
@@ -398,9 +431,10 @@ func newMobileUnmanageCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "unmanage",
-		Short: "Remove management from a mobile device",
-		Long:  "Remove management (unmanage) from a mobile device by serial number, name, or ID.",
+		Use:         "unmanage",
+		Short:       "Remove management from a mobile device",
+		Annotations: destructiveAnnotation("unmanage", true),
+		Long:        "Remove management (unmanage) from a mobile device by serial number, name, or ID.",
 		Example: `  jamf-cli pro md unmanage --serial F4GH5678 --yes
   jamf-cli pro md unmanage --group "Retired iPads" --yes --confirm-destructive`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -607,10 +641,11 @@ func newModernComputerMDMCmd(cliCtx *registry.CLIContext, name, commandType, sho
 		confirmDestructive bool
 	)
 	cmd := &cobra.Command{
-		Use:     name,
-		Short:   short,
-		Long:    long,
-		Example: example,
+		Use:         name,
+		Short:       short,
+		Long:        long,
+		Example:     example,
+		Annotations: destructiveAnnotation(name, destructive),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDeviceAction(cmd, cliCtx, &dt, yes, confirmDestructive, deviceActionConfig{
 				actionName:  name,
@@ -672,9 +707,10 @@ func newComputerRestartCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		rebuildKernelCache bool
 	)
 	cmd := &cobra.Command{
-		Use:   "restart",
-		Short: "Restart a computer",
-		Long:  "Restart a supervised computer by serial number, name, or ID.",
+		Use:         "restart",
+		Short:       "Restart a computer",
+		Annotations: destructiveAnnotation("restart", true),
+		Long:        "Restart a supervised computer by serial number, name, or ID.",
 		Example: `  jamf-cli pro comp restart --serial C02X1234
   jamf-cli pro comp restart --serial C02X1234 --rebuild-kernel-cache
   jamf-cli pro comp restart --group "Lab Macs" --yes`,
@@ -783,10 +819,11 @@ func newModernMobileMDMCmd(cliCtx *registry.CLIContext, name, commandType, short
 		confirmDestructive bool
 	)
 	cmd := &cobra.Command{
-		Use:     name,
-		Short:   short,
-		Long:    long,
-		Example: example,
+		Use:         name,
+		Short:       short,
+		Long:        long,
+		Example:     example,
+		Annotations: destructiveAnnotation(name, destructive),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runMobileAction(cmd, cliCtx, &dt, yes, confirmDestructive, deviceActionConfig{
 				actionName:  name,
@@ -876,9 +913,10 @@ func newMobileLockCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		pin                string
 	)
 	cmd := &cobra.Command{
-		Use:   "lock",
-		Short: "Lock a mobile device",
-		Long:  "Lock a supervised mobile device by serial number, name, or ID. This is a destructive operation.",
+		Use:         "lock",
+		Short:       "Lock a mobile device",
+		Annotations: destructiveAnnotation("lock", true),
+		Long:        "Lock a supervised mobile device by serial number, name, or ID. This is a destructive operation.",
 		Example: `  jamf-cli pro md lock --serial F4GH5678 --yes
   jamf-cli pro md lock --serial F4GH5678 --message "Call IT" --phone-number "555-1234" --yes
   jamf-cli pro md lock --group "Lost Devices" --yes --confirm-destructive`,
@@ -1342,8 +1380,9 @@ func newMobileDeleteUserCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		deleteAll          bool
 	)
 	cmd := &cobra.Command{
-		Use:   "delete-user",
-		Short: "Delete a user from a Shared iPad",
+		Use:         "delete-user",
+		Short:       "Delete a user from a Shared iPad",
+		Annotations: destructiveAnnotation("delete-user", true),
 		Long: `Delete a user account from a Shared iPad.
 Specify --user-name to delete a single user, or --all to delete all users.
 This is a destructive operation.`,

--- a/internal/commands/pro_device_actions.go
+++ b/internal/commands/pro_device_actions.go
@@ -116,8 +116,9 @@ func newComputerEraseCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "erase",
-		Short: "Erase a computer",
+		Use:         "erase",
+		Short:       "Erase a computer",
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		Long: `Erase a computer by serial number, name, or ID, or target a group.
 
 This is a destructive operation that wipes the device. An optional request
@@ -173,9 +174,10 @@ func newComputerRemoveMDMCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "remove-mdm",
-		Short: "Remove the MDM profile from a computer",
-		Long:  "Remove the MDM profile (unmanage) from a computer by serial number, name, or ID.",
+		Use:         "remove-mdm",
+		Short:       "Remove the MDM profile from a computer",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Long:        "Remove the MDM profile (unmanage) from a computer by serial number, name, or ID.",
 		Example: `  jamf-cli pro comp remove-mdm --serial C02X1234 --yes
   jamf-cli pro comp remove-mdm --group "Offboarding" --yes --confirm-destructive`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -346,8 +348,9 @@ func newMobileEraseCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "erase",
-		Short: "Erase a mobile device",
+		Use:         "erase",
+		Short:       "Erase a mobile device",
+		Annotations: map[string]string{"jamf:destructive": "true"},
 		Long: `Erase a mobile device by serial number, name, or ID, or target a group.
 
 This is a destructive operation. An optional request body can configure
@@ -630,7 +633,8 @@ func newModernComputerMDMCmd(cliCtx *registry.CLIContext, name, commandType, sho
 }
 
 func newComputerLockCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newModernComputerMDMCmd(cliCtx, "lock", "DEVICE_LOCK",
+	return newModernComputerMDMCmd(
+		cliCtx, "lock", "DEVICE_LOCK",
 		"Lock a computer",
 		"Lock a computer by serial number, name, or ID. This is a destructive operation.",
 		`  jamf-cli pro comp lock --serial C02X1234 --yes
@@ -640,7 +644,8 @@ func newComputerLockCmd(cliCtx *registry.CLIContext) *cobra.Command {
 }
 
 func newComputerEnableRemoteDesktopCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newModernComputerMDMCmd(cliCtx, "enable-remote-desktop", "ENABLE_REMOTE_DESKTOP",
+	return newModernComputerMDMCmd(
+		cliCtx, "enable-remote-desktop", "ENABLE_REMOTE_DESKTOP",
 		"Enable Remote Desktop on a computer",
 		"Enable the Remote Desktop agent on a computer by serial number, name, or ID.",
 		`  jamf-cli pro comp enable-remote-desktop --serial C02X1234
@@ -650,7 +655,8 @@ func newComputerEnableRemoteDesktopCmd(cliCtx *registry.CLIContext) *cobra.Comma
 }
 
 func newComputerDisableRemoteDesktopCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newModernComputerMDMCmd(cliCtx, "disable-remote-desktop", "DISABLE_REMOTE_DESKTOP",
+	return newModernComputerMDMCmd(
+		cliCtx, "disable-remote-desktop", "DISABLE_REMOTE_DESKTOP",
 		"Disable Remote Desktop on a computer",
 		"Disable the Remote Desktop agent on a computer by serial number, name, or ID.",
 		`  jamf-cli pro comp disable-remote-desktop --serial C02X1234
@@ -693,7 +699,8 @@ func newComputerRestartCmd(cliCtx *registry.CLIContext) *cobra.Command {
 }
 
 func newComputerShutdownCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newModernComputerMDMCmd(cliCtx, "shutdown", "SHUT_DOWN_DEVICE",
+	return newModernComputerMDMCmd(
+		cliCtx, "shutdown", "SHUT_DOWN_DEVICE",
 		"Shut down a computer",
 		"Shut down a supervised computer by serial number, name, or ID.",
 		`  jamf-cli pro comp shutdown --serial C02X1234
@@ -802,7 +809,8 @@ func newModernMobileMDMCmd(cliCtx *registry.CLIContext, name, commandType, short
 }
 
 func newMobileRestartCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newModernMobileMDMCmd(cliCtx, "restart", "RESTART_DEVICE",
+	return newModernMobileMDMCmd(
+		cliCtx, "restart", "RESTART_DEVICE",
 		"Restart a mobile device",
 		"Restart a mobile device by serial number, name, or ID.",
 		`  jamf-cli pro md restart --serial F4GH5678
@@ -812,7 +820,8 @@ func newMobileRestartCmd(cliCtx *registry.CLIContext) *cobra.Command {
 }
 
 func newMobileShutdownCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newModernMobileMDMCmd(cliCtx, "shutdown", "SHUT_DOWN_DEVICE",
+	return newModernMobileMDMCmd(
+		cliCtx, "shutdown", "SHUT_DOWN_DEVICE",
 		"Shut down a mobile device",
 		"Shut down a mobile device by serial number, name, or ID.",
 		`  jamf-cli pro md shutdown --serial F4GH5678`,
@@ -986,7 +995,8 @@ func newMobileEnableLostModeCmd(cliCtx *registry.CLIContext) *cobra.Command {
 }
 
 func newMobileDisableLostModeCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newModernMobileMDMCmd(cliCtx, "disable-lost-mode", "DISABLE_LOST_MODE",
+	return newModernMobileMDMCmd(
+		cliCtx, "disable-lost-mode", "DISABLE_LOST_MODE",
 		"Disable Lost Mode on a mobile device",
 		"Disable Lost Mode on a supervised mobile device that is currently in Lost Mode.",
 		`  jamf-cli pro md disable-lost-mode --serial F4GH5678 --yes
@@ -996,7 +1006,8 @@ func newMobileDisableLostModeCmd(cliCtx *registry.CLIContext) *cobra.Command {
 }
 
 func newMobilePlayLostModeSoundCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newModernMobileMDMCmd(cliCtx, "play-lost-mode-sound", "PLAY_LOST_MODE_SOUND",
+	return newModernMobileMDMCmd(
+		cliCtx, "play-lost-mode-sound", "PLAY_LOST_MODE_SOUND",
 		"Play a sound on a device in Lost Mode",
 		"Play a sound on a supervised mobile device that is currently in Lost Mode.",
 		`  jamf-cli pro md play-lost-mode-sound --serial F4GH5678
@@ -1006,7 +1017,8 @@ func newMobilePlayLostModeSoundCmd(cliCtx *registry.CLIContext) *cobra.Command {
 }
 
 func newMobileClearRestrictionsPasswordCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newModernMobileMDMCmd(cliCtx, "clear-restrictions-password", "CLEAR_RESTRICTIONS_PASSWORD",
+	return newModernMobileMDMCmd(
+		cliCtx, "clear-restrictions-password", "CLEAR_RESTRICTIONS_PASSWORD",
 		"Clear the restrictions password on a mobile device",
 		"Clear the restrictions password on a supervised mobile device.",
 		`  jamf-cli pro md clear-restrictions-password --serial F4GH5678
@@ -1243,7 +1255,8 @@ One of --destination-id or --destination-name is required.`,
 }
 
 func newMobileStopMirroringCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newModernMobileMDMCmd(cliCtx, "stop-mirroring", "STOP_MIRRORING",
+	return newModernMobileMDMCmd(
+		cliCtx, "stop-mirroring", "STOP_MIRRORING",
 		"Stop AirPlay mirroring on a mobile device",
 		"Stop an active AirPlay mirroring session on a mobile device.",
 		`  jamf-cli pro md stop-mirroring --serial F4GH5678`,
@@ -1371,7 +1384,8 @@ This is a destructive operation.`,
 }
 
 func newMobileLogOutUserCmd(cliCtx *registry.CLIContext) *cobra.Command {
-	return newModernMobileMDMCmd(cliCtx, "log-out-user", "LOG_OUT_USER",
+	return newModernMobileMDMCmd(
+		cliCtx, "log-out-user", "LOG_OUT_USER",
 		"Log out the current user on a Shared iPad",
 		"Log out the currently signed-in user on a Shared iPad.",
 		`  jamf-cli pro md log-out-user --serial F4GH5678

--- a/internal/commands/pro_platform_devices.go
+++ b/internal/commands/pro_platform_devices.go
@@ -169,9 +169,10 @@ func newPlatformDevicesUpdateCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newPlatformDevicesDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <id|serial>",
-		Short: "Delete a device",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <id|serial>",
+		Short:       "Delete a device",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := requirePlatformClient(cliCtx); err != nil {
 				return err

--- a/internal/commands/protect_action_configs.go
+++ b/internal/commands/protect_action_configs.go
@@ -139,9 +139,10 @@ func newProtectActionConfigsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command
 func newProtectActionConfigsDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete an action configuration",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete an action configuration",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := protect.NewResolver(cliCtx.ProtectClient)
 			id, err := r.ResolveActionConfigID(cmd.Context(), args[0])

--- a/internal/commands/protect_analytic_sets.go
+++ b/internal/commands/protect_analytic_sets.go
@@ -168,9 +168,10 @@ func newProtectAnalyticSetsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command 
 func newProtectAnalyticSetsDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete an analytic set",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete an analytic set",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := protect.NewResolver(cliCtx.ProtectClient)
 			uuid, err := r.ResolveAnalyticSetUUID(cmd.Context(), args[0])

--- a/internal/commands/protect_analytics.go
+++ b/internal/commands/protect_analytics.go
@@ -178,9 +178,10 @@ func newProtectAnalyticsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newProtectAnalyticsDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete an analytic",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete an analytic",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := protect.NewResolver(cliCtx.ProtectClient)

--- a/internal/commands/protect_api_clients.go
+++ b/internal/commands/protect_api_clients.go
@@ -162,9 +162,10 @@ func newProtectApiClientsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newProtectApiClientsDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete an API client",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete an API client",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := protect.NewResolver(cliCtx.ProtectClient)

--- a/internal/commands/protect_computers.go
+++ b/internal/commands/protect_computers.go
@@ -77,9 +77,10 @@ func newProtectComputersDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 
 	cmd := &cobra.Command{
-		Use:   "delete <hostname|serial>",
-		Short: "Delete a computer by hostname or serial number",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <hostname|serial>",
+		Short:       "Delete a computer by hostname or serial number",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := protect.NewResolver(cliCtx.ProtectClient)

--- a/internal/commands/protect_exception_sets.go
+++ b/internal/commands/protect_exception_sets.go
@@ -142,9 +142,10 @@ func newProtectExceptionSetsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command
 func newProtectExceptionSetsDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete an exception set",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete an exception set",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := protect.NewResolver(cliCtx.ProtectClient)
 			uuid, err := r.ResolveExceptionSetUUID(cmd.Context(), args[0])

--- a/internal/commands/protect_groups.go
+++ b/internal/commands/protect_groups.go
@@ -166,9 +166,10 @@ func newProtectGroupsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newProtectGroupsDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a group",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete a group",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := protect.NewResolver(cliCtx.ProtectClient)

--- a/internal/commands/protect_plans.go
+++ b/internal/commands/protect_plans.go
@@ -180,9 +180,10 @@ func newProtectPlansApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newProtectPlansDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a plan",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete a plan",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := protect.NewResolver(cliCtx.ProtectClient)

--- a/internal/commands/protect_prevent_lists.go
+++ b/internal/commands/protect_prevent_lists.go
@@ -178,9 +178,10 @@ func hasInlineFlags(vals ...string) bool {
 func newProtectPreventListsDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a custom prevent list",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete a custom prevent list",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := protect.NewResolver(cliCtx.ProtectClient)
 			id, err := r.ResolveCustomPreventListID(cmd.Context(), args[0])

--- a/internal/commands/protect_roles.go
+++ b/internal/commands/protect_roles.go
@@ -174,9 +174,10 @@ func newProtectRolesApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newProtectRolesDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a role",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete a role",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := protect.NewResolver(cliCtx.ProtectClient)

--- a/internal/commands/protect_rscs.go
+++ b/internal/commands/protect_rscs.go
@@ -158,9 +158,10 @@ func newProtectRSCSApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newProtectRSCSDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a removable storage control set",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete a removable storage control set",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := protect.NewResolver(cliCtx.ProtectClient)
 			id, err := r.ResolveRemovableStorageControlSetID(cmd.Context(), args[0])

--- a/internal/commands/protect_telemetry.go
+++ b/internal/commands/protect_telemetry.go
@@ -148,9 +148,10 @@ func newProtectTelemetryApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newProtectTelemetryDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a telemetry configuration",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete a telemetry configuration",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := protect.NewResolver(cliCtx.ProtectClient)
 			id, err := r.ResolveTelemetryV2ID(cmd.Context(), args[0])

--- a/internal/commands/protect_ulf.go
+++ b/internal/commands/protect_ulf.go
@@ -161,9 +161,10 @@ func newProtectULFApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newProtectULFDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a unified logging filter",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete a unified logging filter",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := protect.NewResolver(cliCtx.ProtectClient)

--- a/internal/commands/protect_users.go
+++ b/internal/commands/protect_users.go
@@ -178,9 +178,10 @@ func newProtectUsersApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newProtectUsersDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <email>",
-		Short: "Delete a user",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <email>",
+		Short:       "Delete a user",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := protect.NewResolver(cliCtx.ProtectClient)

--- a/internal/commands/school_classes.go
+++ b/internal/commands/school_classes.go
@@ -176,9 +176,10 @@ func newSchoolClassesApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newSchoolClassesDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a class",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete a class",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := school.NewResolver(cliCtx.SchoolClient)

--- a/internal/commands/school_device_groups.go
+++ b/internal/commands/school_device_groups.go
@@ -176,9 +176,10 @@ func newSchoolDeviceGroupsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newSchoolDeviceGroupsDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a device group",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete a device group",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := school.NewResolver(cliCtx.SchoolClient)

--- a/internal/commands/school_devices.go
+++ b/internal/commands/school_devices.go
@@ -187,9 +187,10 @@ func newSchoolDevicesEraseCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		clearActivationLock bool
 	)
 	cmd := &cobra.Command{
-		Use:   "erase <name-or-udid>",
-		Short: "Erase a device",
-		Args:  cobra.ExactArgs(1),
+		Use:         "erase <name-or-udid>",
+		Short:       "Erase a device",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			udid, err := resolveSchoolDeviceUDID(ctx, cliCtx, args[0])

--- a/internal/commands/school_devices.go
+++ b/internal/commands/school_devices.go
@@ -100,9 +100,10 @@ func newSchoolDevicesRestartCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		clearPasscode bool
 	)
 	cmd := &cobra.Command{
-		Use:   "restart <name-or-udid>",
-		Short: "Restart a device",
-		Args:  cobra.ExactArgs(1),
+		Use:         "restart <name-or-udid>",
+		Short:       "Restart a device",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			udid, err := resolveSchoolDeviceUDID(ctx, cliCtx, args[0])

--- a/internal/commands/school_groups.go
+++ b/internal/commands/school_groups.go
@@ -171,9 +171,10 @@ func newSchoolGroupsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newSchoolGroupsDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a user group",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete a user group",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := school.NewResolver(cliCtx.SchoolClient)

--- a/internal/commands/school_ibeacons.go
+++ b/internal/commands/school_ibeacons.go
@@ -160,9 +160,10 @@ func newSchoolIBeaconsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newSchoolIBeaconsDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete an iBeacon",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <name>",
+		Short:       "Delete an iBeacon",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := school.NewResolver(cliCtx.SchoolClient)

--- a/internal/commands/school_users.go
+++ b/internal/commands/school_users.go
@@ -178,9 +178,10 @@ func newSchoolUsersApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 func newSchoolUsersDeleteCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <username-or-email>",
-		Short: "Delete a user",
-		Args:  cobra.ExactArgs(1),
+		Use:         "delete <username-or-email>",
+		Short:       "Delete a user",
+		Annotations: map[string]string{"jamf:destructive": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			r := school.NewResolver(cliCtx.SchoolClient)


### PR DESCRIPTION
## Summary

- Generator templates emit `Annotations["jamf:destructive": "true"]` for every DELETE-method operation (modern UAPI, Classic API, Platform Gateway)
- 23 hand-written destructive commands (protect/school/platform delete/erase, computers-inventory + mobile-devices flush-commands) get the annotation manually
- New structural verifier test asserts the contract from both directions — annotated commands must have `--yes`, destructive-verb commands must have the annotation
- Second consumer of the `lint:*` / `jamf:*` / `mcp:*` annotation namespace introduced by #198/#199

## Why

The pattern docs/solutions/design-patterns/cobra-annotations-as-policy-2026-05-11.md (shipped in #199) argues that per-command policy metadata should live in Cobra annotations rather than in comment magic, separate registries, or per-tool allowlists. PR #198 (dead-code lint) was the first consumer with `lint:keep-flag`. This PR is the second.

The immediate value is *load-bearing*: the new verifier test caught 23 real gaps in hand-written Protect/School/Platform delete commands during development. Those gaps would otherwise have flowed straight into MCP destructiveHint exposure as "this command is safe" — wrong, and unfixable without a structural check.

Future tooling (MCP server, confirmation-gate verifier, destructive-action audit log) reads the same annotation. Adding it once here pays off as those tools come online.

## What's in the PR

### Template surface (3 files)

| Template | Trigger | Lines |
|----------|---------|-------|
| `generator/parser/generator.go` (modern UAPI) | `.IsDestructive` predicate (already existed for confirm prompts) | +3 |
| `generator/classic/generator.go` | Hardcoded on the delete command emitter | +1 |
| `generator/platform/template.go` | `.NeedsConfirm` predicate | +3 |

### Hand-written commands (24 commands across 22 files)

- `pro_device_actions.go`: 5 destructive verbs (`computer-erase`, `mobile-erase`, `remove-mdm`, etc.)
- `pro_command_flush.go`: 2 commands (`flush-commands` on computers and mobile-devices)
- `pro_platform_devices.go`: 1 (`platform-devices delete`)
- `protect_*.go`: 14 resources (`action-configs`, `analytic-sets`, `analytics`, `api-clients`, `computers`, `custom-prevent-lists`, `exception-sets`, `groups`, `plans`, `removable-storage-control-sets`, `roles`, `telemetry`, `unified-logging-filters`, `users`)
- `school_*.go`: 6 resources (`classes`, `device-groups`, `devices` [erase], `groups`, `ibeacons`, `users`)

### Generated commands

~100 generated `delete` files (Pro modern + Classic + Platform) automatically pick up the annotation from the template change. `make verify-generated` passes — regen output matches the committed state.

### Structural verifier

`internal/commands/destructive_annotations_test.go`:

- **`TestDestructiveCommandsHaveYesFlag`** — walks the cobra tree; any command with `Annotations["jamf:destructive"] == "true"` must have `--yes` in its flags, persistent flags, or inherited flags. **Passes.**
- **`TestDestructiveVerbCommandsAreAnnotated`** — inverse contract; commands whose `Use` starts with `delete`, `bulk-delete`, `wipe`, `erase`, `flush-commands`, or `remove-mdm` must carry the annotation. **Passes after fixing the 23 hand-written gaps.**

Both tests produce a violation list with full command paths so future contributors can paste them into a shell to reproduce.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — full suite green (including the new verifier)
- [x] `make lint` — 0 issues
- [x] `make verify-generated` — generated tree matches committed state
- [x] `make lint-dead` — no dead flags or funcs (from #198's lint)
- [x] Manual: ran the verifier in isolation; observed both tests pass

## Notes

The `Platform` template uses `.NeedsConfirm` rather than a method-based `IsDestructive` check, matching how Platform commands declare destructive intent today. If future Platform commands need destructive marking that isn't a DELETE, the `NeedsConfirm` template predicate is the right hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)