### PR TITLE
feat: add agent-context command for AI agent operating guidance

### DIFF
--- a/internal/commands/agent_context.go
+++ b/internal/commands/agent_context.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed agent_context.md
+var agentContextGuide string
+
+// newAgentContextCmd prints durable operating guidance for AI agents driving
+// jamf-cli (auth, exit codes, output/agent flags, destructive-command rules,
+// MCP). The content is a single embedded markdown document; it always prints
+// markdown and ignores -o (like 'completion' always emitting a shell script).
+// The live command list lives in 'commands'; per-command detail in '--help'.
+func newAgentContextCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "agent-context",
+		Short: "Print operating guidance for AI agents (auth, exit codes, flags, MCP)",
+		Long: `Print durable operating guidance for AI agents driving jamf-cli.
+
+Covers authentication, exit codes, output and agent flags, destructive-command
+rules, and MCP usage. Output is plain markdown regardless of -o. For the live
+command list run 'jamf-cli commands -o json'; for a command's flags run
+'<command> --help'.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), agentContextGuide)
+			return err
+		},
+	}
+}

--- a/internal/commands/agent_context.go
+++ b/internal/commands/agent_context.go
@@ -9,6 +9,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// agentContextGuide is the embedded operating guide printed by `agent-context`.
+// It duplicates facts that live in code (exit codes, global flags, the
+// destructive-command rule). When you add or rename an agent-relevant global
+// flag, an exit code, or a notable command — and especially when the local
+// data layer lands — update agent_context.md to match. The TestAgentContextGuide*
+// tests guard the documented set against renames/removals, but they cannot force
+// a newly-added construct to be documented; that is on the contributor (and the
+// PR-review documentation-currency check).
+//
 //go:embed agent_context.md
 var agentContextGuide string
 

--- a/internal/commands/agent_context.md
+++ b/internal/commands/agent_context.md
@@ -28,7 +28,7 @@ check config, credentials, and connectivity without calling the product API.
 - `--compact` — identity + common fields only; fewer tokens
 - `--select <a,b.c>` — project to specific dot-path fields only
 - `--field <name>` — print a single field's value
-- `-q, --quiet` — suppress hints and progress; errors still print
+- `-q, --quiet` — suppress all non-error output (hints, spinner, progress); errors still print
 - `--no-hints` — suppress advisory hints only
 - `--no-input` — never prompt; fail fast if input is required
 - `-n, --dry-run` — preview mutations; GET/HEAD still execute

--- a/internal/commands/agent_context.md
+++ b/internal/commands/agent_context.md
@@ -1,0 +1,69 @@
+# jamf-cli agent operating guide
+
+Durable guidance for AI agents driving jamf-cli. For the live list of every
+command, run `jamf-cli commands -o json`. For a command's flags and arguments,
+run `<command> --help`.
+
+## Authentication
+
+jamf-cli never accepts passwords, tokens, or client secrets via flags or stdin.
+Provide machine credentials through environment variables (CI/CD) or a saved
+profile.
+
+Environment variables (override profile config):
+- `JAMF_URL` — Jamf Pro instance URL
+- `JAMF_TOKEN` — pre-existing bearer token
+- `JAMF_CLIENT_ID` / `JAMF_CLIENT_SECRET` — OAuth2 client credentials
+- `JAMF_TENANT_ID` — tenant id for Platform gateway auth
+- `JAMFPROTECT_URL` / `JAMFPROTECT_CLIENT_ID` / `JAMFPROTECT_CLIENT_SECRET` — Jamf Protect
+
+Profiles: `-p <profile>` (or `JAMF_PROFILE`) selects a saved profile. Create one
+with `jamf-cli pro setup` or `jamf-cli protect setup`. Run `jamf-cli doctor` to
+check config, credentials, and connectivity without calling the product API.
+
+## Output and agent flags (global)
+
+- `-o, --output <fmt>` — `json` (default when piped), `yaml`, `csv`, `plain`,
+  `table` (default on a TTY), `xml`, `raw`
+- `--compact` — identity + common fields only; fewer tokens
+- `--select <a,b.c>` — project to specific dot-path fields only
+- `--field <name>` — print a single field's value
+- `-q, --quiet` — suppress hints and progress; errors still print
+- `--no-hints` — suppress advisory hints only
+- `--no-input` — never prompt; fail fast if input is required
+- `-n, --dry-run` — preview mutations; GET/HEAD still execute
+- `--out-file <path>` — write output to a file
+
+Set session defaults with `JAMF_CLI_ARGS`, e.g. `JAMF_CLI_ARGS='--quiet --no-input'`.
+
+## Exit codes
+
+React to a non-zero exit without parsing the message:
+
+| Code | Name              | Agent action                                        |
+|------|-------------------|-----------------------------------------------------|
+| 0    | success           | —                                                   |
+| 1    | general           | unclassified failure                                |
+| 2    | usage             | bad flags/args — fix the invocation                 |
+| 3    | authentication    | bad/missing credentials — re-check auth, then retry |
+| 4    | not_found         | resource missing — list to find valid ids           |
+| 5    | permission_denied | account lacks API privileges — not retryable as-is  |
+| 6    | rate_limited      | back off and retry                                  |
+| 7    | partial_failure   | batch: some succeeded, some failed                  |
+
+Errors print a one-line remediation hint and, with `-o json`, a structured error
+envelope.
+
+## Destructive commands
+
+Commands that delete, erase, wipe, lock, restart, shut down, unmanage, or flush
+MDM commands require an explicit `--yes`. With `--no-input` and no `--yes` they
+refuse to run rather than prompt. In the MCP catalog (`list_commands`) such
+commands are marked `"destructive": true`.
+
+## MCP
+
+`jamf-cli mcp serve` exposes the command tree to MCP clients over stdio via two
+tools: `list_commands` (catalog) and `run_command` (execute). The server is
+pinned to the profile it was launched with; per-command credential/target flags
+are rejected.

--- a/internal/commands/agent_context_test.go
+++ b/internal/commands/agent_context_test.go
@@ -50,3 +50,19 @@ func TestAgentContextGuideCoversExitCodes(t *testing.T) {
 		}
 	}
 }
+
+// TestAgentContextGuideFlagsExist guards against the guide documenting a global
+// flag that has since been renamed or removed. It pins the documented set to
+// real root persistent flags; --yes is intentionally excluded because it is a
+// per-command destructive gate, not a global flag.
+func TestAgentContextGuideFlagsExist(t *testing.T) {
+	root := NewRootCmd("test", "abc123", "2024-01-01", "unknown")
+	for _, name := range []string{
+		"output", "compact", "select", "field",
+		"quiet", "no-hints", "no-input", "dry-run", "out-file", "profile",
+	} {
+		if root.PersistentFlags().Lookup(name) == nil {
+			t.Errorf("agent-context guide documents --%s, but it is no longer a global persistent flag — update the guide or the flag", name)
+		}
+	}
+}

--- a/internal/commands/agent_context_test.go
+++ b/internal/commands/agent_context_test.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/exitcode"
 )
 
 func TestAgentContextCommand(t *testing.T) {
@@ -23,6 +25,28 @@ func TestAgentContextCommand(t *testing.T) {
 	for _, anchor := range []string{"# jamf-cli agent operating guide", "## Exit codes", "## Destructive commands"} {
 		if !strings.Contains(out, anchor) {
 			t.Errorf("agent-context output missing %q", anchor)
+		}
+	}
+}
+
+// TestAgentContextGuideCoversExitCodes guards against the embedded guide's
+// exit-code table drifting out of sync with internal/exitcode. The guide
+// duplicates facts that live in code; this fails if an exit code is added or
+// renamed in the exitcode package without updating the guide.
+func TestAgentContextGuideCoversExitCodes(t *testing.T) {
+	for _, code := range []int{
+		exitcode.Success,
+		exitcode.General,
+		exitcode.Usage,
+		exitcode.Authentication,
+		exitcode.NotFound,
+		exitcode.PermissionDenied,
+		exitcode.RateLimited,
+		exitcode.PartialFailure,
+	} {
+		name := exitcode.CodeName(code)
+		if !strings.Contains(agentContextGuide, name) {
+			t.Errorf("agent-context guide is missing exit-code name %q (code %d) — keep the guide's exit-code table in sync with internal/exitcode", name, code)
 		}
 	}
 }

--- a/internal/commands/agent_context_test.go
+++ b/internal/commands/agent_context_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestAgentContextCommand(t *testing.T) {
+	root := NewRootCmd("test", "abc123", "2024-01-01", "unknown")
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"agent-context"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("agent-context failed (should run without auth): %v", err)
+	}
+
+	out := buf.String()
+	for _, anchor := range []string{"# jamf-cli agent operating guide", "## Exit codes", "## Destructive commands"} {
+		if !strings.Contains(out, anchor) {
+			t.Errorf("agent-context output missing %q", anchor)
+		}
+	}
+}

--- a/internal/commands/groups.go
+++ b/internal/commands/groups.go
@@ -16,17 +16,18 @@ var rootGroups = []*cobra.Group{
 }
 
 var rootGroupMap = map[string]string{
-	"version":    "core",
-	"config":     "core",
-	"completion": "core",
-	"commands":   "core",
-	"multi":      "core",
-	"doctor":     "core",
-	"mcp":        "core",
-	"pro":        "products",
-	"protect":    "products",
-	"school":     "products",
-	"platform":   "products",
+	"version":       "core",
+	"config":        "core",
+	"completion":    "core",
+	"commands":      "core",
+	"multi":         "core",
+	"doctor":        "core",
+	"mcp":           "core",
+	"agent-context": "core",
+	"pro":           "products",
+	"protect":       "products",
+	"school":        "products",
+	"platform":      "products",
 }
 
 // applyRootGroups registers groups on the root command and assigns each

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -625,15 +625,16 @@ spinner and progress output (narrower than --quiet).`,
 			// "jamf-cli commands" listing command must be skipped, but
 			// "pro mdm-commands commands" must NOT be skipped.
 			chainSkip := map[string]bool{
-				"completion": true,
-				"help":       true,
-				"version":    true,
-				"config":     true,
-				"diff":       true,
-				"setup":      true,
-				"multi":      true,
-				"doctor":     true,
-				"mcp":        true,
+				"completion":    true,
+				"help":          true,
+				"version":       true,
+				"config":        true,
+				"diff":          true,
+				"setup":         true,
+				"multi":         true,
+				"doctor":        true,
+				"mcp":           true,
+				"agent-context": true,
 			}
 			for c := cmd; c != nil; c = c.Parent() {
 				if chainSkip[c.Name()] {
@@ -790,6 +791,9 @@ spinner and progress output (narrower than --quiet).`,
 
 	// Commands discovery subcommand
 	cmd.AddCommand(newCommandsCmd(cmd))
+
+	// Agent operating guide (auth, exit codes, flags, MCP)
+	cmd.AddCommand(newAgentContextCmd())
 
 	// Multi-profile command runner
 	cmd.AddCommand(newMultiCmd())


### PR DESCRIPTION
## What

Adds `jamf-cli agent-context`, a command that prints an embedded markdown operating guide for AI agents driving the CLI: authentication, exit codes, output/agent flags, destructive-command rules, and MCP usage. The content is a single `//go:embed`-ed file (one source of truth, shipped in the binary).

## Why

Agents previously had to discover jamf-cli's conventions by trial and error or by reading `--help` per command. This ships the durable, cross-command conventions in-band. It pairs with #259 (MCP destructive hints) — the guide documents the `destructive` marker that PR surfaces.

## Design

- **Division of labor (won't go stale):** `agent-context` carries only durable conventions; the live command list stays in `commands`, per-command detail in `--help`. The guide points to both.
- **Plain markdown, ignores `-o`:** like `completion` always emitting a shell script. Deliberate exemption from the output-format matrix (content is one prose blob, not tabular data).
- **No auth:** added to the `chainSkip` set so it works before credentials are configured.
- Assigned to the "core" help group.

## Tests

- `TestAgentContextCommand` — runs without auth and asserts the guide contains key section anchors.
- `go test ./internal/commands/` PASS, `go build ./...` clean, `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)