### PR TITLE
fix(packages): drop redundant post-upload PUT that blanked size

### DIFF
--- a/internal/commands/pro_packages_upload.go
+++ b/internal/commands/pro_packages_upload.go
@@ -135,33 +135,32 @@ them to the package metadata after upload.`,
 			fmt.Fprintf(os.Stderr, "Upload complete\n")
 
 			// 6. Verify upload — poll until server-computed hash matches local hash.
-			// Don't PUT hash metadata first — let the server compute from the
-			// uploaded JCDS file independently so we get a true integrity check.
+			// The server computes hashType/hashValue/sha3512/sha256/md5/size itself
+			// from the uploaded JCDS file, so no PUT of hash metadata is needed (and
+			// a PUT would blank the server-managed size field). verifyPackageUpload
+			// returns the complete record on success — reuse it for display.
 			fmt.Fprintf(os.Stderr, "Verifying upload...\n")
-			if err := verifyPackageUpload(ctx, client, pkgID, fileName, hashes.sha3, previousHash); err != nil {
+			data, err := verifyPackageUpload(ctx, client, pkgID, fileName, hashes.sha3, previousHash)
+			if err != nil {
 				if strings.Contains(err.Error(), "hash mismatch") {
 					return fmt.Errorf("upload verification failed: %w", err)
 				}
 				// Timeout is non-fatal — server may still be processing
 				fmt.Fprintf(os.Stderr, "WARNING: %v\n", err)
-				fmt.Fprintf(os.Stderr, "The file was uploaded and hashes were set. The server may still be processing.\n")
+				fmt.Fprintf(os.Stderr, "The file was uploaded. The server may still be processing.\n")
 			} else {
 				fmt.Fprintf(os.Stderr, "Verified: server hash matches local hash\n")
 			}
 
-			// 7. Update metadata with supplementary hashes (sha256, md5)
-			// that the server doesn't compute itself.
-			fmt.Fprintf(os.Stderr, "Updating package hashes...\n")
-			if err := updatePackageHashes(ctx, client, pkgID, hashes, fileSize); err != nil {
-				return fmt.Errorf("updating hashes: %w", err)
-			}
-
-			// 8. Print result
-			data, err := fetchJSON(ctx, client, fmt.Sprintf("/v1/packages/%s", url.PathEscape(pkgID)))
-			if err != nil {
-				// Non-fatal: upload succeeded, just can't show final state
-				fmt.Fprintf(os.Stderr, "Package uploaded successfully (id %s)\n", pkgID)
-				return nil
+			// 7. Print result. On a verify timeout we have no record in hand —
+			// fetch once so the user still sees the current server state.
+			if data == nil {
+				data, err = fetchJSON(ctx, client, fmt.Sprintf("/v1/packages/%s", url.PathEscape(pkgID)))
+				if err != nil {
+					// Non-fatal: upload succeeded, just can't show final state
+					fmt.Fprintf(os.Stderr, "Package uploaded successfully (id %s)\n", pkgID)
+					return nil
+				}
 			}
 			result, _ := json.Marshal(data)
 			return cliCtx.Output.PrintRaw(result)
@@ -303,36 +302,6 @@ func uploadPackageFile(ctx context.Context, uploader registry.FileUploader, pkgI
 	return nil
 }
 
-// updatePackageHashes sets the hash and size fields on an existing package record.
-func updatePackageHashes(ctx context.Context, client registry.HTTPClient, pkgID string, h fileHashes, size int64) error {
-	// Fetch current package to preserve existing fields
-	data, err := fetchJSON(ctx, client, fmt.Sprintf("/v1/packages/%s", url.PathEscape(pkgID)))
-	if err != nil {
-		return fmt.Errorf("fetching package for hash update: %w", err)
-	}
-
-	// Update hash and size fields
-	data["hashType"] = "SHA3_512"
-	data["hashValue"] = h.sha3
-	data["sha3512"] = h.sha3
-	data["sha256"] = h.sha256
-	data["md5"] = h.md5
-	data["size"] = fmt.Sprintf("%d", size)
-
-	body, err := json.Marshal(data)
-	if err != nil {
-		return err
-	}
-
-	path := fmt.Sprintf("/v1/packages/%s", url.PathEscape(pkgID))
-	resp, err := client.Do(ctx, "PUT", path, bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	_ = resp.Body.Close()
-	return nil
-}
-
 // verifyPackageUpload polls the package until the server's computed hash matches
 // the expected value. On each iteration it nudges the JCDS inventory refresh
 // (errors ignored — transient 500s and concurrency failures are expected).
@@ -340,7 +309,13 @@ func updatePackageHashes(ctx context.Context, client registry.HTTPClient, pkgID 
 // new packages). When the server still returns this value, polling continues because
 // the server hasn't recomputed from the new file yet. A different non-matching
 // SHA3_512 hash indicates genuine corruption and fails immediately.
-func verifyPackageUpload(ctx context.Context, client registry.HTTPClient, pkgID, fileName, expectedSHA3, previousHash string) error {
+//
+// On success it returns the verified package record. The server computes
+// hashType/hashValue/sha3512/sha256/md5/size itself from the uploaded JCDS
+// file, so this record is complete — callers can display it directly without
+// a further GET, and must not PUT hash metadata back (a PUT blanks the
+// server-managed size field).
+func verifyPackageUpload(ctx context.Context, client registry.HTTPClient, pkgID, fileName, expectedSHA3, previousHash string) (map[string]any, error) {
 	const (
 		verifyTimeout  = 10 * time.Minute
 		verifyInterval = 10 * time.Second
@@ -354,7 +329,7 @@ func verifyPackageUpload(ctx context.Context, client registry.HTTPClient, pkgID,
 		// Wait first — give the server time to process
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil, ctx.Err()
 		case <-time.After(verifyInterval):
 		}
 
@@ -378,7 +353,7 @@ func verifyPackageUpload(ctx context.Context, client registry.HTTPClient, pkgID,
 		}
 
 		if hashType == "SHA3_512" && hashValue == expectedSHA3 {
-			return nil
+			return data, nil
 		}
 
 		if hashType == "SHA3_512" && hashValue == previousHash {
@@ -389,14 +364,14 @@ func verifyPackageUpload(ctx context.Context, client registry.HTTPClient, pkgID,
 
 		if hashType == "SHA3_512" {
 			// Server computed a new SHA3_512 hash that doesn't match — corrupted upload
-			return fmt.Errorf("hash mismatch: server=%s local=%s", hashValue, expectedSHA3)
+			return nil, fmt.Errorf("hash mismatch: server=%s local=%s", hashValue, expectedSHA3)
 		}
 
 		// Hash type hasn't been updated to SHA3_512 yet — keep polling
 		fmt.Fprintf(os.Stderr, "  waiting for hash type update (current: %s)...\n", hashType)
 	}
 
-	return fmt.Errorf("timed out after %v waiting for server hash to match (check package integrity)", verifyTimeout)
+	return nil, fmt.Errorf("timed out after %v waiting for server hash to match (check package integrity)", verifyTimeout)
 }
 
 // humanSize formats a byte count as a human-readable string.

--- a/internal/commands/pro_packages_upload.go
+++ b/internal/commands/pro_packages_upload.go
@@ -177,6 +177,13 @@ them to the package metadata after upload.`,
 	return cmd
 }
 
+// verifyTimeout/verifyInterval bound the post-upload hash-verification poll.
+// They are package-level vars (not consts) so tests can shrink them.
+var (
+	verifyTimeout  = 10 * time.Minute
+	verifyInterval = 10 * time.Second
+)
+
 // fileHashes holds the computed hash values for a package file.
 type fileHashes struct {
 	sha3   string
@@ -316,11 +323,6 @@ func uploadPackageFile(ctx context.Context, uploader registry.FileUploader, pkgI
 // a further GET, and must not PUT hash metadata back (a PUT blanks the
 // server-managed size field).
 func verifyPackageUpload(ctx context.Context, client registry.HTTPClient, pkgID, fileName, expectedSHA3, previousHash string) (map[string]any, error) {
-	const (
-		verifyTimeout  = 10 * time.Minute
-		verifyInterval = 10 * time.Second
-	)
-
 	refreshPath := fmt.Sprintf("/v1/cloud-distribution-point/refresh-inventory?file-name=%s", url.QueryEscape(fileName))
 	pkgPath := fmt.Sprintf("/v1/packages/%s", url.PathEscape(pkgID))
 

--- a/internal/commands/pro_packages_upload_test.go
+++ b/internal/commands/pro_packages_upload_test.go
@@ -55,7 +55,7 @@ func TestHashFile(t *testing.T) {
 type pkgVerifyServer struct {
 	srv      *httptest.Server
 	hashSeq  []string
-	pollN    int32 // GET count
+	pollN    atomic.Int32 // GET count
 	lastBody string
 }
 
@@ -66,7 +66,7 @@ func newPkgVerifyServer(hashSeq []string) *pkgVerifyServer {
 		w.WriteHeader(http.StatusNoContent)
 	})
 	mux.HandleFunc("/v1/packages/702", func(w http.ResponseWriter, _ *http.Request) {
-		i := int(atomic.AddInt32(&p.pollN, 1)) - 1
+		i := int(p.pollN.Add(1)) - 1
 		if i >= len(p.hashSeq) {
 			i = len(p.hashSeq) - 1
 		}

--- a/internal/commands/pro_packages_upload_test.go
+++ b/internal/commands/pro_packages_upload_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"context"
+	"crypto/md5"
+	"crypto/sha256"
+	"crypto/sha3"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestHashFile checks the single-pass hasher against the standard library.
+func TestHashFile(t *testing.T) {
+	content := []byte("jamf-cli package upload test payload")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sample.pkg")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := hashFile(path)
+	if err != nil {
+		t.Fatalf("hashFile: %v", err)
+	}
+
+	s3 := sha3.Sum512(content)
+	s2 := sha256.Sum256(content)
+	m5 := md5.Sum(content)
+	if want := hex.EncodeToString(s3[:]); got.sha3 != want {
+		t.Errorf("sha3 = %s, want %s", got.sha3, want)
+	}
+	if want := hex.EncodeToString(s2[:]); got.sha256 != want {
+		t.Errorf("sha256 = %s, want %s", got.sha256, want)
+	}
+	if want := hex.EncodeToString(m5[:]); got.md5 != want {
+		t.Errorf("md5 = %s, want %s", got.md5, want)
+	}
+}
+
+// pkgVerifyServer mocks the package GET + refresh-inventory endpoints used by
+// verifyPackageUpload. It serves a sequence of hashValue strings (one per GET
+// poll, the last repeating) so a test can model the server taking several
+// polls to recompute the hash after an upload.
+type pkgVerifyServer struct {
+	srv      *httptest.Server
+	hashSeq  []string
+	pollN    int32 // GET count
+	lastBody string
+}
+
+func newPkgVerifyServer(hashSeq []string) *pkgVerifyServer {
+	p := &pkgVerifyServer{hashSeq: hashSeq}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/cloud-distribution-point/refresh-inventory", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/v1/packages/702", func(w http.ResponseWriter, _ *http.Request) {
+		i := int(atomic.AddInt32(&p.pollN, 1)) - 1
+		if i >= len(p.hashSeq) {
+			i = len(p.hashSeq) - 1
+		}
+		hv := p.hashSeq[i]
+		p.lastBody = fmt.Sprintf(`{"id":"702","fileName":"x.pkg","hashType":"SHA3_512","hashValue":%q,"sha3512":%q,"size":"123"}`, hv, hv)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(p.lastBody))
+	})
+	p.srv = httptest.NewServer(mux)
+	return p
+}
+
+func (p *pkgVerifyServer) Do(_ context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	url := p.srv.URL + path
+	var req *http.Request
+	var err error
+	if body != nil {
+		req, err = http.NewRequest(method, url, body)
+	} else {
+		req, err = http.NewRequest(method, url, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return http.DefaultClient.Do(req)
+}
+
+func (p *pkgVerifyServer) close() { p.srv.Close() }
+
+// withFastVerifyPoll shrinks the verify timing so the polling logic can be
+// exercised in milliseconds, restoring the originals on cleanup.
+func withFastVerifyPoll(t *testing.T) {
+	t.Helper()
+	origTimeout, origInterval := verifyTimeout, verifyInterval
+	verifyTimeout = 2 * time.Second
+	verifyInterval = 5 * time.Millisecond
+	t.Cleanup(func() {
+		verifyTimeout = origTimeout
+		verifyInterval = origInterval
+	})
+}
+
+func TestVerifyPackageUpload(t *testing.T) {
+	const (
+		newHash = "aaaa1111"
+		oldHash = "bbbb2222"
+		badHash = "cccc3333"
+	)
+
+	tests := []struct {
+		name         string
+		hashSeq      []string
+		previousHash string
+		wantErr      string
+		wantHashVal  string // expected hashValue in returned record on success
+	}{
+		{
+			name:        "matches on first poll",
+			hashSeq:     []string{newHash},
+			wantHashVal: newHash,
+		},
+		{
+			name:         "waits out server recompute then matches",
+			hashSeq:      []string{oldHash, oldHash, oldHash, newHash},
+			previousHash: oldHash,
+			wantHashVal:  newHash,
+		},
+		{
+			name:         "genuine mismatch fails fast",
+			hashSeq:      []string{badHash},
+			previousHash: oldHash,
+			wantErr:      "hash mismatch",
+		},
+		{
+			name:        "empty hash then populated",
+			hashSeq:     []string{"", "", newHash},
+			wantHashVal: newHash,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withFastVerifyPoll(t)
+			srv := newPkgVerifyServer(tc.hashSeq)
+			defer srv.close()
+
+			data, err := verifyPackageUpload(context.Background(), srv, "702", "x.pkg", newHash, tc.previousHash)
+
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %q, want substring %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if data == nil {
+				t.Fatal("expected non-nil verified record")
+			}
+			if got, _ := data["hashValue"].(string); got != tc.wantHashVal {
+				t.Errorf("returned hashValue = %q, want %q", got, tc.wantHashVal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

After a package upload, `pro packages upload` made five HTTP calls post-upload: `refresh-inventory` + GET (verify) + GET + PUT + GET. The PUT (`updatePackageHashes`) wrote `hashType`/`hashValue`/`sha3512`/`sha256`/`md5`/`size` back to the record — based on the comment claiming *"supplementary hashes (sha256, md5) that the server doesn't compute itself."*

That comment is wrong. **Jamf Pro computes all of those fields itself** from the uploaded JCDS file once `refresh-inventory` runs. The PUT was redundant — and actively harmful: a PUT with `size` set causes the server to **blank its own server-managed `size`** (it's read-only on that endpoint), so uploaded packages ended up with `size: ""`.

## Change

- Delete the post-upload PUT (`updatePackageHashes` helper removed).
- `verifyPackageUpload` now returns the verified package record; the command reuses it for display instead of re-fetching.
- Post-upload sequence: **refresh + GET + GET + PUT + GET → refresh + a single GET**.
- Fixes `size` ending up empty.

## Verification (live instance)

| Scenario | Result |
|---|---|
| Fresh upload | `size` now persists (was `""`); all hashes server-computed; `READY` |
| Replace (different file, same name) | every field recomputed to the new file; `READY` |
| 5× alternating swap of 1.5 GB ↔ 400 MB files | all PASS; verify poll correctly waited out the server's recompute window (~100s / 10 polls for the 1.5 GB file) without false-matching the prior hash |

The `previousHash` guard in the verify loop is what makes repeated replaces safe — it distinguishes "server still reports the old hash → keep waiting" from "a different hash that doesn't match → genuine corruption."

🤖 Generated with [Claude Code](https://claude.com/claude-code)