### PR TITLE
fix(normalize): escape all U+0000-001F control chars in JSON string values

### DIFF
--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -2753,7 +2753,6 @@ func renameResourceByID(ctx context.Context, client registry.HTTPClient, updateU
 // other fields untouched. Empty value is a no-op; empty body is bootstrapped
 // to {} first. Used to apply a user-supplied --name flag to the request body
 // without requiring them to hand-build JSON.
-// NOTE: Also used by classic helpers (same generated package).
 func setBodyStringField(body []byte, field, value string) ([]byte, error) {
 	if value == "" {
 		return body, nil
@@ -2786,7 +2785,6 @@ type fileFieldSpec struct {
 // If body is empty and at least one file flag is active, a new object is
 // constructed. File values overwrite any value already present in the body;
 // companion and name fields are only filled when absent.
-// NOTE: Also used by classic helpers (same generated package).
 func injectFileFields(body []byte, specs []fileFieldSpec) ([]byte, error) {
 	active := false
 	for _, s := range specs {
@@ -2901,7 +2899,6 @@ func readApplyInput(fromFile string) ([]byte, error) {
 
 // printScaffoldOutput prints a scaffold JSON string, converting to YAML when the
 // output format requests it.
-// NOTE: Also used by classic_registry.go helpers (same generated package).
 func printScaffoldOutput(jsonStr, format string) error {
 	if format == "yaml" {
 		var v any
@@ -2917,7 +2914,6 @@ func printScaffoldOutput(jsonStr, format string) error {
 }
 
 // normalizeInputToJSON converts YAML input to JSON. JSON input is returned unchanged.
-// NOTE: Also used by classic_registry.go helpers (same generated package).
 func normalizeInputToJSON(data []byte) ([]byte, error) {
 	// Fast path: already JSON
 	if json.Valid(data) {
@@ -2942,11 +2938,10 @@ func normalizeInputToJSON(data []byte) ([]byte, error) {
 	return out, nil
 }
 
-// escapeJSONStringLiterals escapes literal control characters (newlines, carriage
-// returns, tabs) that appear inside JSON string values. Fixes input produced by
-// shells like zsh whose built-in echo interprets \n even in single-quoted strings,
-// creating invalid JSON that the YAML fallback would silently mangle.
-// NOTE: Also used by classic_registry.go helpers (same generated package).
+// escapeJSONStringLiterals escapes any U+0000–U+001F control character that
+// appears inside a JSON string value. Fixes input produced by shells like zsh
+// whose built-in echo interprets \n even in single-quoted strings, creating
+// invalid JSON that the YAML fallback would silently mangle.
 func escapeJSONStringLiterals(data []byte) []byte {
 	var buf bytes.Buffer
 	buf.Grow(len(data))
@@ -2963,12 +2958,8 @@ func escapeJSONStringLiterals(data []byte) []byte {
 		case b == '"':
 			inString = !inString
 			buf.WriteByte(b)
-		case inString && b == '\n':
-			buf.WriteString(` + "`" + `\n` + "`" + `)
-		case inString && b == '\r':
-			buf.WriteString(` + "`" + `\r` + "`" + `)
-		case inString && b == '\t':
-			buf.WriteString(` + "`" + `\t` + "`" + `)
+		case inString && b <= 0x1f:
+			fmt.Fprintf(&buf, ` + "`" + `\u%04x` + "`" + `, b)
 		default:
 			buf.WriteByte(b)
 		}

--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -2923,6 +2923,13 @@ func normalizeInputToJSON(data []byte) ([]byte, error) {
 	if json.Valid(data) {
 		return data, nil
 	}
+	// Shells like zsh interpret \n in echo output as real newlines (0x0a), producing
+	// literal control characters inside JSON string values — invalid JSON. Try
+	// escaping those characters and retry before falling back to YAML, which would
+	// silently fold them into spaces.
+	if fixed := escapeJSONStringLiterals(data); json.Valid(fixed) {
+		return fixed, nil
+	}
 	// Try YAML → any → JSON
 	var v any
 	if err := yaml.Unmarshal(data, &v); err != nil {
@@ -2933,6 +2940,40 @@ func normalizeInputToJSON(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("re-marshaling YAML as JSON: %w", err)
 	}
 	return out, nil
+}
+
+// escapeJSONStringLiterals escapes literal control characters (newlines, carriage
+// returns, tabs) that appear inside JSON string values. Fixes input produced by
+// shells like zsh whose built-in echo interprets \n even in single-quoted strings,
+// creating invalid JSON that the YAML fallback would silently mangle.
+// NOTE: Also used by classic_registry.go helpers (same generated package).
+func escapeJSONStringLiterals(data []byte) []byte {
+	var buf bytes.Buffer
+	buf.Grow(len(data))
+	inString := false
+	escaped := false
+	for _, b := range data {
+		switch {
+		case escaped:
+			buf.WriteByte(b)
+			escaped = false
+		case b == '\\' && inString:
+			buf.WriteByte(b)
+			escaped = true
+		case b == '"':
+			inString = !inString
+			buf.WriteByte(b)
+		case inString && b == '\n':
+			buf.WriteString(` + "`" + `\n` + "`" + `)
+		case inString && b == '\r':
+			buf.WriteString(` + "`" + `\r` + "`" + `)
+		case inString && b == '\t':
+			buf.WriteString(` + "`" + `\t` + "`" + `)
+		default:
+			buf.WriteByte(b)
+		}
+	}
+	return buf.Bytes()
 }
 
 // extractJSONField extracts a string field from a JSON object.

--- a/internal/commands/pro/generated/file_fields_test.go
+++ b/internal/commands/pro/generated/file_fields_test.go
@@ -11,6 +11,133 @@ import (
 	"testing"
 )
 
+// ─── escapeJSONStringLiterals ─────────────────────────────────────────────────
+
+func TestEscapeJSONStringLiterals_NoControlChars(t *testing.T) {
+	input := []byte(`{"name":"hello world"}`)
+	got := escapeJSONStringLiterals(input)
+	if string(got) != string(input) {
+		t.Errorf("got %s, want unchanged %s", got, input)
+	}
+}
+
+func TestEscapeJSONStringLiterals_LiteralNewline(t *testing.T) {
+	// zsh echo interprets \n as a real newline even in single-quoted strings
+	input := []byte("{\"scriptContents\":\"#!/bin/bash\necho recon\"}")
+	got := escapeJSONStringLiterals(input)
+	want := `{"scriptContents":"#!/bin/bash\necho recon"}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+	if !json.Valid(got) {
+		t.Errorf("output is not valid JSON: %s", got)
+	}
+}
+
+func TestEscapeJSONStringLiterals_LiteralCRLF(t *testing.T) {
+	input := []byte("{\"x\":\"line1\r\nline2\"}")
+	got := escapeJSONStringLiterals(input)
+	want := `{"x":"line1\r\nline2"}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestEscapeJSONStringLiterals_LiteralTab(t *testing.T) {
+	input := []byte("{\"x\":\"col1\tcol2\"}")
+	got := escapeJSONStringLiterals(input)
+	want := `{"x":"col1\tcol2"}`
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestEscapeJSONStringLiterals_EscapedQuoteNotMistreatedAsStringEnd(t *testing.T) {
+	// \"  inside a string should NOT toggle inString
+	input := []byte("{\"x\":\"say \\\"hello\\\" now\nend\"}")
+	got := escapeJSONStringLiterals(input)
+	if !json.Valid(got) {
+		t.Errorf("output not valid JSON: %s", got)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(got, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["x"] != "say \"hello\" now\nend" {
+		t.Errorf("x = %q, want correct value", m["x"])
+	}
+}
+
+func TestEscapeJSONStringLiterals_NewlineOutsideString(t *testing.T) {
+	// Newlines between JSON tokens are valid — should pass through unchanged
+	input := []byte("{\n\"x\":\"y\"\n}")
+	got := escapeJSONStringLiterals(input)
+	if string(got) != string(input) {
+		t.Errorf("whitespace outside strings should not change: got %s", got)
+	}
+	if !json.Valid(got) {
+		t.Errorf("output not valid JSON: %s", got)
+	}
+}
+
+// ─── normalizeInputToJSON (zsh echo regression) ───────────────────────────────
+
+func TestNormalizeInputToJSON_JSONPassthrough(t *testing.T) {
+	input := []byte(`{"name":"Test","scriptContents":"#!/bin/bash\necho recon"}`)
+	out, err := normalizeInputToJSON(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(input) {
+		t.Errorf("valid JSON should pass through unchanged: got %s", out)
+	}
+}
+
+func TestNormalizeInputToJSON_ZshEchoLiteralNewline(t *testing.T) {
+	// Simulates: echo '{"scriptContents":"#!/bin/bash\necho recon"}' in zsh
+	// zsh echo interprets \n as real newline — input is invalid JSON
+	input := []byte("{\"name\":\"Test\",\"scriptContents\":\"#!/bin/bash\necho recon\necho done\",\"priority\":\"AFTER\"}")
+	if json.Valid(input) {
+		t.Skip("input is already valid JSON on this platform")
+	}
+	out, err := normalizeInputToJSON(input)
+	if err != nil {
+		t.Fatalf("should not error: %v", err)
+	}
+	if !json.Valid(out) {
+		t.Errorf("output not valid JSON: %s", out)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["scriptContents"] != "#!/bin/bash\necho recon\necho done" {
+		t.Errorf("scriptContents = %q, want newlines preserved", m["scriptContents"])
+	}
+}
+
+func TestNormalizeInputToJSON_YAMLBlockLiteral(t *testing.T) {
+	input := []byte("name: Test\nscriptContents: |\n  #!/bin/bash\n  echo recon\n")
+	out, err := normalizeInputToJSON(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(out) {
+		t.Errorf("output not valid JSON: %s", out)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["name"] != "Test" {
+		t.Errorf("name = %q, want Test", m["name"])
+	}
+	// Block literal trailing newline is preserved by yaml.v3
+	if !strings.Contains(m["scriptContents"], "#!/bin/bash") || !strings.Contains(m["scriptContents"], "echo recon") {
+		t.Errorf("scriptContents = %q, missing expected content", m["scriptContents"])
+	}
+}
+
 // writeTempFile creates a file with given contents and returns its path.
 // Uses t.TempDir() so cleanup is automatic.
 func writeTempFile(t *testing.T, name, content string) string {

--- a/internal/commands/pro/generated/file_fields_test.go
+++ b/internal/commands/pro/generated/file_fields_test.go
@@ -25,7 +25,7 @@ func TestEscapeJSONStringLiterals_LiteralNewline(t *testing.T) {
 	// zsh echo interprets \n as a real newline even in single-quoted strings
 	input := []byte("{\"scriptContents\":\"#!/bin/bash\necho recon\"}")
 	got := escapeJSONStringLiterals(input)
-	want := `{"scriptContents":"#!/bin/bash\necho recon"}`
+	want := "{\"scriptContents\":\"#!/bin/bash\\u000aecho recon\"}"
 	if string(got) != want {
 		t.Errorf("got %s, want %s", got, want)
 	}
@@ -37,7 +37,7 @@ func TestEscapeJSONStringLiterals_LiteralNewline(t *testing.T) {
 func TestEscapeJSONStringLiterals_LiteralCRLF(t *testing.T) {
 	input := []byte("{\"x\":\"line1\r\nline2\"}")
 	got := escapeJSONStringLiterals(input)
-	want := `{"x":"line1\r\nline2"}`
+	want := "{\"x\":\"line1\\u000d\\u000aline2\"}"
 	if string(got) != want {
 		t.Errorf("got %s, want %s", got, want)
 	}
@@ -46,9 +46,22 @@ func TestEscapeJSONStringLiterals_LiteralCRLF(t *testing.T) {
 func TestEscapeJSONStringLiterals_LiteralTab(t *testing.T) {
 	input := []byte("{\"x\":\"col1\tcol2\"}")
 	got := escapeJSONStringLiterals(input)
-	want := `{"x":"col1\tcol2"}`
+	want := "{\"x\":\"col1\\u0009col2\"}"
 	if string(got) != want {
 		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestEscapeJSONStringLiterals_OtherControlChars(t *testing.T) {
+	// Non-printable control chars beyond \n/\r/\t also produce \uXXXX.
+	input := []byte("{\"x\":\"a\x00b\x08c\x0cc\"}")
+	got := escapeJSONStringLiterals(input)
+	want := "{\"x\":\"a\\u0000b\\u0008c\\u000cc\"}"
+	if string(got) != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+	if !json.Valid(got) {
+		t.Errorf("output is not valid JSON: %s", got)
 	}
 }
 
@@ -97,9 +110,6 @@ func TestNormalizeInputToJSON_ZshEchoLiteralNewline(t *testing.T) {
 	// Simulates: echo '{"scriptContents":"#!/bin/bash\necho recon"}' in zsh
 	// zsh echo interprets \n as real newline — input is invalid JSON
 	input := []byte("{\"name\":\"Test\",\"scriptContents\":\"#!/bin/bash\necho recon\necho done\",\"priority\":\"AFTER\"}")
-	if json.Valid(input) {
-		t.Skip("input is already valid JSON on this platform")
-	}
 	out, err := normalizeInputToJSON(input)
 	if err != nil {
 		t.Fatalf("should not error: %v", err)

--- a/internal/commands/pro/generated/registry.go
+++ b/internal/commands/pro/generated/registry.go
@@ -376,7 +376,6 @@ func renameResourceByID(ctx context.Context, client registry.HTTPClient, updateU
 // other fields untouched. Empty value is a no-op; empty body is bootstrapped
 // to {} first. Used to apply a user-supplied --name flag to the request body
 // without requiring them to hand-build JSON.
-// NOTE: Also used by classic helpers (same generated package).
 func setBodyStringField(body []byte, field, value string) ([]byte, error) {
 	if value == "" {
 		return body, nil
@@ -409,7 +408,6 @@ type fileFieldSpec struct {
 // If body is empty and at least one file flag is active, a new object is
 // constructed. File values overwrite any value already present in the body;
 // companion and name fields are only filled when absent.
-// NOTE: Also used by classic helpers (same generated package).
 func injectFileFields(body []byte, specs []fileFieldSpec) ([]byte, error) {
 	active := false
 	for _, s := range specs {
@@ -524,7 +522,6 @@ func readApplyInput(fromFile string) ([]byte, error) {
 
 // printScaffoldOutput prints a scaffold JSON string, converting to YAML when the
 // output format requests it.
-// NOTE: Also used by classic_registry.go helpers (same generated package).
 func printScaffoldOutput(jsonStr, format string) error {
 	if format == "yaml" {
 		var v any
@@ -540,7 +537,6 @@ func printScaffoldOutput(jsonStr, format string) error {
 }
 
 // normalizeInputToJSON converts YAML input to JSON. JSON input is returned unchanged.
-// NOTE: Also used by classic_registry.go helpers (same generated package).
 func normalizeInputToJSON(data []byte) ([]byte, error) {
 	// Fast path: already JSON
 	if json.Valid(data) {
@@ -565,11 +561,10 @@ func normalizeInputToJSON(data []byte) ([]byte, error) {
 	return out, nil
 }
 
-// escapeJSONStringLiterals escapes literal control characters (newlines, carriage
-// returns, tabs) that appear inside JSON string values. Fixes input produced by
-// shells like zsh whose built-in echo interprets \n even in single-quoted strings,
-// creating invalid JSON that the YAML fallback would silently mangle.
-// NOTE: Also used by classic_registry.go helpers (same generated package).
+// escapeJSONStringLiterals escapes any U+0000–U+001F control character that
+// appears inside a JSON string value. Fixes input produced by shells like zsh
+// whose built-in echo interprets \n even in single-quoted strings, creating
+// invalid JSON that the YAML fallback would silently mangle.
 func escapeJSONStringLiterals(data []byte) []byte {
 	var buf bytes.Buffer
 	buf.Grow(len(data))
@@ -586,12 +581,8 @@ func escapeJSONStringLiterals(data []byte) []byte {
 		case b == '"':
 			inString = !inString
 			buf.WriteByte(b)
-		case inString && b == '\n':
-			buf.WriteString(`\n`)
-		case inString && b == '\r':
-			buf.WriteString(`\r`)
-		case inString && b == '\t':
-			buf.WriteString(`\t`)
+		case inString && b <= 0x1f:
+			fmt.Fprintf(&buf, `\u%04x`, b)
 		default:
 			buf.WriteByte(b)
 		}

--- a/internal/commands/pro/generated/registry.go
+++ b/internal/commands/pro/generated/registry.go
@@ -546,6 +546,13 @@ func normalizeInputToJSON(data []byte) ([]byte, error) {
 	if json.Valid(data) {
 		return data, nil
 	}
+	// Shells like zsh interpret \n in echo output as real newlines (0x0a), producing
+	// literal control characters inside JSON string values — invalid JSON. Try
+	// escaping those characters and retry before falling back to YAML, which would
+	// silently fold them into spaces.
+	if fixed := escapeJSONStringLiterals(data); json.Valid(fixed) {
+		return fixed, nil
+	}
 	// Try YAML → any → JSON
 	var v any
 	if err := yaml.Unmarshal(data, &v); err != nil {
@@ -556,6 +563,40 @@ func normalizeInputToJSON(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("re-marshaling YAML as JSON: %w", err)
 	}
 	return out, nil
+}
+
+// escapeJSONStringLiterals escapes literal control characters (newlines, carriage
+// returns, tabs) that appear inside JSON string values. Fixes input produced by
+// shells like zsh whose built-in echo interprets \n even in single-quoted strings,
+// creating invalid JSON that the YAML fallback would silently mangle.
+// NOTE: Also used by classic_registry.go helpers (same generated package).
+func escapeJSONStringLiterals(data []byte) []byte {
+	var buf bytes.Buffer
+	buf.Grow(len(data))
+	inString := false
+	escaped := false
+	for _, b := range data {
+		switch {
+		case escaped:
+			buf.WriteByte(b)
+			escaped = false
+		case b == '\\' && inString:
+			buf.WriteByte(b)
+			escaped = true
+		case b == '"':
+			inString = !inString
+			buf.WriteByte(b)
+		case inString && b == '\n':
+			buf.WriteString(`\n`)
+		case inString && b == '\r':
+			buf.WriteString(`\r`)
+		case inString && b == '\t':
+			buf.WriteString(`\t`)
+		default:
+			buf.WriteByte(b)
+		}
+	}
+	return buf.Bytes()
 }
 
 // extractJSONField extracts a string field from a JSON object.


### PR DESCRIPTION
## Summary

- Fixes a bug where shells like `zsh` interpret `\n` in `echo` output as real newline bytes (0x0A), producing invalid JSON that the YAML fallback would silently mangle (converting newlines to spaces in script contents, etc.)
- Replaces the original three-case switch (`\n`, `\r`, `\t` only) with a full RFC 8259 range check: any byte ≤ 0x1F inside a JSON string value is escaped as `\uXXXX`
- Removes four stale `NOTE: Also used by classic_registry.go` comments from functions not referenced by `classic_registry.go`; the two accurate ones (`readApplyInput`, `extractIDString`) are kept
- Removes dead `t.Skip` guard that could never fire (literal-newline bytes are never valid JSON)
- Updates test `want` strings to match `\uXXXX` output format; adds `TestEscapeJSONStringLiterals_OtherControlChars` to cover non-common control characters

## Test plan

- [x] `make test` passes
- [x] `make generate && make verify-generated` confirms generated code is in sync
- [x] Live test: `echo '{"name":"...","scriptContents":"#!/bin/bash\necho recon","priority":"AFTER"}' | jamf-cli pro scripts create` succeeds against a real Jamf Pro instance (script created with newline preserved in `scriptContents`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)