### PR TITLE
feat(backup): include prestages with device scope (#256)

### DIFF
--- a/internal/commands/pro_backup.go
+++ b/internal/commands/pro_backup.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -223,6 +224,13 @@ func runBackup(ctx context.Context, cliCtx *registry.CLIContext, opts backupOpti
 				if err != nil {
 					return itemResult{}, fmt.Errorf("%s id=%s: %w", def.Key, item.ID, err)
 				}
+				if def.ScopePath != "" {
+					serials, serr := fetchPrestageScope(ctx, client, def.ScopePath, item.ID)
+					if serr != nil {
+						return itemResult{}, fmt.Errorf("%s id=%s scope: %w", def.Key, item.ID, serr)
+					}
+					data["scope"] = serials
+				}
 				return itemResult{Name: item.Name, Data: data}, nil
 			})
 			for _, e := range errs {
@@ -408,6 +416,34 @@ func listResourceItemsAndMaps(ctx context.Context, client registry.HTTPClient, d
 func listResourceItems(ctx context.Context, client registry.HTTPClient, def ResolvedBackupResource) ([]resourceItem, error) {
 	items, _, err := listResourceItemsAndMaps(ctx, client, &def)
 	return items, err
+}
+
+// fetchPrestageScope fetches the device scope for a single prestage and returns
+// its assigned serial numbers, sorted for stable diffs. Server-generated
+// assignment metadata (assignmentDate, userAssigned) and the optimistic-lock
+// versionLock are dropped — only the serial set is meaningful config. A
+// prestage with no devices yields an empty (non-nil) slice so the "scope" key
+// is always present and renders as `[]` rather than `null`.
+func fetchPrestageScope(ctx context.Context, client registry.HTTPClient, scopePath, id string) ([]string, error) {
+	path := strings.Replace(scopePath, "{id}", id, 1)
+	data, err := fetchJSON(ctx, client, path)
+	if err != nil {
+		return nil, err
+	}
+	serials := []string{}
+	if assignments, ok := data["assignments"].([]any); ok {
+		for _, a := range assignments {
+			m, ok := a.(map[string]any)
+			if !ok {
+				continue
+			}
+			if s, ok := m["serialNumber"].(string); ok && s != "" {
+				serials = append(serials, s)
+			}
+		}
+	}
+	sort.Strings(serials)
+	return serials, nil
 }
 
 // extractID gets the "id" field from a map, handling both string and float64.

--- a/internal/commands/pro_diff.go
+++ b/internal/commands/pro_diff.go
@@ -283,6 +283,13 @@ func loadSnapshotFromProfile(ctx context.Context, profileName string, nameFilter
 				fmt.Fprintf(os.Stderr, "WARNING: fetching %s id=%s from %q: %v\n", def.Key, item.ID, profileName, err)
 				continue
 			}
+			if def.ScopePath != "" {
+				if serials, serr := fetchPrestageScope(ctx, httpCli, def.ScopePath, item.ID); serr == nil {
+					data["scope"] = serials
+				} else {
+					fmt.Fprintf(os.Stderr, "WARNING: fetching scope for %s id=%s from %q: %v\n", def.Key, item.ID, profileName, serr)
+				}
+			}
 			data = unwrapClassicDetail(data)
 			data = StripServerFields(data)
 

--- a/internal/commands/pro_helpers.go
+++ b/internal/commands/pro_helpers.go
@@ -313,6 +313,9 @@ func StripServerFields(obj map[string]any) map[string]any {
 		"updatedTimestamp":   true,
 		"date_created_epoch": true,
 		"date_created_utc":   true,
+		// versionLock is the prestage optimistic-locking token — pure server
+		// state that increments on every write and carries no config meaning.
+		"versionLock": true,
 	}
 
 	result := make(map[string]any, len(obj))

--- a/internal/commands/pro_resources.go
+++ b/internal/commands/pro_resources.go
@@ -26,6 +26,12 @@ type BackupResource struct {
 	// directly to disk as its own file. Used for resources whose list response
 	// is already the complete record (e.g. sites: {id, name}).
 	ListOnly bool
+	// ScopePath, when set, names a per-ID device-scope endpoint
+	// (e.g. "/v2/computer-prestages/{id}/scope"). After fetching each detail
+	// record the backup/diff code fetches this path and embeds the sorted
+	// serial numbers under a "scope" key so the assignment list travels with
+	// the prestage config in a single, diff-friendly file.
+	ScopePath string
 }
 
 // BackupResources is the curated set of resources included in `backup` and
@@ -41,6 +47,10 @@ var BackupResources = []BackupResource{
 	// Configuration profiles (no modern equivalent for CRUD)
 	{Key: "classic-macos-config-profiles", FilterName: "profiles", SubDir: "profiles/macos"},
 	{Key: "classic-mobile-config-profiles", FilterName: "profiles", SubDir: "profiles/ios"},
+
+	// Prestage enrollments — modern v3 config + embedded device scope (serials).
+	{Key: "computer-prestages", FilterName: "prestages", SubDir: "prestages/computers", ScopePath: "/v2/computer-prestages/{id}/scope"},
+	{Key: "mobile-device-prestages", FilterName: "prestages", SubDir: "prestages/mobile", ScopePath: "/v2/mobile-device-prestages/{id}/scope"},
 
 	// Scripts
 	{Key: "scripts", FilterName: "scripts", SubDir: "scripts"},

--- a/internal/commands/pro_resources_test.go
+++ b/internal/commands/pro_resources_test.go
@@ -4,6 +4,7 @@ package commands
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/commands/pro/generated"
@@ -125,6 +126,26 @@ func TestResolveBackupResources_AccountsSplit(t *testing.T) {
 	for _, r := range got {
 		if r.ListSubset == "" {
 			t.Errorf("accounts entry %q missing ListSubset", r.Key)
+		}
+	}
+}
+
+func TestResolveBackupResources_PrestagesWithScope(t *testing.T) {
+	// The prestages filter must resolve to both computer + mobile prestages,
+	// each carrying a per-ID scope endpoint so device assignments are embedded.
+	got, err := ResolveBackupResources([]string{"prestages"})
+	if err != nil {
+		t.Fatalf("ResolveBackupResources: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 resolved entries for prestages filter, got %d", len(got))
+	}
+	for _, r := range got {
+		if r.ScopePath == "" {
+			t.Errorf("prestages entry %q missing ScopePath", r.Key)
+		}
+		if !strings.Contains(r.ScopePath, "{id}") {
+			t.Errorf("prestages entry %q ScopePath %q lacks {id} placeholder", r.Key, r.ScopePath)
 		}
 	}
 }


### PR DESCRIPTION
Closes #256.

## What

Adds computer + mobile-device prestages to the `pro backup` (and `diff`) curated resource set under a new `prestages` filter. Each prestage's **device scope** (assigned serial numbers) is fetched from the per-ID scope endpoint and embedded under a `scope:` key, so config and assignments travel together in one diff-friendly file.

```
jamf-cli pro backup --output ./bk --resources prestages
```
→ `prestages/computers/<name>.yaml` + `prestages/mobile/<name>.yaml`, each with a `scope:` list of serials.

## How

- New `ScopePath` field on `BackupResource` names the per-ID scope endpoint (`/v2/{computer,mobile-device}-prestages/{id}/scope`). Backup and the live-profile `diff` path both fetch it and embed sorted serials.
- Noisy assignment metadata (`assignmentDate`, `userAssigned`) dropped — only the serial set is meaningful config.
- `versionLock` added to `StripServerFields` (prestage optimistic-lock token, pure server state).

## Testing

- New unit test `TestResolveBackupResources_PrestagesWithScope`; `make lint` + `make test` green.
- **Live** against a platform-gateway profile: 11 prestages exported, 0 failures, every file carries a `scope:` key, `id`/`versionLock` stripped. (Tenant has no device assignments, so `scope: []` — 0 failures proves all 11 scope GETs returned 200 and parsed.)

## Note (out of scope)

`pro diff` against a platform-gateway profile already 404s on **all** modern (`/api/v1`,`/api/v3`) resources — its hand-built HTTP client doesn't apply the gateway `/api/pro/tenant/{id}/` path rewrite. Pre-existing, affects scripts/categories identically; not touched here. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)