### PR TITLE
fix(site): show release tag instead of "vunknown" version badge

### DIFF
--- a/generator/site/main.go
+++ b/generator/site/main.go
@@ -53,7 +53,7 @@ func main() {
 	previous := flag.String("previous", "", "path to previous commands.json for new-command detection")
 	flag.Parse()
 
-	versionOut, err := exec.Command(*binary, "version").Output()
+	versionOut, err := exec.Command(*binary, "version", "-o", "json").Output()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error running %s version: %v\n", *binary, err)
 		os.Exit(1)
@@ -369,13 +369,16 @@ func splitCSV(s string) []string {
 }
 
 func parseVersion(output string) string {
-	line, _, _ := strings.Cut(output, "\n")
-	fields := strings.Fields(line)
-	if len(fields) < 2 {
+	v := extractRawVersion(output)
+	if v == "" {
 		return "unknown"
 	}
-	v := fields[1]
-	// Strip git-describe suffix (e.g. "v1.2.0-52-gffc0b5a-dirty" → "v1.2.0")
+	// Drop the git-describe "-dirty" marker so the site shows the clean
+	// release tag. The deploy workflow builds from the latest release tag but
+	// overlays site files from main, which dirties the tree — without this a
+	// clean tag surfaces as "v1.17.0-dirty" instead of "v1.17.0".
+	v = strings.TrimSuffix(v, "-dirty")
+	// Strip git-describe suffix (e.g. "v1.2.0-52-gffc0b5a" → "v1.2.0")
 	if parts := strings.SplitN(v, "-", 2); len(parts) == 2 && strings.ContainsAny(parts[1], "0123456789") {
 		if _, err := strconv.Atoi(strings.Split(parts[1], "-")[0]); err == nil {
 			v = parts[0]
@@ -384,4 +387,25 @@ func parseVersion(output string) string {
 	// Normalize: strip "v" prefix so display layer can format consistently
 	v = strings.TrimPrefix(v, "v")
 	return v
+}
+
+// extractRawVersion pulls the raw version string out of `jamf-cli version`
+// output. The command emits JSON by default (the global -o default is json),
+// so we parse that first; older binaries that predate -o support print a
+// "jamf-cli <version>" banner, so we fall back to that. Returns "" when
+// neither yields a version, letting the caller map it to "unknown".
+func extractRawVersion(output string) string {
+	if strings.HasPrefix(strings.TrimSpace(output), "{") {
+		var report struct {
+			Version string `json:"version"`
+		}
+		if json.Unmarshal([]byte(output), &report) == nil {
+			return report.Version
+		}
+	}
+	line, _, _ := strings.Cut(output, "\n")
+	if fields := strings.Fields(line); len(fields) >= 2 {
+		return fields[1]
+	}
+	return ""
 }

--- a/generator/site/main_test.go
+++ b/generator/site/main_test.go
@@ -285,6 +285,31 @@ func TestParseVersion(t *testing.T) {
 			input: "",
 			want:  "unknown",
 		},
+		{
+			name:  "json default output strips git-describe suffix",
+			input: "{\n  \"version\": \"v1.17.0-25-g74846ff\",\n  \"commit\": \"74846ff\",\n  \"built\": \"2026-05-31T04:31:46Z\"\n}\n",
+			want:  "1.17.0",
+		},
+		{
+			name:  "json exact tag",
+			input: `{"version":"v1.2.0","commit":"abc1234"}`,
+			want:  "1.2.0",
+		},
+		{
+			name:  "json empty version falls back to unknown",
+			input: `{"version":"","commit":"abc1234"}`,
+			want:  "unknown",
+		},
+		{
+			name:  "json exact tag dirty build strips dirty marker",
+			input: `{"version":"v1.17.0-dirty","commit":"abc1234"}`,
+			want:  "1.17.0",
+		},
+		{
+			name:  "json describe with count and dirty marker",
+			input: `{"version":"v1.17.0-25-g74846ff-dirty","commit":"74846ff"}`,
+			want:  "1.17.0",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

The showcase site rendered **`vunknown`** as the version badge.

Root cause is a broken implicit contract. The site generator ran `jamf-cli version` and parsed the first line expecting the text banner `jamf-cli <version>` (`fields[1]`). But the global `-o` default is `json`, and since #195 the `version` command honors `-o` — so the bare call now returns JSON whose first line is just `{`. `parseVersion` saw a single field, fell into its `len(fields) < 2` → `"unknown"` branch, and `catalog.js` prefixed `v` → **`vunknown`**. This affected the deployed site, since the deploy workflow makes the same flagless call.

## Fix

`generator/site/main.go`:
- Invoke `version -o json` explicitly and read the structured `version` field, with a fallback to the legacy banner for binaries that predate `-o` support (the deploy builds the binary from the latest **release tag** while taking the generator from **main**, so the generator can't assume the binary speaks JSON).
- Strip the git-describe `-dirty` marker. The deploy overlays site files from `main` onto the tagged checkout, which dirties the tree — without this, a clean tag surfaced as `v1.17.0-dirty`.

## Result

All build paths now resolve to the clean nearest release tag:

| Build path | `git describe` | Badge |
|---|---|---|
| Deploy on push to `main` (tag + dirty overlay) | `v1.17.0-dirty` | **v1.17.0** |
| Release event | `v1.17.0` | **v1.17.0** |
| Local `make site` | `v1.17.0-25-g74846ff-dirty` | **v1.17.0** |

## Testing

- Added JSON `TestParseVersion` cases incl. both dirty-build scenarios; existing banner cases retained (now exercise the fallback path). Full `generator/site` package passes; `go vet`, `gofmt`, `go build ./...` clean.
- Verified end-to-end by simulating the deploy: checked out `v1.17.0`, applied the workflow's overlay, built the binary, ran the fixed generator → `commands.json` reports `"version": "1.17.0"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)