### PR TITLE
feat(output): add --no-hints flag to suppress advisory hints (#214)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,7 @@ Adding a converter: create `ddm_<name>.go`, implement `convertFunc`, register vi
 - Pro `overview` makes ~37 parallel API calls; Protect `overview` makes ~14.
 - Classic API paths start with `/JSSResource/` and bypass `/api` prefix added by `client.Do()`. In platform gateway mode, rewritten to `/api/proclassic/tenant/{id}/`.
 - `NO_COLOR` env var respected (https://no-color.org).
+- `--no-hints` flag / `JAMF_CLI_NO_HINTS` env (value-parsed via `strconv.ParseBool`) suppress advisory hints only, leaving the spinner and progress output intact; `--quiet` remains a strict superset that also silences both.
 
 ## Common Workflows
 

--- a/docs/superpowers/specs/2026-05-30-no-hints-flag-design.md
+++ b/docs/superpowers/specs/2026-05-30-no-hints-flag-design.md
@@ -1,0 +1,166 @@
+# Design: `--no-hints` flag + `JAMF_CLI_NO_HINTS` env var
+
+- **Issue:** [#214 — Way to disable hints without using --quiet](https://github.com/Jamf-Concepts/jamf-cli/issues/214)
+- **Date:** 2026-05-30
+- **Status:** Approved for planning
+
+## Problem
+
+`--quiet` / `-q` is overloaded. A single flag drives three independent
+suppression paths:
+
+```
+--quiet / -q  ──┬─→ Formatter.SetQuiet()   → suppresses the list-size "hint:" line (internal/output/output.go:190)
+                ├─→ shouldShowSpinner()     → suppresses the "Loading…" spinner      (internal/commands/root.go:146)
+                └─→ (implicit) progress msgs many commands gate stderr chatter on it
+```
+
+A user who only wants the advisory hint gone
+(`hint: 73 results returned. Narrow with --select=<fields>, --compact, …`)
+must currently also disable the loading spinner and all progress feedback.
+The issue requests a narrower opt-out, suggesting `--no-hint`.
+
+Today there is exactly **one** hint: `maybePrintListHint` in
+`internal/output/output.go:189`, which fires only for non-table output formats,
+when the row count is ≥ `listHintThreshold` (50), and when not quiet.
+
+## Goals
+
+- Add a flag that suppresses advisory hints **without** affecting the spinner
+  or progress output.
+- Provide a persistent, discoverable way to set it (env var) for users who
+  always want hints off.
+- Keep `--quiet` behavior unchanged (it remains a strict superset).
+
+## Non-goals
+
+- Splitting `--quiet` into component flags. `--quiet` suppressing the spinner
+  and progress output is existing, relied-upon behavior — the documented CI
+  pattern is `JAMF_CLI_ARGS='--quiet --no-input'` (`root.go:417`). Changing what
+  `--quiet` does would be a silent breaking change.
+- A config-file setting for hints (`disable-hints: true`). Out of scope; the
+  env var plus the existing `JAMF_CLI_ARGS` mechanism cover persistence.
+- New hint types. `hints` is framed as a category for naming durability only.
+- A "force hints on" override flag. No use case; matches `NO_COLOR`'s one-way
+  model.
+
+## Behavior contract
+
+| Input | Hint | Spinner | Progress msgs |
+|---|---|---|---|
+| (default) | shown | shown | shown |
+| `--no-hints` or `JAMF_CLI_NO_HINTS=1` | **off** | shown | shown |
+| `--quiet` / `-q` | off | off | off |
+
+`--no-hints` and `--quiet` compose: the hint is suppressed if **either** is set.
+`--quiet` remains a strict superset of `--no-hints`.
+
+## Naming
+
+- Flag: `--no-hints` (plural — treats hints as a category; matches the existing
+  `--no-color` / `--no-input` `no-*` convention; survives a future second hint
+  without a rename).
+- Env var: `JAMF_CLI_NO_HINTS` (mirrors the `JAMF_*` env namespace; parallels
+  `NO_COLOR`).
+
+## Design
+
+The change is isolated. The hint is emitted **inside** the `Formatter`, so
+generated and hand-written commands need no edits — wiring one `Formatter`
+field plus one global flag covers every command at once. Six edit sites total.
+
+### 1. `internal/output/output.go` — the only behavioral logic
+
+- Add field to `Formatter`:
+  ```go
+  noHints bool
+  ```
+- Add setter (mirrors `SetQuiet`):
+  ```go
+  // SetNoHints suppresses advisory hints (e.g. the list-size hint) written
+  // to stderr, without affecting the spinner or progress output. A narrower
+  // opt-out than SetQuiet.
+  func (f *Formatter) SetNoHints(v bool) {
+      f.noHints = v
+  }
+  ```
+- Gate in `maybePrintListHint` (currently line 190):
+  ```go
+  if f.quiet || f.noHints || rowCount < listHintThreshold {
+      return
+  }
+  ```
+
+### 2. `internal/commands/root.go` — flag, env, wiring
+
+- New package-level var alongside the other global flags (`var (… quiet bool …)`):
+  ```go
+  noHints bool
+  ```
+- Env honoring in `PersistentPreRunE`, immediately after the existing
+  `NO_COLOR` block (~line 425):
+  ```go
+  // JAMF_CLI_NO_HINTS disables advisory hints (parallels NO_COLOR, but
+  // value-parsed so JAMF_CLI_NO_HINTS=0 leaves hints on).
+  if b, err := strconv.ParseBool(os.Getenv("JAMF_CLI_NO_HINTS")); err == nil && b {
+      noHints = true
+  }
+  ```
+  Requires adding `"strconv"` to the import block.
+- Wire into the formatter immediately after `formatter.SetQuiet(quiet)` (line 458):
+  ```go
+  formatter.SetNoHints(noHints)
+  ```
+- Register the flag near the other persistent flags (~line 580):
+  ```go
+  cmd.PersistentFlags().BoolVar(&noHints, "no-hints", false,
+      "suppress advisory hints (e.g. large-result narrowing tips); keeps spinner and progress output")
+  ```
+
+### Env-var parsing rationale
+
+`NO_COLOR` (the adjacent precedent) is presence-based: any value, even empty or
+`0`, enables it. For our own `JAMF_CLI_NO_HINTS` we deliberately diverge and use
+`strconv.ParseBool`, so `JAMF_CLI_NO_HINTS=0` / `=false` leaves hints **on**.
+This avoids the well-known `NO_COLOR=0`-still-disables footgun for a Jamf-owned
+variable where users will reasonably expect `=0` to mean "off". The flag default
+is `false`; both the flag and the env var only ever turn the suppression **on**,
+so there is no flag-vs-env conflict to resolve.
+
+### 3. Docs
+
+- Add a one-line mention of `JAMF_CLI_NO_HINTS` to the root command `Long`
+  help text, next to where `JAMF_CLI_ARGS` / `NO_COLOR` are already documented
+  (`root.go` ~line 416).
+- CLAUDE.md `Conventions` note about `NO_COLOR` may optionally gain a parallel
+  line — decided during spec review, not required for the feature.
+
+## Testing
+
+Per the project's output-flag-matrix convention
+(`docs/solutions/conventions/output-flag-matrix-2026-05-08.md`):
+
+- **`internal/output/list_hint_test.go`**: add `TestListHint_SuppressedByNoHints`,
+  mirroring the existing `TestListHint_SuppressedByQuiet` — set `SetNoHints(true)`,
+  print ≥ threshold rows in a non-table format, assert stderr is empty. The
+  existing fire/threshold/table/format tests already cover the
+  hints-still-shown-by-default cases.
+- **`internal/commands/root_test.go`**: add a test that `JAMF_CLI_NO_HINTS=1`
+  (via `t.Setenv`) results in the hint being suppressed end-to-end, mirroring
+  the existing `NO_COLOR` test (~line 1014); and a paired case asserting
+  `JAMF_CLI_NO_HINTS=0` leaves the hint shown (locks in the `ParseBool` choice).
+- **Manual matrix check before declaring done**:
+  - `-o json` on a list returning ≥ 50 rows with `--no-hints`: hint gone, JSON
+    output intact, spinner still appears during the request.
+  - Same with `JAMF_CLI_NO_HINTS=1` and no flag.
+  - `--quiet` still suppresses both hint and spinner (unchanged).
+  - `JAMF_CLI_NO_HINTS=0` shows the hint.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `internal/output/output.go` | `noHints` field, `SetNoHints` setter, gate in `maybePrintListHint` |
+| `internal/commands/root.go` | `noHints` var, `strconv` import, env parse, `SetNoHints` wiring, flag registration, `Long` help line |
+| `internal/output/list_hint_test.go` | `TestListHint_SuppressedByNoHints` |
+| `internal/commands/root_test.go` | `JAMF_CLI_NO_HINTS` env tests (on + off) |

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -11,6 +11,7 @@ import (
 	"net/http/cookiejar"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -36,6 +37,7 @@ var (
 	profile        string
 	outputFmt      string
 	quiet          bool
+	noHints        bool
 	verboseLevel   int
 	noInput        bool
 	noColor        bool
@@ -546,13 +548,22 @@ users, classes, and apps).
 
 Set JAMF_CLI_ARGS to prepend default flags to every invocation:
   export JAMF_CLI_ARGS='--quiet --no-input'
-  export JAMF_CLI_ARGS='--profile "My CI Profile"'`,
+  export JAMF_CLI_ARGS='--profile "My CI Profile"'
+
+Set JAMF_CLI_NO_HINTS=1 to suppress advisory hints while keeping the
+spinner and progress output (narrower than --quiet).`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// Respect NO_COLOR env var (https://no-color.org)
 			if _, ok := os.LookupEnv("NO_COLOR"); ok {
 				noColor = true
+			}
+
+			// JAMF_CLI_NO_HINTS disables advisory hints (parallels NO_COLOR,
+			// but value-parsed so JAMF_CLI_NO_HINTS=0 leaves hints on).
+			if b, err := strconv.ParseBool(os.Getenv("JAMF_CLI_NO_HINTS")); err == nil && b {
+				noHints = true
 			}
 
 			// Load config up-front so the formatter honours default-output
@@ -587,6 +598,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 			}
 			formatter.SetProjector(output.Projector{Compact: compact, Select: selectFields})
 			formatter.SetQuiet(quiet)
+			formatter.SetNoHints(noHints)
 			cliCtx.Output = &cliOutput{formatter}
 
 			// Skip auth for commands that don't need it. Most are matched
@@ -711,6 +723,7 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
 	cmd.PersistentFlags().StringVarP(&profile, "profile", "p", "", "config profile to use (or JAMF_PROFILE env)")
 	cmd.PersistentFlags().StringVarP(&outputFmt, "output", "o", "json", "output format: table, json, csv, yaml, plain, xml (pretty), raw (classic commands default to xml)")
 	cmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "suppress non-error output")
+	cmd.PersistentFlags().BoolVar(&noHints, "no-hints", false, "suppress advisory hints (e.g. large-result narrowing tips); keeps spinner and progress output (or JAMF_CLI_NO_HINTS env)")
 	cmd.PersistentFlags().CountVarP(&verboseLevel, "verbose", "v", "show HTTP requests/responses (-vv adds headers, -vvv adds bodies)")
 	cmd.PersistentFlags().BoolVar(&noInput, "no-input", false, "never prompt; fail if input required")
 	cmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "disable colored output")

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -1112,6 +1112,18 @@ func TestShouldShowSpinner(t *testing.T) {
 	}
 }
 
+// TestShouldShowSpinner_IgnoresNoHints guards the defining invariant of #214:
+// --no-hints / JAMF_CLI_NO_HINTS suppresses advisory hints but must NOT touch
+// the spinner. If noHints ever leaks into shouldShowSpinner(), this fails.
+func TestShouldShowSpinner_IgnoresNoHints(t *testing.T) {
+	t.Cleanup(resetGlobals)
+	resetGlobals()
+	noHints = true
+	if !shouldShowSpinner() {
+		t.Error("shouldShowSpinner()=false with noHints=true; --no-hints must not suppress the spinner")
+	}
+}
+
 func TestSpinnerClient_PassesThrough(t *testing.T) {
 	mock := &mockHTTPClient{}
 	sc := &spinnerClient{inner: mock}

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -439,6 +439,7 @@ func resetGlobals() {
 	profile = ""
 	outputFmt = "json"
 	quiet = false
+	noHints = false
 	verboseLevel = 0
 	noInput = false
 	noColor = false
@@ -1036,6 +1037,47 @@ func TestPersistentPreRunE_NOCOLOREnv(t *testing.T) {
 	// Verify no ANSI escape sequences
 	if strings.Contains(output, "\033[") {
 		t.Errorf("output with NO_COLOR should not contain ANSI codes, got: %q", output)
+	}
+}
+
+func TestPersistentPreRunE_NoHintsEnv(t *testing.T) {
+	cases := []struct {
+		name        string
+		envVal      string
+		wantNoHints bool
+	}{
+		{"1 enables", "1", true},
+		{"true enables", "true", true},
+		{"TRUE enables", "TRUE", true},
+		{"0 leaves hints on", "0", false},
+		{"false leaves hints on", "false", false},
+		{"empty leaves hints on", "", false},
+		{"garbage leaves hints on", "yarp", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetGlobals()
+			clearAuthEnv(t)
+			t.Setenv("JAMF_CLI_NO_HINTS", tc.envVal)
+
+			root := NewRootCmd("test", "abc123", "2024-01-01", "unknown")
+
+			// version is in chainSkip, but the JAMF_CLI_NO_HINTS parse runs
+			// before the skip return — same as the NO_COLOR handling — so the
+			// global reflects the env regardless of the command.
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			root.SetArgs([]string{"version"})
+			_ = root.Execute()
+			_ = w.Close()
+			os.Stdout = oldStdout
+			_, _ = io.ReadAll(r)
+
+			if noHints != tc.wantNoHints {
+				t.Errorf("JAMF_CLI_NO_HINTS=%q: noHints=%v, want %v", tc.envVal, noHints, tc.wantNoHints)
+			}
+		})
 	}
 }
 

--- a/internal/output/list_hint_test.go
+++ b/internal/output/list_hint_test.go
@@ -75,9 +75,11 @@ func TestListHint_SuppressedByNoHints(t *testing.T) {
 	}
 }
 
-func TestListHint_NoHintsKeepsSpinnerSemantics(t *testing.T) {
+func TestListHint_NoHintsDoesNotImplyQuiet(t *testing.T) {
 	// --no-hints suppresses the hint but, unlike --quiet, does not set
-	// quiet — a regression guard so the two stay independent.
+	// quiet — a regression guard so the two stay independent. The spinner
+	// half of that independence is guarded in the commands package by
+	// TestShouldShowSpinner_IgnoresNoHints (spinner logic lives there).
 	f, _, stderr := newTestFormatterWithStderr("json")
 	f.SetNoHints(true)
 	rows := makeRows(listHintThreshold)

--- a/internal/output/list_hint_test.go
+++ b/internal/output/list_hint_test.go
@@ -63,6 +63,35 @@ func TestListHint_SuppressedByQuiet(t *testing.T) {
 	}
 }
 
+func TestListHint_SuppressedByNoHints(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("json")
+	f.SetNoHints(true)
+	rows := makeRows(listHintThreshold + 50)
+	if err := f.Print(rows); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("--no-hints should suppress hint, got stderr=%q", stderr.String())
+	}
+}
+
+func TestListHint_NoHintsKeepsSpinnerSemantics(t *testing.T) {
+	// --no-hints suppresses the hint but, unlike --quiet, does not set
+	// quiet — a regression guard so the two stay independent.
+	f, _, stderr := newTestFormatterWithStderr("json")
+	f.SetNoHints(true)
+	rows := makeRows(listHintThreshold)
+	if err := f.Print(rows); err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+	if f.quiet {
+		t.Error("SetNoHints must not flip quiet; they are independent suppressors")
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("--no-hints should suppress hint, got stderr=%q", stderr.String())
+	}
+}
+
 func TestListHint_SuppressedForTable(t *testing.T) {
 	f, _, stderr := newTestFormatterWithStderr("table")
 	rows := makeRows(listHintThreshold + 10)

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -62,6 +62,7 @@ type Formatter struct {
 	noColor   bool
 	wide      bool
 	quiet     bool
+	noHints   bool
 	projector Projector
 }
 
@@ -86,6 +87,13 @@ func (f *Formatter) SetProjector(p Projector) {
 // list-size hint). Errors and primary output on stdout are unaffected.
 func (f *Formatter) SetQuiet(q bool) {
 	f.quiet = q
+}
+
+// SetNoHints suppresses advisory hints (e.g. the list-size hint) written to
+// stderr. Unlike SetQuiet it leaves the spinner and progress output alone —
+// a narrower opt-out. Errors and primary output on stdout are unaffected.
+func (f *Formatter) SetNoHints(v bool) {
+	f.noHints = v
 }
 
 // listHintThreshold is the minimum row count that triggers the
@@ -187,7 +195,7 @@ func (f *Formatter) Print(data any) error {
 // below threshold, and for table format (which already shows "(N total)"
 // in its summary header).
 func (f *Formatter) maybePrintListHint(rowCount int) {
-	if f.quiet || rowCount < listHintThreshold {
+	if f.quiet || f.noHints || rowCount < listHintThreshold {
 		return
 	}
 	if f.format == FormatTable || f.format == "" {


### PR DESCRIPTION
## Problem

Closes #214.

`--quiet` is overloaded. A single flag drives three independent suppression paths:

- the list-size advisory hint (`hint: 73 results returned. Narrow with …`)
- the `Loading…` spinner
- progress / status output in various commands

A user who only wants the hint gone has no choice but to also kill the spinner and all progress feedback. The issue requests a narrower opt-out.

## Solution

Add a `--no-hints` flag and a `JAMF_CLI_NO_HINTS` env var that suppress **advisory hints only**, leaving the spinner and progress output intact.

| Input | Hint | Spinner | Progress |
|---|---|---|---|
| (default) | shown | shown | shown |
| `--no-hints` / `JAMF_CLI_NO_HINTS=1` | **off** | shown | shown |
| `--quiet` / `-q` | off | off | off |

`--quiet` is unchanged and remains a strict superset; the two compose (the hint is suppressed if **either** is set). This keeps the documented CI pattern `JAMF_CLI_ARGS='--quiet --no-input'` working — no behavior change for existing users.

The hint is emitted inside the `Formatter`, so this is wired once (one field + one global flag) and applies to every command; no per-command edits.

### Env-var semantics

`JAMF_CLI_NO_HINTS` is value-parsed via `strconv.ParseBool`, **not** presence-based like `NO_COLOR`. So `JAMF_CLI_NO_HINTS=0` / `=false` correctly leaves hints **on**, avoiding the well-known `NO_COLOR=0`-still-disables footgun for a Jamf-owned variable.

## Changes

- `internal/output/output.go` — `noHints` field, `SetNoHints` setter, gate in `maybePrintListHint`
- `internal/commands/root.go` — `noHints` global, `--no-hints` flag, `JAMF_CLI_NO_HINTS` parse, formatter wiring, `Long` help line
- `CLAUDE.md` — convention note beside the existing `NO_COLOR` entry
- `docs/superpowers/specs/2026-05-30-no-hints-flag-design.md` — design spec

## Testing

Built test-first (RED watched to fail for both the formatter gate and the env wiring before implementing).

- `internal/output/list_hint_test.go` — `--no-hints` suppresses the hint; regression guard that it does **not** flip `quiet`
- `internal/commands/root_test.go` — table test that `JAMF_CLI_NO_HINTS` truthy values enable and `0`/`false`/empty/garbage leave hints on
- `make test`: full suite passes (0 failures) · `make lint`: 0 issues · `make build`: ok
- Verified `--no-hints` and `JAMF_CLI_NO_HINTS` surface in `--help`, and that `shouldShowSpinner()` does not reference `noHints` (spinner provably untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)