### PR TITLE
fix(platform): apply commands fail to create new resources

### DIFF
--- a/internal/commands/pro_platform_device_groups.go
+++ b/internal/commands/pro_platform_device_groups.go
@@ -67,6 +67,9 @@ func newPDGApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 
 			dg := devicegroups.New(cliCtx.PlatformSDKClient)
 			id, resolveErr := dg.ResolveDeviceGroupIDByName(ctx, createReq.Name)
+			if resolveErr != nil && !platform.IsNotFound(resolveErr) {
+				return resolveErr
+			}
 			if resolveErr != nil {
 				// Not found — create
 				result, err := devicegroups.New(cliCtx.PlatformSDKClient).CreateDeviceGroup(ctx, &createReq)

--- a/internal/platform/resolve.go
+++ b/internal/platform/resolve.go
@@ -2,7 +2,11 @@
 
 package platform
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
+)
 
 // ErrNotFound is returned when a resource name cannot be resolved to an ID.
 //
@@ -20,7 +24,15 @@ import "errors"
 // platform.IsNotFound assertions across the codebase.
 var ErrNotFound = errors.New("not found")
 
-// IsNotFound reports whether err is or wraps ErrNotFound.
+// IsNotFound reports whether err is or wraps ErrNotFound, or is a 404
+// *APIResponseError from the Platform SDK (returned by Resolve* methods when
+// a name lookup yields zero results).
 func IsNotFound(err error) bool {
-	return errors.Is(err, ErrNotFound)
+	if errors.Is(err, ErrNotFound) {
+		return true
+	}
+	if apiErr := jamfplatform.AsAPIError(err); apiErr != nil && apiErr.HasStatus(404) {
+		return true
+	}
+	return false
 }

--- a/internal/platform/resolve_test.go
+++ b/internal/platform/resolve_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
 )
 
 func TestIsNotFound(t *testing.T) {
@@ -14,10 +16,28 @@ func TestIsNotFound(t *testing.T) {
 		t.Error("expected IsNotFound(ErrNotFound) = true")
 	}
 
-	// Wrapped sentinel (as produced by ResolveBlueprintID)
+	// Wrapped sentinel
 	wrapped := fmt.Errorf("blueprint %q not found: %w", "test", ErrNotFound)
 	if !IsNotFound(wrapped) {
-		t.Error("expected IsNotFound on wrapped error = true")
+		t.Error("expected IsNotFound on wrapped sentinel = true")
+	}
+
+	// SDK *APIResponseError 404 (returned by ResolveBlueprintIDByName on empty results)
+	api404 := &jamfplatform.APIResponseError{StatusCode: 404}
+	if !IsNotFound(api404) {
+		t.Error("expected IsNotFound(*APIResponseError{404}) = true")
+	}
+
+	// SDK *APIResponseError 404 wrapped in fmt.Errorf (as the SDK wraps it)
+	wrapped404 := fmt.Errorf("ResolveBlueprintIDByName(Brand New Blueprint): %w", api404)
+	if !IsNotFound(wrapped404) {
+		t.Error("expected IsNotFound on wrapped *APIResponseError{404} = true")
+	}
+
+	// SDK *APIResponseError non-404 must not match
+	api500 := &jamfplatform.APIResponseError{StatusCode: 500}
+	if IsNotFound(api500) {
+		t.Error("expected IsNotFound(*APIResponseError{500}) = false")
 	}
 
 	// Non-matching error


### PR DESCRIPTION
## Summary

- `platform.IsNotFound` matched only the `ErrNotFound` sentinel via `errors.Is`; SDK `Resolve*` methods return `*APIResponseError{404}` on empty search results, which never matched
- `blueprints apply` always errored on new names — resolver returned 404, `IsNotFound` returned false, command exited instead of creating
- `platform-device-groups apply` had the inverse problem: no `IsNotFound` guard at all, so any error (500s, auth failures) fell through to a create attempt

## Fix

- `platform.IsNotFound` now also matches `*APIResponseError` with status 404 (via `jamfplatform.AsAPIError`)
- Added the missing `IsNotFound` guard to `platform-device-groups apply` to match the blueprint pattern
- Extended `TestIsNotFound` to cover SDK 404, wrapped SDK 404, SDK 500 (must not match), sentinel, nil

## Test

Live-tested on `platform-nmartin` for both commands:
- New name → `GET` (empty) → `POST` → 201 ✓
- Existing name → `GET` (found) → `PATCH`/`PUT` → 204/200 ✓

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)