### PR TITLE
feat(hooks): re-add jamf-cli spec-check hook with correct Platform spec mapping

### DIFF
--- a/skills/hooks/hooks.json
+++ b/skills/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null); [ -z \"$cmd\" ] && exit 0; echo \"$cmd\" | grep -qE 'jamf-cli\\b[^|&;]*\\b(create|update|apply|patch)\\b' || exit 0; echo \"$cmd\" | grep -q -- '--scaffold' && exit 0; printf '[jamf-cli] Spec check required before this mutation.\\nLoad the API spec first (WebFetch), then run --scaffold to get the exact template.\\n  Platform — fetch from specs/platform/ (filenames are abbreviated, NOT <resource>-api.json):\\n    blueprints              -> blueprints-api.json\\n    compliance-benchmarks   -> jamf-compliance-benchmark-engine-api.json\\n    platform-devices        -> device-inventory-api.json (+ device-management-actions-api.json)\\n    platform-device-groups  -> device-groups-api.json\\n    ddm-reports             -> Declaration-reporting-openapi.json\\n    base: https://raw.githubusercontent.com/Jamf-Concepts/jamf-cli/main/specs/platform/\\n  Classic API (/JSSResource/ paths):\\n    https://raw.githubusercontent.com/Jamf-Concepts/jamf-cli/main/specs/classic/resources.yaml\\n  Pro modern API (all other resources):\\n    https://raw.githubusercontent.com/Jamf-Concepts/jamf-cli/main/specs/<ResourceName>.yaml\\n' >&2; exit 0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/skills/jamf-cli/SKILL.md
+++ b/skills/skills/jamf-cli/SKILL.md
@@ -115,7 +115,17 @@ Specs live in three locations depending on the command namespace:
 |---|---|---|---|
 | `pro <resource>` (modern API) | `specs/<ResourceName>.yaml` | PascalCase singular | `Category.yaml`, `MobileDevice.yaml` |
 | `pro <resource>` (Classic API) | `specs/classic/resources.yaml` | single manifest | `specs/classic/resources.yaml` |
-| `pro blueprints`, `pro compliance-benchmarks`, `pro platform-devices`, `pro platform-device-groups`, `pro ddm-reports` (Platform API) | `specs/platform/<resource>-api.json` | kebab-case + `-api.json` | `blueprints-api.json`, `device-groups-api.json` |
+| `pro blueprints`, `pro compliance-benchmarks`, `pro platform-devices`, `pro platform-device-groups`, `pro ddm-reports` (Platform API) | `specs/platform/` (see mapping below) | abbreviated, **not** derivable from the command name | `compliance-benchmarks` → `jamf-compliance-benchmark-engine-api.json` |
+
+Platform spec filenames do **not** follow a `<resource>-api.json` rule — they are abbreviated and must be looked up explicitly:
+
+| Command namespace | Spec file under `specs/platform/` |
+|---|---|
+| `pro blueprints` | `blueprints-api.json` |
+| `pro compliance-benchmarks` | `jamf-compliance-benchmark-engine-api.json` |
+| `pro platform-devices` | `device-inventory-api.json` (+ `device-management-actions-api.json` for actions) |
+| `pro platform-device-groups` | `device-groups-api.json` |
+| `pro ddm-reports` | `Declaration-reporting-openapi.json` |
 
 **Steps:**
 
@@ -124,7 +134,7 @@ Specs live in three locations depending on the command namespace:
 2. Fetch the raw spec via WebFetch using the appropriate URL:
    - Pro modern: `https://raw.githubusercontent.com/Jamf-Concepts/jamf-cli/main/specs/<ResourceName>.yaml`
    - Pro classic: `https://raw.githubusercontent.com/Jamf-Concepts/jamf-cli/main/specs/classic/resources.yaml`
-   - Platform: `https://raw.githubusercontent.com/Jamf-Concepts/jamf-cli/main/specs/platform/<resource>-api.json`
+   - Platform: `https://raw.githubusercontent.com/Jamf-Concepts/jamf-cli/main/specs/platform/<file>` — resolve `<file>` from the Platform mapping table above (e.g. `jamf-compliance-benchmark-engine-api.json`), do not assume `<resource>-api.json`
 
 3. Extract the request schema (`requestBody` → `content` → `application/json` → `schema`). Use that schema — and only that schema — to construct the body.
 
@@ -174,3 +184,33 @@ jamf-cli -p <profile> pro <resource> list -o json | jq '.' | head -40
 ```
 
 Common patterns: `.id`, `.computerAppleId`, `.udid`. Always derive the field name from the actual output.
+
+### Platform resource group operations
+
+When the task involves Platform resources (blueprints, compliance-benchmarks, ddm-reports, platform-devices), **always use `pro platform-device-groups` for all group operations** — creating test groups, listing groups, resolving group IDs, assigning scope.
+
+**Never use Classic or Pro API group commands** (`pro smart-computer-groups`, `pro static-computer-groups`, `pro computer-groups`, `pro mobile-device-groups`) for Platform workflows. These are incompatible:
+
+| API | Group ID type | Works with Platform resources? |
+|---|---|---|
+| `pro platform-device-groups` | UUID (`cda24521-…`) | Yes |
+| `pro smart-computer-groups` / `pro static-computer-groups` | Integer (`42`) | No |
+
+Blueprint and benchmark scope fields accept only Platform device group UUIDs. Passing a Classic integer group ID will fail silently or be rejected by the API.
+
+**Pattern for creating a test group and scoping a blueprint to it:**
+
+```bash
+# 1. Create the Platform device group
+echo '{"name":"Test Group","deviceType":"COMPUTER","groupType":"STATIC"}' \
+  | jamf-cli -p <profile> pro platform-device-groups create
+
+# 2. Get the new group's UUID
+jamf-cli -p <profile> pro platform-device-groups list -o json \
+  | jq -r '.results[] | select(.name == "Test Group") | .id'
+
+# 3. Scope the blueprint using that UUID
+jamf-cli -p <profile> pro blueprints get "My Blueprint" -o json \
+  | jq '.scope.deviceGroups += ["<uuid>"]' \
+  | jamf-cli -p <profile> pro blueprints apply
+```


### PR DESCRIPTION
## Summary

Reinstates the `PreToolUse` Bash spec-check hook that was reverted in #241, with the [ktn-jamf review on #240](https://github.com/Jamf-Concepts/jamf-cli/pull/240) addressed. The hook lives in `skills/hooks/hooks.json` (auto-discovered plugin location — **not** `.claude/settings.json`, which carries only the repo's Go-dev hooks) and prints a non-blocking stderr reminder before a `jamf-cli create|update|apply|patch` mutation, immune to context decay. `--scaffold` runs are excluded.

## What changed vs the reverted PR

### 🟧 (1) — Platform spec paths no longer 404 *(the blocker)*

The reverted hook printed `specs/platform/<resource>-api.json`, which resolved only for `blueprints`; the other four Platform resources 404'd. Replaced the substitution template with an **explicit resource→file mapping** — deterministic, so a decayed-context agent doesn't have to browse and guess:

| Resource | Spec file |
|---|---|
| `blueprints` | `blueprints-api.json` |
| `compliance-benchmarks` | `jamf-compliance-benchmark-engine-api.json` |
| `platform-devices` | `device-inventory-api.json` (+ `device-management-actions-api.json`) |
| `platform-device-groups` | `device-groups-api.json` |
| `ddm-reports` | `Declaration-reporting-openapi.json` |

Fixed in **all three** places the bogus template lived: the hook stderr, the `SKILL.md` table, and the `SKILL.md` step list. All six named files verified to exist under `specs/platform/`.

### 🟩 (2) — Matcher tightened

Now requires the verb to follow `jamf-cli` on the same command segment: `jamf-cli\b[^|&;]*\b(create|update|apply|patch)\b`. Eliminates two of the three reported false positives. **Not fully resolved:** the literal-echo case (`echo "...jamf-cli apply..."`) still warns — a known harmless residual (non-blocking nudge; robust shell-line parsing is out of scope and the reviewer's own suggested regex doesn't catch it either).

### 🟩 (3) — Accurate file reference

This description names the correct file (`skills/hooks/hooks.json`), unlike #240's body.

### Deliberate non-changes (4/5/6)

- **(4) scope:** the hook intentionally covers only body-bearing CRUD verbs (`create|update|apply|patch`). `deploy`/`undeploy`/`clone`/`scope` don't construct a request body; `import-profile` is a conversion command with its own workflow — left out by design.
- **(5) template duplication:** `hooks.json` is pure JSON and can't carry a cross-ref comment; the explicit mapping makes each copy independently correct.
- **(6) jq-absent no-op:** `jq` is a suite-wide dependency; not hardening here.

## Verification

CI is Go-lint only, so the hook was verified locally:

| Command | Expected | Result |
|---|---|---|
| `… apply` / `create` / `update 1` / `patch 1` | warn | ✅ |
| `… create --scaffold` | pass | ✅ |
| `… list` / `delete 1` / `git status` | pass | ✅ |
| `… list && git commit -m "update docs"` | pass | ✅ |
| `… list \| grep create` | pass | ✅ |
| `echo "…jamf-cli apply…"` | warn (known residual) | ⚠️ |

`jq` confirms `hooks.json` parses; the rendered stderr mapping was checked against `specs/platform/` — every named file exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)