### PR TITLE
fix(keychain): add actionable guidance to keychain write failures

### DIFF
--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -379,7 +379,7 @@ func storeOrRefSecret(store keychain.Store, profile, field, value string, dest *
 	}
 	account := profile + "/" + field
 	if err := store.Set(keychain.DefaultService, account, value); err != nil {
-		return fmt.Errorf("failed to store %s in keychain: %w", field, err)
+		return keychain.WriteError(field, err)
 	}
 	*dest = keychain.KeychainRef(profile, field)
 	return nil

--- a/internal/commands/platform.go
+++ b/internal/commands/platform.go
@@ -145,10 +145,10 @@ Create API client credentials in the Jamf Account portal
 			// 6. Store secrets in keychain
 			store := config.GetKeychainStore()
 			if err := store.Set(keychain.DefaultService, setupProfile+"/client-id", clientID); err != nil {
-				return fmt.Errorf("failed to store client ID in keychain: %w", err)
+				return keychain.WriteError("client ID", err)
 			}
 			if err := store.Set(keychain.DefaultService, setupProfile+"/client-secret", clientSecret); err != nil {
-				return fmt.Errorf("failed to store client secret in keychain: %w", err)
+				return keychain.WriteError("client secret", err)
 			}
 
 			// 7. Save profile

--- a/internal/commands/pro_setup.go
+++ b/internal/commands/pro_setup.go
@@ -571,10 +571,10 @@ func setupInstance(ctx context.Context, w io.Writer, cfg *config.Config, instanc
 		_, _ = fmt.Fprintln(w, "✓")
 
 		if err := store.Set(keychain.DefaultService, profileName+"/client-id", clientID); err != nil {
-			return fmt.Errorf("failed to store client ID in keychain: %w", err)
+			return keychain.WriteError("client ID", err)
 		}
 		if err := store.Set(keychain.DefaultService, profileName+"/client-secret", clientSecret); err != nil {
-			return fmt.Errorf("failed to store client secret in keychain: %w", err)
+			return keychain.WriteError("client secret", err)
 		}
 	}
 

--- a/internal/commands/protect_setup.go
+++ b/internal/commands/protect_setup.go
@@ -94,10 +94,10 @@ Settings > API Clients before running this command.`,
 			// Store secrets in keychain
 			store := config.GetKeychainStore()
 			if err := store.Set(keychain.DefaultService, setupProfile+"/client-id", setupCID); err != nil {
-				return fmt.Errorf("failed to store client ID in keychain: %w", err)
+				return keychain.WriteError("client ID", err)
 			}
 			if err := store.Set(keychain.DefaultService, setupProfile+"/client-secret", setupSecret); err != nil {
-				return fmt.Errorf("failed to store client secret in keychain: %w", err)
+				return keychain.WriteError("client secret", err)
 			}
 
 			// Save profile to config

--- a/internal/commands/school_setup.go
+++ b/internal/commands/school_setup.go
@@ -98,10 +98,10 @@ portal (account.jamf.com).`,
 			// Store secrets in keychain
 			store := config.GetKeychainStore()
 			if err := store.Set(keychain.DefaultService, setupProfile+"/network-id", networkID); err != nil {
-				return fmt.Errorf("failed to store network ID in keychain: %w", err)
+				return keychain.WriteError("network ID", err)
 			}
 			if err := store.Set(keychain.DefaultService, setupProfile+"/api-key", apiKey); err != nil {
-				return fmt.Errorf("failed to store API key in keychain: %w", err)
+				return keychain.WriteError("API key", err)
 			}
 
 			// Build profile
@@ -226,10 +226,10 @@ func collectPlatformCredentials(w io.Writer, reader *bufio.Reader, store keychai
 
 	// Store in keychain
 	if err := store.Set(keychain.DefaultService, profileName+"/client-id", clientID); err != nil {
-		return prof, fmt.Errorf("failed to store client ID in keychain: %w", err)
+		return prof, keychain.WriteError("client ID", err)
 	}
 	if err := store.Set(keychain.DefaultService, profileName+"/client-secret", clientSecret); err != nil {
-		return prof, fmt.Errorf("failed to store client secret in keychain: %w", err)
+		return prof, keychain.WriteError("client secret", err)
 	}
 
 	prof.ClientID = keychain.KeychainRef(profileName, "client-id")

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -4,6 +4,8 @@ package keychain
 
 import (
 	"errors"
+	"fmt"
+	"runtime"
 	"strings"
 
 	gokeyring "github.com/zalando/go-keyring"
@@ -78,6 +80,40 @@ func ParseRef(value string) (service, account string) {
 	}
 
 	return DefaultService, value
+}
+
+// WriteError wraps a failed keychain write (Store.Set) with actionable,
+// OS-specific guidance. The underlying go-keyring backends shell out to the
+// system credential store and surface only the process exit code (e.g. macOS
+// "exit status 154"), discarding the descriptive message — so on its own the
+// raw error tells the user nothing about how to fix it. item is a short,
+// human-readable label for what was being stored (e.g. "client ID").
+func WriteError(item string, err error) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return fmt.Errorf("failed to store %s in the macOS keychain: %w\n\n"+
+			"The login keychain rejected the write. It is usually locked, not the\n"+
+			"default keychain, or unavailable in this session (e.g. over SSH).\n\n"+
+			"Try unlocking it:\n"+
+			"  security unlock-keychain ~/Library/Keychains/login.keychain-db\n\n"+
+			"To see the underlying error directly:\n"+
+			"  security add-generic-password -U -s %s -a jamf-cli-test -w test\n\n"+
+			"Alternatively, store secrets without the keychain using env: or file:\n"+
+			"secret references in your config profile.", item, err, DefaultService)
+	case "linux":
+		return fmt.Errorf("failed to store %s in the system keyring: %w\n\n"+
+			"The Secret Service backend (e.g. gnome-keyring) is usually locked or\n"+
+			"unavailable in this session (e.g. a headless or SSH session with no\n"+
+			"D-Bus / keyring daemon running).\n\n"+
+			"Alternatively, store secrets without the keyring using env: or file:\n"+
+			"secret references in your config profile.", item, err)
+	default:
+		return fmt.Errorf("failed to store %s in the system keychain: %w\n\n"+
+			"The system credential store rejected the write. It may be locked or\n"+
+			"unavailable in this session.\n\n"+
+			"Alternatively, store secrets without the keychain using env: or file:\n"+
+			"secret references in your config profile.", item, err)
+	}
 }
 
 // KeychainRef builds a keychain: reference string for use in config files.

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -89,31 +89,36 @@ func ParseRef(value string) (service, account string) {
 // raw error tells the user nothing about how to fix it. item is a short,
 // human-readable label for what was being stored (e.g. "client ID").
 func WriteError(item string, err error) error {
+	// The guidance body is built separately and passed as a trailing %s so the
+	// fmt.Errorf format string does not end in punctuation/newline (staticcheck
+	// ST1005). The body is deliberately multi-line, user-facing text.
+	var store, guidance string
 	switch runtime.GOOS {
 	case "darwin":
-		return fmt.Errorf("failed to store %s in the macOS keychain: %w\n\n"+
-			"The login keychain rejected the write. It is usually locked, not the\n"+
-			"default keychain, or unavailable in this session (e.g. over SSH).\n\n"+
-			"Try unlocking it:\n"+
-			"  security unlock-keychain ~/Library/Keychains/login.keychain-db\n\n"+
-			"To see the underlying error directly:\n"+
-			"  security add-generic-password -U -s %s -a jamf-cli-test -w test\n\n"+
-			"Alternatively, store secrets without the keychain using env: or file:\n"+
-			"secret references in your config profile.", item, err, DefaultService)
+		store = "macOS keychain"
+		guidance = "The login keychain rejected the write. It is usually locked, not the\n" +
+			"default keychain, or unavailable in this session (e.g. over SSH).\n\n" +
+			"Try unlocking it:\n" +
+			"  security unlock-keychain ~/Library/Keychains/login.keychain-db\n\n" +
+			"To see the underlying error directly:\n" +
+			"  security add-generic-password -U -s " + DefaultService + " -a jamf-cli-test -w test\n\n" +
+			"Alternatively, store secrets without the keychain using env: or file:\n" +
+			"secret references in your config profile."
 	case "linux":
-		return fmt.Errorf("failed to store %s in the system keyring: %w\n\n"+
-			"The Secret Service backend (e.g. gnome-keyring) is usually locked or\n"+
-			"unavailable in this session (e.g. a headless or SSH session with no\n"+
-			"D-Bus / keyring daemon running).\n\n"+
-			"Alternatively, store secrets without the keyring using env: or file:\n"+
-			"secret references in your config profile.", item, err)
+		store = "system keyring"
+		guidance = "The Secret Service backend (e.g. gnome-keyring) is usually locked or\n" +
+			"unavailable in this session (e.g. a headless or SSH session with no\n" +
+			"D-Bus / keyring daemon running).\n\n" +
+			"Alternatively, store secrets without the keyring using env: or file:\n" +
+			"secret references in your config profile."
 	default:
-		return fmt.Errorf("failed to store %s in the system keychain: %w\n\n"+
-			"The system credential store rejected the write. It may be locked or\n"+
-			"unavailable in this session.\n\n"+
-			"Alternatively, store secrets without the keychain using env: or file:\n"+
-			"secret references in your config profile.", item, err)
+		store = "system keychain"
+		guidance = "The system credential store rejected the write. It may be locked or\n" +
+			"unavailable in this session.\n\n" +
+			"Alternatively, store secrets without the keychain using env: or file:\n" +
+			"secret references in your config profile."
 	}
+	return fmt.Errorf("failed to store %s in the %s: %w\n\n%s", item, store, err, guidance)
 }
 
 // KeychainRef builds a keychain: reference string for use in config files.

--- a/internal/keychain/keychain_test.go
+++ b/internal/keychain/keychain_test.go
@@ -3,6 +3,9 @@
 package keychain
 
 import (
+	"errors"
+	"runtime"
+	"strings"
 	"testing"
 
 	gokeyring "github.com/zalando/go-keyring"
@@ -109,6 +112,33 @@ func TestSystemStore_DeleteSuccess(t *testing.T) {
 	_, err := store.Get("test-service", "del-account")
 	if err != ErrNotFound {
 		t.Errorf("Get after Delete: error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestWriteError(t *testing.T) {
+	cause := errors.New("exit status 154")
+	err := WriteError("client ID", cause)
+
+	if err == nil {
+		t.Fatal("WriteError returned nil")
+	}
+	if !errors.Is(err, cause) {
+		t.Errorf("WriteError does not wrap the cause; errors.Is = false")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "client ID") {
+		t.Errorf("message missing item label: %q", msg)
+	}
+	if !strings.Contains(msg, "exit status 154") {
+		t.Errorf("message missing underlying error: %q", msg)
+	}
+	// Every platform should point users at the env:/file: escape hatch.
+	if !strings.Contains(msg, "env:") || !strings.Contains(msg, "file:") {
+		t.Errorf("message missing env:/file: fallback guidance: %q", msg)
+	}
+	// macOS guidance should name the concrete unlock command.
+	if runtime.GOOS == "darwin" && !strings.Contains(msg, "unlock-keychain") {
+		t.Errorf("darwin message missing unlock-keychain guidance: %q", msg)
 	}
 }
 


### PR DESCRIPTION
## Problem

A user running `jamf-cli platform setup` got:

```json
{ "error": "general", "exitCode": 1, "message": "failed to store client ID in keychain: exit status 154" }
```

`exit status 154` is the low byte of macOS OSStatus `-25190` — a keychain-services error that `security error` itself reports as "unknown error". The real cause is the login keychain being locked / not the default / unavailable in the session (e.g. SSH). But the message tells the user none of that, because `go-keyring`'s macOS `Set` shells out to `/usr/bin/security` and **discards its stderr**, surfacing only the process exit code.

Credential validation already succeeds before this step, so it is purely a local keychain-write failure.

## Fix

Add `keychain.WriteError(item, err)` — wraps a failed `Store.Set` with OS-specific remediation guidance while still wrapping the underlying error (`errors.Is` continues to work):

- **macOS**: names the concrete `security unlock-keychain ~/Library/Keychains/login.keychain-db` command and a one-liner to surface the real error.
- **Linux**: notes Secret Service / D-Bus availability in headless sessions.
- **All platforms**: points at the `env:`/`file:` secret-reference escape hatch.

Wired into every keychain write callsite:

| Site | Command |
|---|---|
| `platform.go` | `platform setup` (the reported case) |
| `pro_setup.go` | `pro setup` |
| `protect_setup.go` | `protect setup` |
| `school_setup.go` | `school setup` (incl. platform-creds helper) |
| `config.go` | `config add-profile` / generic secret store |

## Testing

- `TestWriteError` asserts the wrapped cause, item label, and platform-specific guidance.
- `go build ./...`, `go vet`, `internal/keychain` + `internal/commands` tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)