### PR TITLE
feat: -o ndjson output + determinate --all pagination progress

### DIFF
--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -3284,7 +3284,7 @@ type tableColumn struct {
 // columns with display labels. Only applies for table/csv/plain formats;
 // JSON/YAML output is returned unchanged.
 func selectTableColumns(data []byte, columns []tableColumn, format string) []byte {
-	if format == "json" || format == "yaml" || format == "xml" || format == "raw" {
+	if format == "json" || format == "yaml" || format == "xml" || format == "raw" || format == "ndjson" {
 		return data
 	}
 

--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -1921,6 +1921,8 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -2215,6 +2215,25 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 			}
 			return err
 {{- else }}
+{{- if .IsPaginated }}
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage ` + "`" + `json:"results"` + "`" + `
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
+{{- end }}
 			return ctx.Output.PrintResponse(resp)
 {{- end }}
 {{- end }}

--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -1362,6 +1362,9 @@ import (
 {{- if hasDestructive .Operations }}
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 {{- end }}
+{{- if hasPaginated .Operations }}
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
+{{- end }}
 )
 
 // New{{ .GoName }}Cmd creates the {{ .Name }} command group
@@ -1845,6 +1848,9 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -1899,6 +1905,7 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/generator/parser/generator_test.go
+++ b/generator/parser/generator_test.go
@@ -2243,3 +2243,51 @@ func TestGeneratePatchCommand(t *testing.T) {
 		t.Error("patch-by-name should not be generated as a separate command")
 	}
 }
+
+func TestGenerate_PaginationProgressWiring(t *testing.T) {
+	dir := t.TempDir()
+	gen := NewGenerator(dir)
+
+	resource := &Resource{
+		Name:         "items",
+		NameSingular: "item",
+		GoName:       "Items",
+		Operations: []*Operation{
+			{
+				Name:        "list",
+				Method:      "GET",
+				Path:        "/v1/items",
+				Summary:     "List items",
+				IsList:      true,
+				IsPaginated: true,
+				APIVersion:  "v1",
+				Parameters: []*Parameter{
+					{Name: "page", In: "query", Type: "integer"},
+				},
+			},
+		},
+		Schemas: make(map[string]*Schema),
+	}
+
+	outPath, err := gen.Generate(resource)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	content, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(content)
+
+	for _, want := range []string{
+		"PaginationProgress()",
+		"spinner.WithSuppressed(",
+		".Update(len(allResults),",
+		".Stop()",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("generated --all loop missing %q", want)
+		}
+	}
+}

--- a/generator/parser/generator_test.go
+++ b/generator/parser/generator_test.go
@@ -2291,3 +2291,50 @@ func TestGenerate_PaginationProgressWiring(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerate_NdjsonSinglePageUnwrap(t *testing.T) {
+	dir := t.TempDir()
+	gen := NewGenerator(dir)
+
+	resource := &Resource{
+		Name:         "items",
+		NameSingular: "item",
+		GoName:       "Items",
+		Operations: []*Operation{
+			{
+				Name:        "list",
+				Method:      "GET",
+				Path:        "/v1/items",
+				Summary:     "List items",
+				IsList:      true,
+				IsPaginated: true,
+				APIVersion:  "v1",
+				Parameters: []*Parameter{
+					{Name: "page", In: "query", Type: "integer"},
+				},
+			},
+		},
+		Schemas: make(map[string]*Schema),
+	}
+
+	outPath, err := gen.Generate(resource)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	content, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(content)
+
+	// The single-page path (--all=false) should unwrap results for ndjson format.
+	for _, want := range []string{
+		`ctx.Output.Format() == "ndjson"`,
+		"ndjsonWrap.Results",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("generated single-page path missing ndjson unwrap %q", want)
+		}
+	}
+}

--- a/generator/parser/generator_test.go
+++ b/generator/parser/generator_test.go
@@ -2290,6 +2290,24 @@ func TestGenerate_PaginationProgressWiring(t *testing.T) {
 			t.Errorf("generated --all loop missing %q", want)
 		}
 	}
+
+	// There must be at least two prog.Stop() calls: the defer (error paths) and
+	// the explicit call before output. Count occurrences.
+	stopCount := strings.Count(src, "prog.Stop()")
+	if stopCount < 2 {
+		t.Errorf("expected at least 2 prog.Stop() calls (defer + explicit), got %d", stopCount)
+	}
+
+	// The explicit Stop must appear BEFORE json.MarshalIndent(allResults so that
+	// the in-place counter is cleared before records are written to stdout.
+	lastStopIdx := strings.LastIndex(src, "prog.Stop()")
+	marshalIdx := strings.Index(src, "json.MarshalIndent(allResults")
+	if marshalIdx < 0 {
+		t.Fatal("generated source missing json.MarshalIndent(allResults")
+	}
+	if lastStopIdx >= marshalIdx {
+		t.Errorf("last prog.Stop() (offset %d) must appear before json.MarshalIndent(allResults (offset %d)", lastStopIdx, marshalIdx)
+	}
 }
 
 func TestGenerate_NdjsonSinglePageUnwrap(t *testing.T) {

--- a/internal/commands/pro/generated/account_groups.go
+++ b/internal/commands/pro/generated/account_groups.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -75,6 +76,9 @@ func newAccountGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -114,6 +118,7 @@ func newAccountGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/account_groups.go
+++ b/internal/commands/pro/generated/account_groups.go
@@ -149,6 +149,23 @@ func newAccountGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/account_groups.go
+++ b/internal/commands/pro/generated/account_groups.go
@@ -134,6 +134,8 @@ func newAccountGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/activation_codes.go
+++ b/internal/commands/pro/generated/activation_codes.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -141,6 +142,9 @@ func newActivationCodesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -180,6 +184,7 @@ func newActivationCodesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/activation_codes.go
+++ b/internal/commands/pro/generated/activation_codes.go
@@ -200,6 +200,8 @@ func newActivationCodesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/activation_codes.go
+++ b/internal/commands/pro/generated/activation_codes.go
@@ -215,6 +215,23 @@ func newActivationCodesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/adcs_settings.go
+++ b/internal/commands/pro/generated/adcs_settings.go
@@ -527,6 +527,23 @@ func newAdcsSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/adcs_settings.go
+++ b/internal/commands/pro/generated/adcs_settings.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -452,6 +453,9 @@ func newAdcsSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -492,6 +496,7 @@ func newAdcsSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/adcs_settings.go
+++ b/internal/commands/pro/generated/adcs_settings.go
@@ -512,6 +512,8 @@ func newAdcsSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/all_pagination_ndjson_test.go
+++ b/internal/commands/pro/generated/all_pagination_ndjson_test.go
@@ -1,0 +1,249 @@
+// Copyright 2026, Jamf Software LLC
+
+package generated
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/output"
+	"github.com/Jamf-Concepts/jamf-cli/internal/progress"
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+)
+
+// ── ndjson output wrapper ─────────────────────────────────────────────────────
+
+// ndjsonOutput wraps output.Formatter and satisfies registry.OutputFormatter
+// with a real ndjson formatter writing to a captured buffer.
+type ndjsonOutput struct {
+	f   *output.Formatter
+	buf *bytes.Buffer
+}
+
+func newNDJSONOutput() *ndjsonOutput {
+	buf := &bytes.Buffer{}
+	f := output.New("ndjson", true, false)
+	f.SetWriter(buf)
+	return &ndjsonOutput{f: f, buf: buf}
+}
+
+func (o *ndjsonOutput) PrintResponse(resp *http.Response) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	return o.f.PrintRaw(body)
+}
+
+func (o *ndjsonOutput) PrintRaw(data []byte) error {
+	return o.f.PrintRaw(data)
+}
+
+func (o *ndjsonOutput) PrintBytes(data []byte) error {
+	return o.f.PrintBytes(data)
+}
+
+func (o *ndjsonOutput) Format() string {
+	return o.f.Format()
+}
+
+func (o *ndjsonOutput) PaginationProgress() *progress.Reporter {
+	return progress.New(io.Discard, progress.Silent)
+}
+
+// ── paginated fake HTTP client ────────────────────────────────────────────────
+
+// paginatedClient serves a two-page computers-inventory response keyed on the
+// "page" query parameter. Page 0 → 100 results; page 1 → 50 results (150 total).
+type paginatedClient struct {
+	totalCount int
+	pageSize   int
+	// pagePrefix is the path prefix to match (without query string)
+	pathPrefix string
+}
+
+func newComputersInventoryClient() *paginatedClient {
+	return &paginatedClient{
+		totalCount: 150,
+		pageSize:   100,
+		pathPrefix: "/v3/computers-inventory",
+	}
+}
+
+func (c *paginatedClient) Do(_ context.Context, method, path string, _ io.Reader) (*http.Response, error) {
+	if method != "GET" || !strings.HasPrefix(path, c.pathPrefix) {
+		return &http.Response{
+			StatusCode: 404,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"not found"}`)),
+		}, nil
+	}
+
+	// Parse page number from query string.
+	pageNum := 0
+	if idx := strings.Index(path, "page="); idx >= 0 {
+		rest := path[idx+len("page="):]
+		// Read digits until non-digit
+		end := 0
+		for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+			end++
+		}
+		_, _ = fmt.Sscanf(rest[:end], "%d", &pageNum)
+	}
+
+	// Page 0: first 100 results. Page 1: remaining 50. Any other page: empty.
+	var results []json.RawMessage
+	start := pageNum * c.pageSize
+	total := c.totalCount
+	for i := start; i < start+c.pageSize && i < total; i++ {
+		obj := json.RawMessage(fmt.Sprintf(`{"id":"%d","general":{"name":"computer-%d"}}`, i+1, i+1))
+		results = append(results, obj)
+	}
+
+	body := struct {
+		TotalCount int               `json:"totalCount"`
+		Results    []json.RawMessage `json:"results"`
+	}{
+		TotalCount: total,
+		Results:    results,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
+	}, nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// nonEmptyNDJSONLines splits output on newlines, dropping blank trailing lines.
+func nonEmptyNDJSONLines(s string) []string {
+	var out []string
+	for _, ln := range strings.Split(s, "\n") {
+		if ln != "" {
+			out = append(out, ln)
+		}
+	}
+	return out
+}
+
+// assertNDJSONObjects checks that every line is a valid JSON object (not an array).
+func assertNDJSONObjects(t *testing.T, lines []string) {
+	t.Helper()
+	for i, ln := range lines {
+		if strings.HasPrefix(strings.TrimSpace(ln), "[") {
+			t.Errorf("line %d starts with '[' (array wrapper leaked): %q", i, ln)
+		}
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(ln), &obj); err != nil {
+			t.Errorf("line %d is not a valid JSON object: %q (%v)", i, ln, err)
+		}
+	}
+}
+
+// ── TEST 5a: --all pagination produces 150 NDJSON lines ──────────────────────
+
+func TestAllPagination_NDJSON_PerRecord(t *testing.T) {
+	out := newNDJSONOutput()
+	cliCtx := &registry.CLIContext{
+		Client: newComputersInventoryClient(),
+		Output: out,
+	}
+
+	// --all is the default (true), so no explicit flag needed; we just run list.
+	cmd := NewComputersInventoryCmd(cliCtx)
+	cmd.SetArgs([]string{"list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("list execute: %v", err)
+	}
+
+	lines := nonEmptyNDJSONLines(out.buf.String())
+	if len(lines) != 150 {
+		t.Errorf("expected 150 NDJSON lines (100+50 pages), got %d", len(lines))
+	}
+	assertNDJSONObjects(t, lines)
+}
+
+// ── TEST 5b: --limit 120 truncates to 120 lines ───────────────────────────────
+
+func TestAllPagination_NDJSON_Limit(t *testing.T) {
+	out := newNDJSONOutput()
+	cliCtx := &registry.CLIContext{
+		Client: newComputersInventoryClient(),
+		Output: out,
+	}
+
+	cmd := NewComputersInventoryCmd(cliCtx)
+	cmd.SetArgs([]string{"list", "--limit", "120"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("list execute: %v", err)
+	}
+
+	lines := nonEmptyNDJSONLines(out.buf.String())
+	if len(lines) != 120 {
+		t.Errorf("expected 120 NDJSON lines (--limit 120), got %d", len(lines))
+	}
+	assertNDJSONObjects(t, lines)
+}
+
+// ── TEST 5c: classic list produces per-record NDJSON lines ───────────────────
+
+// classicUsersClient returns an XML /JSSResource/accounts response with N users.
+type classicUsersClient struct {
+	count int
+}
+
+func (c *classicUsersClient) Do(_ context.Context, method, path string, _ io.Reader) (*http.Response, error) {
+	if method != "GET" || path != "/JSSResource/accounts" {
+		return &http.Response{
+			StatusCode: 404,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?><accounts><users>`)
+	for i := 1; i <= c.count; i++ {
+		fmt.Fprintf(&sb, `<user><id>%d</id><name>user-%d</name></user>`, i, i)
+	}
+	sb.WriteString(`</users><groups/></accounts>`)
+
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(sb.String())),
+	}, nil
+}
+
+func TestClassicList_NDJSON_PerRecord(t *testing.T) {
+	out := newNDJSONOutput()
+	cliCtx := &registry.CLIContext{
+		Client: &classicUsersClient{count: 5},
+		Output: out,
+	}
+
+	// The formatter's Format() returns "ndjson", so the classic list code will
+	// skip its "default to pretty-printed XML" branch and take the structured path.
+	cmd := NewClassicAccountUsersCmd(cliCtx)
+	cmd.SetArgs([]string{"list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("list execute: %v", err)
+	}
+
+	lines := nonEmptyNDJSONLines(out.buf.String())
+	if len(lines) != 5 {
+		t.Errorf("expected 5 NDJSON lines (one per user), got %d\noutput:\n%s", len(lines), out.buf.String())
+	}
+	assertNDJSONObjects(t, lines)
+	// Each line should contain the user name field.
+	for i, ln := range lines {
+		if !strings.Contains(ln, fmt.Sprintf("user-%d", i+1)) {
+			t.Errorf("line %d does not contain expected user name 'user-%d': %q", i, i+1, ln)
+		}
+	}
+}

--- a/internal/commands/pro/generated/api_integrations.go
+++ b/internal/commands/pro/generated/api_integrations.go
@@ -158,6 +158,23 @@ func newApiIntegrationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/api_integrations.go
+++ b/internal/commands/pro/generated/api_integrations.go
@@ -143,6 +143,8 @@ func newApiIntegrationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/api_integrations.go
+++ b/internal/commands/pro/generated/api_integrations.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -84,6 +85,9 @@ func newApiIntegrationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -123,6 +127,7 @@ func newApiIntegrationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/api_roles.go
+++ b/internal/commands/pro/generated/api_roles.go
@@ -157,6 +157,23 @@ func newApiRolesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/api_roles.go
+++ b/internal/commands/pro/generated/api_roles.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -83,6 +84,9 @@ func newApiRolesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -122,6 +126,7 @@ func newApiRolesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/api_roles.go
+++ b/internal/commands/pro/generated/api_roles.go
@@ -142,6 +142,8 @@ func newApiRolesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/apns_client_push_status.go
+++ b/internal/commands/pro/generated/apns_client_push_status.go
@@ -148,6 +148,23 @@ func newApnsClientPushStatusApnsClientPushStatusCmd(ctx *registry.CLIContext) *c
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/apns_client_push_status.go
+++ b/internal/commands/pro/generated/apns_client_push_status.go
@@ -133,6 +133,8 @@ func newApnsClientPushStatusApnsClientPushStatusCmd(ctx *registry.CLIContext) *c
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/apns_client_push_status.go
+++ b/internal/commands/pro/generated/apns_client_push_status.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -74,6 +75,9 @@ func newApnsClientPushStatusApnsClientPushStatusCmd(ctx *registry.CLIContext) *c
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -113,6 +117,7 @@ func newApnsClientPushStatusApnsClientPushStatusCmd(ctx *registry.CLIContext) *c
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/app_installer_deployments.go
+++ b/internal/commands/pro/generated/app_installer_deployments.go
@@ -150,6 +150,23 @@ func newAppInstallerDeploymentsListCmd(ctx *registry.CLIContext) *cobra.Command 
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/app_installer_deployments.go
+++ b/internal/commands/pro/generated/app_installer_deployments.go
@@ -135,6 +135,8 @@ func newAppInstallerDeploymentsListCmd(ctx *registry.CLIContext) *cobra.Command 
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/app_installer_deployments.go
+++ b/internal/commands/pro/generated/app_installer_deployments.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -76,6 +77,9 @@ func newAppInstallerDeploymentsListCmd(ctx *registry.CLIContext) *cobra.Command 
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -115,6 +119,7 @@ func newAppInstallerDeploymentsListCmd(ctx *registry.CLIContext) *cobra.Command 
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/app_installer_titles.go
+++ b/internal/commands/pro/generated/app_installer_titles.go
@@ -124,6 +124,8 @@ func newAppInstallerTitlesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/app_installer_titles.go
+++ b/internal/commands/pro/generated/app_installer_titles.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -65,6 +66,9 @@ func newAppInstallerTitlesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -104,6 +108,7 @@ func newAppInstallerTitlesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/app_installer_titles.go
+++ b/internal/commands/pro/generated/app_installer_titles.go
@@ -139,6 +139,23 @@ func newAppInstallerTitlesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/buildings.go
+++ b/internal/commands/pro/generated/buildings.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -88,6 +89,9 @@ func newBuildingsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -127,6 +131,7 @@ func newBuildingsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -770,6 +775,9 @@ func newBuildingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -810,6 +818,7 @@ func newBuildingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/buildings.go
+++ b/internal/commands/pro/generated/buildings.go
@@ -162,6 +162,23 @@ func newBuildingsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -849,6 +866,23 @@ func newBuildingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/buildings.go
+++ b/internal/commands/pro/generated/buildings.go
@@ -147,6 +147,8 @@ func newBuildingsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -850,6 +852,8 @@ func newBuildingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/categories.go
+++ b/internal/commands/pro/generated/categories.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -86,6 +87,9 @@ func newCategoriesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -125,6 +129,7 @@ func newCategoriesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -758,6 +763,9 @@ func newCategoriesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -798,6 +806,7 @@ func newCategoriesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/categories.go
+++ b/internal/commands/pro/generated/categories.go
@@ -145,6 +145,8 @@ func newCategoriesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -838,6 +840,8 @@ func newCategoriesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/categories.go
+++ b/internal/commands/pro/generated/categories.go
@@ -160,6 +160,23 @@ func newCategoriesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -837,6 +854,23 @@ func newCategoriesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/client_check_in.go
+++ b/internal/commands/pro/generated/client_check_in.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -186,6 +187,9 @@ func newClientCheckInHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -225,6 +229,7 @@ func newClientCheckInHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/client_check_in.go
+++ b/internal/commands/pro/generated/client_check_in.go
@@ -260,6 +260,23 @@ func newClientCheckInHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/client_check_in.go
+++ b/internal/commands/pro/generated/client_check_in.go
@@ -245,6 +245,8 @@ func newClientCheckInHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/cloud_distribution_points.go
+++ b/internal/commands/pro/generated/cloud_distribution_points.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -243,6 +244,9 @@ func newCloudDistributionPointsHistoryCmd(ctx *registry.CLIContext) *cobra.Comma
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -282,6 +286,7 @@ func newCloudDistributionPointsHistoryCmd(ctx *registry.CLIContext) *cobra.Comma
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -623,6 +628,9 @@ func newCloudDistributionPointsFilesCmd(ctx *registry.CLIContext) *cobra.Command
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -662,6 +670,7 @@ func newCloudDistributionPointsFilesCmd(ctx *registry.CLIContext) *cobra.Command
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/cloud_distribution_points.go
+++ b/internal/commands/pro/generated/cloud_distribution_points.go
@@ -302,6 +302,8 @@ func newCloudDistributionPointsHistoryCmd(ctx *registry.CLIContext) *cobra.Comma
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -702,6 +704,8 @@ func newCloudDistributionPointsFilesCmd(ctx *registry.CLIContext) *cobra.Command
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/cloud_distribution_points.go
+++ b/internal/commands/pro/generated/cloud_distribution_points.go
@@ -317,6 +317,23 @@ func newCloudDistributionPointsHistoryCmd(ctx *registry.CLIContext) *cobra.Comma
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -701,6 +718,23 @@ func newCloudDistributionPointsFilesCmd(ctx *registry.CLIContext) *cobra.Command
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/cloud_id_p_configurations.go
+++ b/internal/commands/pro/generated/cloud_id_p_configurations.go
@@ -148,6 +148,23 @@ func newCloudIdPConfigurationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/cloud_id_p_configurations.go
+++ b/internal/commands/pro/generated/cloud_id_p_configurations.go
@@ -133,6 +133,8 @@ func newCloudIdPConfigurationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/cloud_id_p_configurations.go
+++ b/internal/commands/pro/generated/cloud_id_p_configurations.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -74,6 +75,9 @@ func newCloudIdPConfigurationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -113,6 +117,7 @@ func newCloudIdPConfigurationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/cloud_id_p_histories.go
+++ b/internal/commands/pro/generated/cloud_id_p_histories.go
@@ -151,6 +151,23 @@ func newCloudIdPHistoriesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/cloud_id_p_histories.go
+++ b/internal/commands/pro/generated/cloud_id_p_histories.go
@@ -136,6 +136,8 @@ func newCloudIdPHistoriesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/cloud_id_p_histories.go
+++ b/internal/commands/pro/generated/cloud_id_p_histories.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -76,6 +77,9 @@ func newCloudIdPHistoriesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -116,6 +120,7 @@ func newCloudIdPHistoriesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/computer_extension_attributes.go
+++ b/internal/commands/pro/generated/computer_extension_attributes.go
@@ -164,6 +164,23 @@ func newComputerExtensionAttributesListCmd(ctx *registry.CLIContext) *cobra.Comm
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -892,6 +909,23 @@ func newComputerExtensionAttributesHistoryCmd(ctx *registry.CLIContext) *cobra.C
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/computer_extension_attributes.go
+++ b/internal/commands/pro/generated/computer_extension_attributes.go
@@ -149,6 +149,8 @@ func newComputerExtensionAttributesListCmd(ctx *registry.CLIContext) *cobra.Comm
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -893,6 +895,8 @@ func newComputerExtensionAttributesHistoryCmd(ctx *registry.CLIContext) *cobra.C
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/computer_extension_attributes.go
+++ b/internal/commands/pro/generated/computer_extension_attributes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -90,6 +91,9 @@ func newComputerExtensionAttributesListCmd(ctx *registry.CLIContext) *cobra.Comm
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -129,6 +133,7 @@ func newComputerExtensionAttributesListCmd(ctx *registry.CLIContext) *cobra.Comm
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -813,6 +818,9 @@ func newComputerExtensionAttributesHistoryCmd(ctx *registry.CLIContext) *cobra.C
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -853,6 +861,7 @@ func newComputerExtensionAttributesHistoryCmd(ctx *registry.CLIContext) *cobra.C
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/computer_groups_smart_groups.go
+++ b/internal/commands/pro/generated/computer_groups_smart_groups.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -84,6 +85,9 @@ func newComputerGroupsSmartGroupsListCmd(ctx *registry.CLIContext) *cobra.Comman
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -123,6 +127,7 @@ func newComputerGroupsSmartGroupsListCmd(ctx *registry.CLIContext) *cobra.Comman
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/computer_groups_smart_groups.go
+++ b/internal/commands/pro/generated/computer_groups_smart_groups.go
@@ -158,6 +158,23 @@ func newComputerGroupsSmartGroupsListCmd(ctx *registry.CLIContext) *cobra.Comman
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/computer_groups_smart_groups.go
+++ b/internal/commands/pro/generated/computer_groups_smart_groups.go
@@ -143,6 +143,8 @@ func newComputerGroupsSmartGroupsListCmd(ctx *registry.CLIContext) *cobra.Comman
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/computer_groups_static_groups.go
+++ b/internal/commands/pro/generated/computer_groups_static_groups.go
@@ -157,6 +157,23 @@ func newComputerGroupsStaticGroupsListCmd(ctx *registry.CLIContext) *cobra.Comma
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/computer_groups_static_groups.go
+++ b/internal/commands/pro/generated/computer_groups_static_groups.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -83,6 +84,9 @@ func newComputerGroupsStaticGroupsListCmd(ctx *registry.CLIContext) *cobra.Comma
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -122,6 +126,7 @@ func newComputerGroupsStaticGroupsListCmd(ctx *registry.CLIContext) *cobra.Comma
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/computer_groups_static_groups.go
+++ b/internal/commands/pro/generated/computer_groups_static_groups.go
@@ -142,6 +142,8 @@ func newComputerGroupsStaticGroupsListCmd(ctx *registry.CLIContext) *cobra.Comma
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/computer_prestages.go
+++ b/internal/commands/pro/generated/computer_prestages.go
@@ -153,6 +153,23 @@ func newComputerPrestagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/computer_prestages.go
+++ b/internal/commands/pro/generated/computer_prestages.go
@@ -138,6 +138,8 @@ func newComputerPrestagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/computer_prestages.go
+++ b/internal/commands/pro/generated/computer_prestages.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -79,6 +80,9 @@ func newComputerPrestagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -118,6 +122,7 @@ func newComputerPrestagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/computers.go
+++ b/internal/commands/pro/generated/computers.go
@@ -150,6 +150,23 @@ func newComputersListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/computers.go
+++ b/internal/commands/pro/generated/computers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -76,6 +77,9 @@ func newComputersListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -115,6 +119,7 @@ func newComputersListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/computers.go
+++ b/internal/commands/pro/generated/computers.go
@@ -135,6 +135,8 @@ func newComputersListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/computers_inventory.go
+++ b/internal/commands/pro/generated/computers_inventory.go
@@ -182,6 +182,23 @@ func newComputersInventoryListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -947,6 +964,23 @@ func newComputersInventoryFilevaultCmd(ctx *registry.CLIContext) *cobra.Command 
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/computers_inventory.go
+++ b/internal/commands/pro/generated/computers_inventory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -100,6 +101,9 @@ func newComputersInventoryListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -139,6 +143,7 @@ func newComputersInventoryListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -861,6 +866,9 @@ func newComputersInventoryFilevaultCmd(ctx *registry.CLIContext) *cobra.Command 
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -900,6 +908,7 @@ func newComputersInventoryFilevaultCmd(ctx *registry.CLIContext) *cobra.Command 
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/computers_inventory.go
+++ b/internal/commands/pro/generated/computers_inventory.go
@@ -159,6 +159,8 @@ func newComputersInventoryListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -940,6 +942,8 @@ func newComputersInventoryFilevaultCmd(ctx *registry.CLIContext) *cobra.Command 
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/departments.go
+++ b/internal/commands/pro/generated/departments.go
@@ -160,6 +160,23 @@ func newDepartmentsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -835,6 +852,23 @@ func newDepartmentsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/departments.go
+++ b/internal/commands/pro/generated/departments.go
@@ -145,6 +145,8 @@ func newDepartmentsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -836,6 +838,8 @@ func newDepartmentsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/departments.go
+++ b/internal/commands/pro/generated/departments.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -86,6 +87,9 @@ func newDepartmentsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -125,6 +129,7 @@ func newDepartmentsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -756,6 +761,9 @@ func newDepartmentsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -796,6 +804,7 @@ func newDepartmentsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/device_communication_settings.go
+++ b/internal/commands/pro/generated/device_communication_settings.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -183,6 +184,9 @@ func newDeviceCommunicationSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.C
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -222,6 +226,7 @@ func newDeviceCommunicationSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.C
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/device_communication_settings.go
+++ b/internal/commands/pro/generated/device_communication_settings.go
@@ -257,6 +257,23 @@ func newDeviceCommunicationSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.C
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/device_communication_settings.go
+++ b/internal/commands/pro/generated/device_communication_settings.go
@@ -242,6 +242,8 @@ func newDeviceCommunicationSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.C
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/device_enrollment_instances.go
+++ b/internal/commands/pro/generated/device_enrollment_instances.go
@@ -144,6 +144,8 @@ func newDeviceEnrollmentInstancesListCmd(ctx *registry.CLIContext) *cobra.Comman
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -822,6 +824,8 @@ func newDeviceEnrollmentInstancesHistoryCmd(ctx *registry.CLIContext) *cobra.Com
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/device_enrollment_instances.go
+++ b/internal/commands/pro/generated/device_enrollment_instances.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -85,6 +86,9 @@ func newDeviceEnrollmentInstancesListCmd(ctx *registry.CLIContext) *cobra.Comman
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -124,6 +128,7 @@ func newDeviceEnrollmentInstancesListCmd(ctx *registry.CLIContext) *cobra.Comman
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -742,6 +747,9 @@ func newDeviceEnrollmentInstancesHistoryCmd(ctx *registry.CLIContext) *cobra.Com
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -782,6 +790,7 @@ func newDeviceEnrollmentInstancesHistoryCmd(ctx *registry.CLIContext) *cobra.Com
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/device_enrollment_instances.go
+++ b/internal/commands/pro/generated/device_enrollment_instances.go
@@ -159,6 +159,23 @@ func newDeviceEnrollmentInstancesListCmd(ctx *registry.CLIContext) *cobra.Comman
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -821,6 +838,23 @@ func newDeviceEnrollmentInstancesHistoryCmd(ctx *registry.CLIContext) *cobra.Com
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/distribution_points.go
+++ b/internal/commands/pro/generated/distribution_points.go
@@ -146,6 +146,8 @@ func newDistributionPointsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -879,6 +881,8 @@ func newDistributionPointsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/distribution_points.go
+++ b/internal/commands/pro/generated/distribution_points.go
@@ -161,6 +161,23 @@ func newDistributionPointsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -878,6 +895,23 @@ func newDistributionPointsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/distribution_points.go
+++ b/internal/commands/pro/generated/distribution_points.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -87,6 +88,9 @@ func newDistributionPointsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -126,6 +130,7 @@ func newDistributionPointsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -799,6 +804,9 @@ func newDistributionPointsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -839,6 +847,7 @@ func newDistributionPointsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/ebooks.go
+++ b/internal/commands/pro/generated/ebooks.go
@@ -146,6 +146,23 @@ func newEbooksListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/ebooks.go
+++ b/internal/commands/pro/generated/ebooks.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -72,6 +73,9 @@ func newEbooksListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -111,6 +115,7 @@ func newEbooksListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/ebooks.go
+++ b/internal/commands/pro/generated/ebooks.go
@@ -131,6 +131,8 @@ func newEbooksListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/enrollment_customizations.go
+++ b/internal/commands/pro/generated/enrollment_customizations.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -85,6 +86,9 @@ func newEnrollmentCustomizationsListCmd(ctx *registry.CLIContext) *cobra.Command
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -124,6 +128,7 @@ func newEnrollmentCustomizationsListCmd(ctx *registry.CLIContext) *cobra.Command
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -659,6 +664,9 @@ func newEnrollmentCustomizationsHistoryCmd(ctx *registry.CLIContext) *cobra.Comm
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -699,6 +707,7 @@ func newEnrollmentCustomizationsHistoryCmd(ctx *registry.CLIContext) *cobra.Comm
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/enrollment_customizations.go
+++ b/internal/commands/pro/generated/enrollment_customizations.go
@@ -159,6 +159,23 @@ func newEnrollmentCustomizationsListCmd(ctx *registry.CLIContext) *cobra.Command
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -738,6 +755,23 @@ func newEnrollmentCustomizationsHistoryCmd(ctx *registry.CLIContext) *cobra.Comm
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/enrollment_customizations.go
+++ b/internal/commands/pro/generated/enrollment_customizations.go
@@ -144,6 +144,8 @@ func newEnrollmentCustomizationsListCmd(ctx *registry.CLIContext) *cobra.Command
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -739,6 +741,8 @@ func newEnrollmentCustomizationsHistoryCmd(ctx *registry.CLIContext) *cobra.Comm
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/enrollment_languages.go
+++ b/internal/commands/pro/generated/enrollment_languages.go
@@ -139,6 +139,8 @@ func newEnrollmentLanguagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/enrollment_languages.go
+++ b/internal/commands/pro/generated/enrollment_languages.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -80,6 +81,9 @@ func newEnrollmentLanguagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -119,6 +123,7 @@ func newEnrollmentLanguagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/enrollment_languages.go
+++ b/internal/commands/pro/generated/enrollment_languages.go
@@ -154,6 +154,23 @@ func newEnrollmentLanguagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/enrollment_settings.go
+++ b/internal/commands/pro/generated/enrollment_settings.go
@@ -147,6 +147,8 @@ func newEnrollmentSettingsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -730,6 +732,8 @@ func newEnrollmentSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/enrollment_settings.go
+++ b/internal/commands/pro/generated/enrollment_settings.go
@@ -162,6 +162,23 @@ func newEnrollmentSettingsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -729,6 +746,23 @@ func newEnrollmentSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/enrollment_settings.go
+++ b/internal/commands/pro/generated/enrollment_settings.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -88,6 +89,9 @@ func newEnrollmentSettingsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -127,6 +131,7 @@ func newEnrollmentSettingsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -651,6 +656,9 @@ func newEnrollmentSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -690,6 +698,7 @@ func newEnrollmentSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/groups.go
+++ b/internal/commands/pro/generated/groups.go
@@ -141,6 +141,8 @@ func newGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/groups.go
+++ b/internal/commands/pro/generated/groups.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -82,6 +83,9 @@ func newGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -121,6 +125,7 @@ func newGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/groups.go
+++ b/internal/commands/pro/generated/groups.go
@@ -156,6 +156,23 @@ func newGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/gsx_connection.go
+++ b/internal/commands/pro/generated/gsx_connection.go
@@ -244,6 +244,8 @@ func newGsxConnectionHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/gsx_connection.go
+++ b/internal/commands/pro/generated/gsx_connection.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -185,6 +186,9 @@ func newGsxConnectionHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -224,6 +228,7 @@ func newGsxConnectionHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/gsx_connection.go
+++ b/internal/commands/pro/generated/gsx_connection.go
@@ -259,6 +259,23 @@ func newGsxConnectionHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/inventory_preloads.go
+++ b/internal/commands/pro/generated/inventory_preloads.go
@@ -167,6 +167,23 @@ func newInventoryPreloadsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -770,6 +787,23 @@ func newInventoryPreloadsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/inventory_preloads.go
+++ b/internal/commands/pro/generated/inventory_preloads.go
@@ -152,6 +152,8 @@ func newInventoryPreloadsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -771,6 +773,8 @@ func newInventoryPreloadsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/inventory_preloads.go
+++ b/internal/commands/pro/generated/inventory_preloads.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -93,6 +94,9 @@ func newInventoryPreloadsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -132,6 +136,7 @@ func newInventoryPreloadsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -692,6 +697,9 @@ func newInventoryPreloadsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -731,6 +739,7 @@ func newInventoryPreloadsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/jamf_connect_deployment_tasks.go
+++ b/internal/commands/pro/generated/jamf_connect_deployment_tasks.go
@@ -218,6 +218,23 @@ func newJamfConnectDeploymentTasksTasksCmd(ctx *registry.CLIContext) *cobra.Comm
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/jamf_connect_deployment_tasks.go
+++ b/internal/commands/pro/generated/jamf_connect_deployment_tasks.go
@@ -203,6 +203,8 @@ func newJamfConnectDeploymentTasksTasksCmd(ctx *registry.CLIContext) *cobra.Comm
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/jamf_connect_deployment_tasks.go
+++ b/internal/commands/pro/generated/jamf_connect_deployment_tasks.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -143,6 +144,9 @@ func newJamfConnectDeploymentTasksTasksCmd(ctx *registry.CLIContext) *cobra.Comm
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -183,6 +187,7 @@ func newJamfConnectDeploymentTasksTasksCmd(ctx *registry.CLIContext) *cobra.Comm
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/jamf_connects.go
+++ b/internal/commands/pro/generated/jamf_connects.go
@@ -154,6 +154,23 @@ func newJamfConnectsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -372,6 +389,23 @@ func newJamfConnectsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/jamf_connects.go
+++ b/internal/commands/pro/generated/jamf_connects.go
@@ -139,6 +139,8 @@ func newJamfConnectsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -373,6 +375,8 @@ func newJamfConnectsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/jamf_connects.go
+++ b/internal/commands/pro/generated/jamf_connects.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -80,6 +81,9 @@ func newJamfConnectsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -119,6 +123,7 @@ func newJamfConnectsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -294,6 +299,9 @@ func newJamfConnectsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -333,6 +341,7 @@ func newJamfConnectsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/jamf_pro_server_url.go
+++ b/internal/commands/pro/generated/jamf_pro_server_url.go
@@ -239,6 +239,8 @@ func newJamfProServerUrlHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/jamf_pro_server_url.go
+++ b/internal/commands/pro/generated/jamf_pro_server_url.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -180,6 +181,9 @@ func newJamfProServerUrlHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -219,6 +223,7 @@ func newJamfProServerUrlHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/jamf_pro_server_url.go
+++ b/internal/commands/pro/generated/jamf_pro_server_url.go
@@ -254,6 +254,23 @@ func newJamfProServerUrlHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/jamf_protect.go
+++ b/internal/commands/pro/generated/jamf_protect.go
@@ -388,6 +388,8 @@ func newJamfProtectHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/jamf_protect.go
+++ b/internal/commands/pro/generated/jamf_protect.go
@@ -403,6 +403,23 @@ func newJamfProtectHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/jamf_protect.go
+++ b/internal/commands/pro/generated/jamf_protect.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -329,6 +330,9 @@ func newJamfProtectHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -368,6 +372,7 @@ func newJamfProtectHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/jamf_protect_deployment_tasks.go
+++ b/internal/commands/pro/generated/jamf_protect_deployment_tasks.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -74,6 +75,9 @@ func newJamfProtectDeploymentTasksTasksCmd(ctx *registry.CLIContext) *cobra.Comm
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -114,6 +118,7 @@ func newJamfProtectDeploymentTasksTasksCmd(ctx *registry.CLIContext) *cobra.Comm
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/jamf_protect_deployment_tasks.go
+++ b/internal/commands/pro/generated/jamf_protect_deployment_tasks.go
@@ -134,6 +134,8 @@ func newJamfProtectDeploymentTasksTasksCmd(ctx *registry.CLIContext) *cobra.Comm
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/jamf_protect_deployment_tasks.go
+++ b/internal/commands/pro/generated/jamf_protect_deployment_tasks.go
@@ -149,6 +149,23 @@ func newJamfProtectDeploymentTasksTasksCmd(ctx *registry.CLIContext) *cobra.Comm
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/jamf_protect_plans.go
+++ b/internal/commands/pro/generated/jamf_protect_plans.go
@@ -151,6 +151,23 @@ func newJamfProtectPlansListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/jamf_protect_plans.go
+++ b/internal/commands/pro/generated/jamf_protect_plans.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -77,6 +78,9 @@ func newJamfProtectPlansListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -116,6 +120,7 @@ func newJamfProtectPlansListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/jamf_protect_plans.go
+++ b/internal/commands/pro/generated/jamf_protect_plans.go
@@ -136,6 +136,8 @@ func newJamfProtectPlansListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/jamf_remote_assist_session_histories.go
+++ b/internal/commands/pro/generated/jamf_remote_assist_session_histories.go
@@ -137,6 +137,8 @@ func newJamfRemoteAssistSessionHistoriesListCmd(ctx *registry.CLIContext) *cobra
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/jamf_remote_assist_session_histories.go
+++ b/internal/commands/pro/generated/jamf_remote_assist_session_histories.go
@@ -152,6 +152,23 @@ func newJamfRemoteAssistSessionHistoriesListCmd(ctx *registry.CLIContext) *cobra
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/jamf_remote_assist_session_histories.go
+++ b/internal/commands/pro/generated/jamf_remote_assist_session_histories.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -78,6 +79,9 @@ func newJamfRemoteAssistSessionHistoriesListCmd(ctx *registry.CLIContext) *cobra
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -117,6 +121,7 @@ func newJamfRemoteAssistSessionHistoriesListCmd(ctx *registry.CLIContext) *cobra
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/managed_software_updates_plans.go
+++ b/internal/commands/pro/generated/managed_software_updates_plans.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -85,6 +86,9 @@ func newManagedSoftwareUpdatesPlansListCmd(ctx *registry.CLIContext) *cobra.Comm
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -124,6 +128,7 @@ func newManagedSoftwareUpdatesPlansListCmd(ctx *registry.CLIContext) *cobra.Comm
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/managed_software_updates_plans.go
+++ b/internal/commands/pro/generated/managed_software_updates_plans.go
@@ -159,6 +159,23 @@ func newManagedSoftwareUpdatesPlansListCmd(ctx *registry.CLIContext) *cobra.Comm
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/managed_software_updates_plans.go
+++ b/internal/commands/pro/generated/managed_software_updates_plans.go
@@ -144,6 +144,8 @@ func newManagedSoftwareUpdatesPlansListCmd(ctx *registry.CLIContext) *cobra.Comm
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/mdm_commands.go
+++ b/internal/commands/pro/generated/mdm_commands.go
@@ -153,6 +153,23 @@ func newMdmCommandsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/mdm_commands.go
+++ b/internal/commands/pro/generated/mdm_commands.go
@@ -138,6 +138,8 @@ func newMdmCommandsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/mdm_commands.go
+++ b/internal/commands/pro/generated/mdm_commands.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -79,6 +80,9 @@ func newMdmCommandsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -118,6 +122,7 @@ func newMdmCommandsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/mobile_device_extension_attributes.go
+++ b/internal/commands/pro/generated/mobile_device_extension_attributes.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -86,6 +87,9 @@ func newMobileDeviceExtensionAttributesListCmd(ctx *registry.CLIContext) *cobra.
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -125,6 +129,7 @@ func newMobileDeviceExtensionAttributesListCmd(ctx *registry.CLIContext) *cobra.
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -679,6 +684,9 @@ func newMobileDeviceExtensionAttributesHistoryCmd(ctx *registry.CLIContext) *cob
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -719,6 +727,7 @@ func newMobileDeviceExtensionAttributesHistoryCmd(ctx *registry.CLIContext) *cob
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/mobile_device_extension_attributes.go
+++ b/internal/commands/pro/generated/mobile_device_extension_attributes.go
@@ -160,6 +160,23 @@ func newMobileDeviceExtensionAttributesListCmd(ctx *registry.CLIContext) *cobra.
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -758,6 +775,23 @@ func newMobileDeviceExtensionAttributesHistoryCmd(ctx *registry.CLIContext) *cob
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/mobile_device_extension_attributes.go
+++ b/internal/commands/pro/generated/mobile_device_extension_attributes.go
@@ -145,6 +145,8 @@ func newMobileDeviceExtensionAttributesListCmd(ctx *registry.CLIContext) *cobra.
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -759,6 +761,8 @@ func newMobileDeviceExtensionAttributesHistoryCmd(ctx *registry.CLIContext) *cob
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/mobile_device_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups.go
@@ -199,6 +199,8 @@ func newMobileDeviceGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/mobile_device_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -139,6 +140,9 @@ func newMobileDeviceGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -179,6 +183,7 @@ func newMobileDeviceGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/mobile_device_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups.go
@@ -214,6 +214,23 @@ func newMobileDeviceGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -84,6 +85,9 @@ func newMobileDeviceGroupsSmartGroupsListCmd(ctx *registry.CLIContext) *cobra.Co
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -123,6 +127,7 @@ func newMobileDeviceGroupsSmartGroupsListCmd(ctx *registry.CLIContext) *cobra.Co
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
@@ -143,6 +143,8 @@ func newMobileDeviceGroupsSmartGroupsListCmd(ctx *registry.CLIContext) *cobra.Co
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
@@ -158,6 +158,23 @@ func newMobileDeviceGroupsSmartGroupsListCmd(ctx *registry.CLIContext) *cobra.Co
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/mobile_device_groups_static_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_static_groups.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -84,6 +85,9 @@ func newMobileDeviceGroupsStaticGroupsListCmd(ctx *registry.CLIContext) *cobra.C
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -123,6 +127,7 @@ func newMobileDeviceGroupsStaticGroupsListCmd(ctx *registry.CLIContext) *cobra.C
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/mobile_device_groups_static_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_static_groups.go
@@ -158,6 +158,23 @@ func newMobileDeviceGroupsStaticGroupsListCmd(ctx *registry.CLIContext) *cobra.C
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/mobile_device_groups_static_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_static_groups.go
@@ -143,6 +143,8 @@ func newMobileDeviceGroupsStaticGroupsListCmd(ctx *registry.CLIContext) *cobra.C
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/mobile_device_inventory_details.go
+++ b/internal/commands/pro/generated/mobile_device_inventory_details.go
@@ -144,6 +144,8 @@ func newMobileDeviceInventoryDetailsListCmd(ctx *registry.CLIContext) *cobra.Com
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -300,6 +302,8 @@ func newMobileDeviceInventoryDetailsPairedDevicesCmd(ctx *registry.CLIContext) *
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/mobile_device_inventory_details.go
+++ b/internal/commands/pro/generated/mobile_device_inventory_details.go
@@ -159,6 +159,23 @@ func newMobileDeviceInventoryDetailsListCmd(ctx *registry.CLIContext) *cobra.Com
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -299,6 +316,23 @@ func newMobileDeviceInventoryDetailsPairedDevicesCmd(ctx *registry.CLIContext) *
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/mobile_device_inventory_details.go
+++ b/internal/commands/pro/generated/mobile_device_inventory_details.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -85,6 +86,9 @@ func newMobileDeviceInventoryDetailsListCmd(ctx *registry.CLIContext) *cobra.Com
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -124,6 +128,7 @@ func newMobileDeviceInventoryDetailsListCmd(ctx *registry.CLIContext) *cobra.Com
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -220,6 +225,9 @@ func newMobileDeviceInventoryDetailsPairedDevicesCmd(ctx *registry.CLIContext) *
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -260,6 +268,7 @@ func newMobileDeviceInventoryDetailsPairedDevicesCmd(ctx *registry.CLIContext) *
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/mobile_device_prestages.go
+++ b/internal/commands/pro/generated/mobile_device_prestages.go
@@ -159,6 +159,23 @@ func newMobileDevicePrestagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -1069,6 +1086,23 @@ func newMobileDevicePrestagesHistoryCmd(ctx *registry.CLIContext) *cobra.Command
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/mobile_device_prestages.go
+++ b/internal/commands/pro/generated/mobile_device_prestages.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -85,6 +86,9 @@ func newMobileDevicePrestagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -124,6 +128,7 @@ func newMobileDevicePrestagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -990,6 +995,9 @@ func newMobileDevicePrestagesHistoryCmd(ctx *registry.CLIContext) *cobra.Command
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -1030,6 +1038,7 @@ func newMobileDevicePrestagesHistoryCmd(ctx *registry.CLIContext) *cobra.Command
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/mobile_device_prestages.go
+++ b/internal/commands/pro/generated/mobile_device_prestages.go
@@ -144,6 +144,8 @@ func newMobileDevicePrestagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -1070,6 +1072,8 @@ func newMobileDevicePrestagesHistoryCmd(ctx *registry.CLIContext) *cobra.Command
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/mobile_devices.go
+++ b/internal/commands/pro/generated/mobile_devices.go
@@ -143,6 +143,8 @@ func newMobileDevicesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/mobile_devices.go
+++ b/internal/commands/pro/generated/mobile_devices.go
@@ -166,6 +166,23 @@ func newMobileDevicesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/mobile_devices.go
+++ b/internal/commands/pro/generated/mobile_devices.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -84,6 +85,9 @@ func newMobileDevicesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -123,6 +127,7 @@ func newMobileDevicesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/onboardings.go
+++ b/internal/commands/pro/generated/onboardings.go
@@ -137,6 +137,8 @@ func newOnboardingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -461,6 +463,8 @@ func newOnboardingsEligibleAppsCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -602,6 +606,8 @@ func newOnboardingsEligibleConfigurationProfilesCmd(ctx *registry.CLIContext) *c
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -742,6 +748,8 @@ func newOnboardingsEligiblePoliciesCmd(ctx *registry.CLIContext) *cobra.Command 
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/onboardings.go
+++ b/internal/commands/pro/generated/onboardings.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -78,6 +79,9 @@ func newOnboardingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -117,6 +121,7 @@ func newOnboardingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -381,6 +386,9 @@ func newOnboardingsEligibleAppsCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -420,6 +428,7 @@ func newOnboardingsEligibleAppsCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -501,6 +510,9 @@ func newOnboardingsEligibleConfigurationProfilesCmd(ctx *registry.CLIContext) *c
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -540,6 +552,7 @@ func newOnboardingsEligibleConfigurationProfilesCmd(ctx *registry.CLIContext) *c
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -621,6 +634,9 @@ func newOnboardingsEligiblePoliciesCmd(ctx *registry.CLIContext) *cobra.Command 
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -660,6 +676,7 @@ func newOnboardingsEligiblePoliciesCmd(ctx *registry.CLIContext) *cobra.Command 
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/onboardings.go
+++ b/internal/commands/pro/generated/onboardings.go
@@ -152,6 +152,23 @@ func newOnboardingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -459,6 +476,23 @@ func newOnboardingsEligibleAppsCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -583,6 +617,23 @@ func newOnboardingsEligibleConfigurationProfilesCmd(ctx *registry.CLIContext) *c
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -707,6 +758,23 @@ func newOnboardingsEligiblePoliciesCmd(ctx *registry.CLIContext) *cobra.Command 
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/packages.go
+++ b/internal/commands/pro/generated/packages.go
@@ -149,6 +149,8 @@ func newPackagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -902,6 +904,8 @@ func newPackagesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/packages.go
+++ b/internal/commands/pro/generated/packages.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Jamf-Concepts/jamf-cli/internal/client"
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -90,6 +91,9 @@ func newPackagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -129,6 +133,7 @@ func newPackagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -822,6 +827,9 @@ func newPackagesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -862,6 +870,7 @@ func newPackagesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/packages.go
+++ b/internal/commands/pro/generated/packages.go
@@ -164,6 +164,23 @@ func newPackagesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -901,6 +918,23 @@ func newPackagesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/parent_app.go
+++ b/internal/commands/pro/generated/parent_app.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -188,6 +189,9 @@ func newParentAppHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -227,6 +231,7 @@ func newParentAppHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/parent_app.go
+++ b/internal/commands/pro/generated/parent_app.go
@@ -247,6 +247,8 @@ func newParentAppHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/parent_app.go
+++ b/internal/commands/pro/generated/parent_app.go
@@ -262,6 +262,23 @@ func newParentAppHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/patch_policies.go
+++ b/internal/commands/pro/generated/patch_policies.go
@@ -156,6 +156,23 @@ func newPatchPoliciesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -497,6 +514,23 @@ func newPatchPoliciesPolicyDetailsCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/patch_policies.go
+++ b/internal/commands/pro/generated/patch_policies.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -82,6 +83,9 @@ func newPatchPoliciesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -121,6 +125,7 @@ func newPatchPoliciesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -419,6 +424,9 @@ func newPatchPoliciesPolicyDetailsCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -458,6 +466,7 @@ func newPatchPoliciesPolicyDetailsCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/patch_policies.go
+++ b/internal/commands/pro/generated/patch_policies.go
@@ -141,6 +141,8 @@ func newPatchPoliciesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -498,6 +500,8 @@ func newPatchPoliciesPolicyDetailsCmd(ctx *registry.CLIContext) *cobra.Command {
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/patch_policy_logs.go
+++ b/internal/commands/pro/generated/patch_policy_logs.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -77,6 +78,9 @@ func newPatchPolicyLogsLogsCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -117,6 +121,7 @@ func newPatchPolicyLogsLogsCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/patch_policy_logs.go
+++ b/internal/commands/pro/generated/patch_policy_logs.go
@@ -152,6 +152,23 @@ func newPatchPolicyLogsLogsCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/patch_policy_logs.go
+++ b/internal/commands/pro/generated/patch_policy_logs.go
@@ -137,6 +137,8 @@ func newPatchPolicyLogsLogsCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/patch_software_title_configurations.go
+++ b/internal/commands/pro/generated/patch_software_title_configurations.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -495,6 +496,9 @@ func newPatchSoftwareTitleConfigurationsHistoryCmd(ctx *registry.CLIContext) *co
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -535,6 +539,7 @@ func newPatchSoftwareTitleConfigurationsHistoryCmd(ctx *registry.CLIContext) *co
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -837,6 +842,9 @@ func newPatchSoftwareTitleConfigurationsDefinitionsCmd(ctx *registry.CLIContext)
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -877,6 +885,7 @@ func newPatchSoftwareTitleConfigurationsDefinitionsCmd(ctx *registry.CLIContext)
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -1298,6 +1307,9 @@ func newPatchSoftwareTitleConfigurationsPatchReportCmd(ctx *registry.CLIContext)
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -1338,6 +1350,7 @@ func newPatchSoftwareTitleConfigurationsPatchReportCmd(ctx *registry.CLIContext)
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/patch_software_title_configurations.go
+++ b/internal/commands/pro/generated/patch_software_title_configurations.go
@@ -555,6 +555,8 @@ func newPatchSoftwareTitleConfigurationsHistoryCmd(ctx *registry.CLIContext) *co
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -917,6 +919,8 @@ func newPatchSoftwareTitleConfigurationsDefinitionsCmd(ctx *registry.CLIContext)
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
@@ -1399,6 +1403,8 @@ func newPatchSoftwareTitleConfigurationsPatchReportCmd(ctx *registry.CLIContext)
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/patch_software_title_configurations.go
+++ b/internal/commands/pro/generated/patch_software_title_configurations.go
@@ -570,6 +570,23 @@ func newPatchSoftwareTitleConfigurationsHistoryCmd(ctx *registry.CLIContext) *co
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -916,6 +933,23 @@ func newPatchSoftwareTitleConfigurationsDefinitionsCmd(ctx *registry.CLIContext)
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -1381,6 +1415,23 @@ func newPatchSoftwareTitleConfigurationsPatchReportCmd(ctx *registry.CLIContext)
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/reenrollment.go
+++ b/internal/commands/pro/generated/reenrollment.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -186,6 +187,9 @@ func newReenrollmentHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -225,6 +229,7 @@ func newReenrollmentHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/reenrollment.go
+++ b/internal/commands/pro/generated/reenrollment.go
@@ -260,6 +260,23 @@ func newReenrollmentHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/reenrollment.go
+++ b/internal/commands/pro/generated/reenrollment.go
@@ -245,6 +245,8 @@ func newReenrollmentHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/registry.go
+++ b/internal/commands/pro/generated/registry.go
@@ -872,7 +872,7 @@ type tableColumn struct {
 // columns with display labels. Only applies for table/csv/plain formats;
 // JSON/YAML output is returned unchanged.
 func selectTableColumns(data []byte, columns []tableColumn, format string) []byte {
-	if format == "json" || format == "yaml" || format == "xml" || format == "raw" {
+	if format == "json" || format == "yaml" || format == "xml" || format == "raw" || format == "ndjson" {
 		return data
 	}
 

--- a/internal/commands/pro/generated/remote_administration_configurations.go
+++ b/internal/commands/pro/generated/remote_administration_configurations.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -63,6 +64,9 @@ func newRemoteAdministrationConfigurationsListCmd(ctx *registry.CLIContext) *cob
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -102,6 +106,7 @@ func newRemoteAdministrationConfigurationsListCmd(ctx *registry.CLIContext) *cob
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/remote_administration_configurations.go
+++ b/internal/commands/pro/generated/remote_administration_configurations.go
@@ -122,6 +122,8 @@ func newRemoteAdministrationConfigurationsListCmd(ctx *registry.CLIContext) *cob
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/remote_administration_configurations.go
+++ b/internal/commands/pro/generated/remote_administration_configurations.go
@@ -137,6 +137,23 @@ func newRemoteAdministrationConfigurationsListCmd(ctx *registry.CLIContext) *cob
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/schedulers.go
+++ b/internal/commands/pro/generated/schedulers.go
@@ -201,6 +201,23 @@ func newSchedulersTriggersCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/schedulers.go
+++ b/internal/commands/pro/generated/schedulers.go
@@ -186,6 +186,8 @@ func newSchedulersTriggersCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/schedulers.go
+++ b/internal/commands/pro/generated/schedulers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -126,6 +127,9 @@ func newSchedulersTriggersCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -166,6 +170,7 @@ func newSchedulersTriggersCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/scripts.go
+++ b/internal/commands/pro/generated/scripts.go
@@ -145,6 +145,8 @@ func newScriptsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -796,6 +798,8 @@ func newScriptsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/scripts.go
+++ b/internal/commands/pro/generated/scripts.go
@@ -160,6 +160,23 @@ func newScriptsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -795,6 +812,23 @@ func newScriptsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/scripts.go
+++ b/internal/commands/pro/generated/scripts.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -86,6 +87,9 @@ func newScriptsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -125,6 +129,7 @@ func newScriptsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -716,6 +721,9 @@ func newScriptsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -756,6 +764,7 @@ func newScriptsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/self_service_branding_ios_resource.go
+++ b/internal/commands/pro/generated/self_service_branding_ios_resource.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -79,6 +80,9 @@ func newSelfServiceBrandingIosListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -118,6 +122,7 @@ func newSelfServiceBrandingIosListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/self_service_branding_ios_resource.go
+++ b/internal/commands/pro/generated/self_service_branding_ios_resource.go
@@ -138,6 +138,8 @@ func newSelfServiceBrandingIosListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/self_service_branding_ios_resource.go
+++ b/internal/commands/pro/generated/self_service_branding_ios_resource.go
@@ -153,6 +153,23 @@ func newSelfServiceBrandingIosListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/self_service_branding_macos.go
+++ b/internal/commands/pro/generated/self_service_branding_macos.go
@@ -153,6 +153,23 @@ func newSelfServiceBrandingMacosListCmd(ctx *registry.CLIContext) *cobra.Command
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/self_service_branding_macos.go
+++ b/internal/commands/pro/generated/self_service_branding_macos.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -79,6 +80,9 @@ func newSelfServiceBrandingMacosListCmd(ctx *registry.CLIContext) *cobra.Command
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -118,6 +122,7 @@ func newSelfServiceBrandingMacosListCmd(ctx *registry.CLIContext) *cobra.Command
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/self_service_branding_macos.go
+++ b/internal/commands/pro/generated/self_service_branding_macos.go
@@ -138,6 +138,8 @@ func newSelfServiceBrandingMacosListCmd(ctx *registry.CLIContext) *cobra.Command
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/self_service_settings.go
+++ b/internal/commands/pro/generated/self_service_settings.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -180,6 +181,9 @@ func newSelfServiceSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -219,6 +223,7 @@ func newSelfServiceSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/self_service_settings.go
+++ b/internal/commands/pro/generated/self_service_settings.go
@@ -239,6 +239,8 @@ func newSelfServiceSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/self_service_settings.go
+++ b/internal/commands/pro/generated/self_service_settings.go
@@ -254,6 +254,23 @@ func newSelfServiceSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/sites.go
+++ b/internal/commands/pro/generated/sites.go
@@ -200,6 +200,23 @@ func newSitesObjectsCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/sites.go
+++ b/internal/commands/pro/generated/sites.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -125,6 +126,9 @@ func newSitesObjectsCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -165,6 +169,7 @@ func newSitesObjectsCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/sites.go
+++ b/internal/commands/pro/generated/sites.go
@@ -185,6 +185,8 @@ func newSitesObjectsCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/smtp_server.go
+++ b/internal/commands/pro/generated/smtp_server.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -190,6 +191,9 @@ func newSmtpServerHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -229,6 +233,7 @@ func newSmtpServerHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/smtp_server.go
+++ b/internal/commands/pro/generated/smtp_server.go
@@ -249,6 +249,8 @@ func newSmtpServerHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/smtp_server.go
+++ b/internal/commands/pro/generated/smtp_server.go
@@ -264,6 +264,23 @@ func newSmtpServerHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/sso_settings.go
+++ b/internal/commands/pro/generated/sso_settings.go
@@ -265,6 +265,23 @@ func newSsoSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/sso_settings.go
+++ b/internal/commands/pro/generated/sso_settings.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -191,6 +192,9 @@ func newSsoSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -230,6 +234,7 @@ func newSsoSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/sso_settings.go
+++ b/internal/commands/pro/generated/sso_settings.go
@@ -250,6 +250,8 @@ func newSsoSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/static_computer_groups.go
+++ b/internal/commands/pro/generated/static_computer_groups.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -83,6 +84,9 @@ func newStaticComputerGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -122,6 +126,7 @@ func newStaticComputerGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/static_computer_groups.go
+++ b/internal/commands/pro/generated/static_computer_groups.go
@@ -142,6 +142,8 @@ func newStaticComputerGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/static_computer_groups.go
+++ b/internal/commands/pro/generated/static_computer_groups.go
@@ -157,6 +157,23 @@ func newStaticComputerGroupsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/supervision_identities.go
+++ b/internal/commands/pro/generated/supervision_identities.go
@@ -161,6 +161,23 @@ func newSupervisionIdentitiesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/supervision_identities.go
+++ b/internal/commands/pro/generated/supervision_identities.go
@@ -146,6 +146,8 @@ func newSupervisionIdentitiesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/supervision_identities.go
+++ b/internal/commands/pro/generated/supervision_identities.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -87,6 +88,9 @@ func newSupervisionIdentitiesListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -126,6 +130,7 @@ func newSupervisionIdentitiesListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/teacher_settings.go
+++ b/internal/commands/pro/generated/teacher_settings.go
@@ -256,6 +256,23 @@ func newTeacherSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/teacher_settings.go
+++ b/internal/commands/pro/generated/teacher_settings.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -182,6 +183,9 @@ func newTeacherSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -221,6 +225,7 @@ func newTeacherSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/teacher_settings.go
+++ b/internal/commands/pro/generated/teacher_settings.go
@@ -241,6 +241,8 @@ func newTeacherSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/team_viewer_remote_administrations.go
+++ b/internal/commands/pro/generated/team_viewer_remote_administrations.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -437,6 +438,9 @@ func newTeamViewerRemoteAdministrationsSessionsCmd(ctx *registry.CLIContext) *co
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -477,6 +481,7 @@ func newTeamViewerRemoteAdministrationsSessionsCmd(ctx *registry.CLIContext) *co
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/team_viewer_remote_administrations.go
+++ b/internal/commands/pro/generated/team_viewer_remote_administrations.go
@@ -497,6 +497,8 @@ func newTeamViewerRemoteAdministrationsSessionsCmd(ctx *registry.CLIContext) *co
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/team_viewer_remote_administrations.go
+++ b/internal/commands/pro/generated/team_viewer_remote_administrations.go
@@ -512,6 +512,23 @@ func newTeamViewerRemoteAdministrationsSessionsCmd(ctx *registry.CLIContext) *co
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/user_accounts.go
+++ b/internal/commands/pro/generated/user_accounts.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -83,6 +84,9 @@ func newUserAccountsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -122,6 +126,7 @@ func newUserAccountsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/user_accounts.go
+++ b/internal/commands/pro/generated/user_accounts.go
@@ -157,6 +157,23 @@ func newUserAccountsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/user_accounts.go
+++ b/internal/commands/pro/generated/user_accounts.go
@@ -142,6 +142,8 @@ func newUserAccountsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/users.go
+++ b/internal/commands/pro/generated/users.go
@@ -146,6 +146,8 @@ func newUsersListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/users.go
+++ b/internal/commands/pro/generated/users.go
@@ -161,6 +161,23 @@ func newUsersListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/users.go
+++ b/internal/commands/pro/generated/users.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -87,6 +88,9 @@ func newUsersListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -126,6 +130,7 @@ func newUsersListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/venafis.go
+++ b/internal/commands/pro/generated/venafis.go
@@ -510,6 +510,8 @@ func newVenafisHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {

--- a/internal/commands/pro/generated/venafis.go
+++ b/internal/commands/pro/generated/venafis.go
@@ -525,6 +525,23 @@ func newVenafisHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/venafis.go
+++ b/internal/commands/pro/generated/venafis.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -450,6 +451,9 @@ func newVenafisHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -490,6 +494,7 @@ func newVenafisHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/vpp_locations.go
+++ b/internal/commands/pro/generated/vpp_locations.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -88,6 +89,9 @@ func newVppLocationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -127,6 +131,7 @@ func newVppLocationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -600,6 +605,9 @@ func newVppLocationsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -640,6 +648,7 @@ func newVppLocationsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -955,6 +964,9 @@ func newVppLocationsContentCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -995,6 +1007,7 @@ func newVppLocationsContentCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/vpp_locations.go
+++ b/internal/commands/pro/generated/vpp_locations.go
@@ -162,6 +162,23 @@ func newVppLocationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -679,6 +696,23 @@ func newVppLocationsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -1038,6 +1072,23 @@ func newVppLocationsContentCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/vpp_locations.go
+++ b/internal/commands/pro/generated/vpp_locations.go
@@ -147,6 +147,8 @@ func newVppLocationsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -681,6 +683,8 @@ func newVppLocationsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -1056,6 +1060,8 @@ func newVppLocationsContentCmd(ctx *registry.CLIContext) *cobra.Command {
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro/generated/vpp_subscriptions.go
+++ b/internal/commands/pro/generated/vpp_subscriptions.go
@@ -155,6 +155,23 @@ func newVppSubscriptionsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}
@@ -744,6 +761,23 @@ func newVppSubscriptionsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			}
 			defer resp.Body.Close()
 
+			if ctx.Output.Format() == "ndjson" {
+				ndjsonBody, ndjsonErr := io.ReadAll(resp.Body)
+				if ndjsonErr != nil {
+					return ndjsonErr
+				}
+				var ndjsonWrap struct {
+					Results []json.RawMessage `json:"results"`
+				}
+				if err := json.Unmarshal(ndjsonBody, &ndjsonWrap); err == nil && ndjsonWrap.Results != nil {
+					arr, marshalErr := json.Marshal(ndjsonWrap.Results)
+					if marshalErr != nil {
+						return marshalErr
+					}
+					return ctx.Output.PrintRaw(arr)
+				}
+				return ctx.Output.PrintRaw(ndjsonBody)
+			}
 			return ctx.Output.PrintResponse(resp)
 		},
 	}

--- a/internal/commands/pro/generated/vpp_subscriptions.go
+++ b/internal/commands/pro/generated/vpp_subscriptions.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/cooldown"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -81,6 +82,9 @@ func newVppSubscriptionsListCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -120,6 +124,7 @@ func newVppSubscriptionsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {
@@ -665,6 +670,9 @@ func newVppSubscriptionsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Auto-pagination: fetch all pages when --all is set and --page was not manually specified
 			if flagAll && flagPage == 0 {
 				var allResults []json.RawMessage
+				prog := ctx.Output.PaginationProgress()
+				defer prog.Stop()
+				reqCtx = spinner.WithSuppressed(reqCtx)
 				pageNum := 0
 				pageSize := 100
 
@@ -705,6 +713,7 @@ func newVppSubscriptionsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 					}
 
 					allResults = append(allResults, pageResp.Results...)
+					prog.Update(len(allResults), pageResp.TotalCount)
 
 					// Check limit
 					if flagLimit > 0 && len(allResults) >= flagLimit {

--- a/internal/commands/pro/generated/vpp_subscriptions.go
+++ b/internal/commands/pro/generated/vpp_subscriptions.go
@@ -140,6 +140,8 @@ func newVppSubscriptionsListCmd(ctx *registry.CLIContext) *cobra.Command {
 					pageNum++
 				}
 
+				prog.Stop()
+
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")
 				if err != nil {
@@ -745,6 +747,8 @@ func newVppSubscriptionsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 
 					pageNum++
 				}
+
+				prog.Stop()
 
 				// Output combined results as JSON array
 				combined, err := json.MarshalIndent(allResults, "", "  ")

--- a/internal/commands/pro_command_flush_test.go
+++ b/internal/commands/pro_command_flush_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Jamf-Concepts/jamf-cli/internal/progress"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 )
 
@@ -93,6 +94,9 @@ func (d *discardOutput) PrintResponse(_ *http.Response) error { return nil }
 func (d *discardOutput) PrintRaw(_ []byte) error              { return nil }
 func (d *discardOutput) PrintBytes(_ []byte) error            { return nil }
 func (d *discardOutput) Format() string                       { return "json" }
+func (d *discardOutput) PaginationProgress() *progress.Reporter {
+	return progress.New(io.Discard, progress.Silent)
+}
 
 const classicGroupXML = `<?xml version="1.0" encoding="UTF-8"?>
 <computer_group>

--- a/internal/commands/pro_device_actions_test.go
+++ b/internal/commands/pro_device_actions_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Jamf-Concepts/jamf-cli/internal/progress"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 	"github.com/Jamf-Concepts/jamf-cli/internal/resolve"
 )
@@ -294,6 +295,9 @@ func (mockOutput) PrintResponse(_ *http.Response) error { return nil }
 func (mockOutput) PrintRaw(_ []byte) error              { return nil }
 func (mockOutput) PrintBytes(_ []byte) error            { return nil }
 func (mockOutput) Format() string                       { return "json" }
+func (mockOutput) PaginationProgress() *progress.Reporter {
+	return progress.New(io.Discard, progress.Silent)
+}
 
 // bodyCapturingClient captures the request body for assertion in tests.
 type bodyCapturingClient struct {

--- a/internal/commands/pro_platform_test.go
+++ b/internal/commands/pro_platform_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Jamf-Concepts/jamf-cli/internal/progress"
 	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/blueprints"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform/compliancebenchmarks"
@@ -412,6 +413,9 @@ func (o *captureOutput) PrintRaw(data []byte) error {
 }
 func (o *captureOutput) PrintBytes(data []byte) error { o.rawData = data; return nil }
 func (o *captureOutput) Format() string               { return "json" }
+func (o *captureOutput) PaginationProgress() *progress.Reporter {
+	return progress.New(io.Discard, progress.Silent)
+}
 
 // writeTempJSON marshals v to a temporary JSON file, returning the path. Caller must remove it.
 func writeTempJSON(t *testing.T, v any) string {

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -842,6 +842,19 @@ type commandEntry struct {
 	Destructive bool     `json:"destructive,omitempty"`
 }
 
+// isFullDetailFormat reports whether an output format carries the full
+// per-command detail (aliases, flags, product, group, destructive) in the
+// `commands` catalog. Structured machine formats get full detail; table/plain
+// stay compact unless --wide is set.
+func isFullDetailFormat(format string) bool {
+	switch format {
+	case "json", "ndjson", "yaml", "csv":
+		return true
+	default:
+		return false
+	}
+}
+
 // newCommandsCmd creates the "commands" subcommand that outputs the full
 // command tree in a machine-readable format.
 func newCommandsCmd(root *cobra.Command) *cobra.Command {
@@ -854,7 +867,7 @@ func newCommandsCmd(root *cobra.Command) *cobra.Command {
 			formatter := output.New(outputFmt, noColor, wide)
 			// Structured formats always get full detail; table/plain
 			// show only command+description unless --wide is set.
-			full := wide || outputFmt == "json" || outputFmt == "yaml" || outputFmt == "csv"
+			full := wide || isFullDetailFormat(outputFmt)
 			return formatter.Print(commandEntriesToMaps(entries, full))
 		},
 	}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -590,6 +590,9 @@ spinner and progress output (narrower than --quiet).`,
 				cmd.Flags().Changed("output"), outputFmt, cfg.DefaultOutput,
 				stdoutTTY, outFile != "",
 			)
+			// noColor at this point reflects only explicit sources (--no-color
+			// flag or NO_COLOR env), before stdout-piping / out-file auto-disable.
+			explicitNoColor := noColor
 			if !stdoutTTY {
 				noColor = true
 			}
@@ -615,6 +618,7 @@ spinner and progress output (narrower than --quiet).`,
 			formatter.SetProjector(output.Projector{Compact: compact, Select: selectFields})
 			formatter.SetQuiet(quiet)
 			formatter.SetNoHints(noHints)
+			formatter.SetExplicitNoColor(explicitNoColor)
 			cliCtx.Output = &cliOutput{formatter}
 
 			// Group parent commands (made runnable only to reject unknown

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -851,8 +851,8 @@ type commandEntry struct {
 // `commands` catalog. Structured machine formats get full detail; table/plain
 // stay compact unless --wide is set.
 func isFullDetailFormat(format string) bool {
-	switch format {
-	case "json", "ndjson", "yaml", "csv":
+	switch output.Format(format) {
+	case output.FormatJSON, output.FormatNDJSON, output.FormatYAML, output.FormatCSV:
 		return true
 	default:
 		return false

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -157,6 +157,9 @@ type spinnerClient struct {
 }
 
 func (c *spinnerClient) Do(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	if spinner.IsSuppressed(ctx) {
+		return c.inner.Do(ctx, method, path, body)
+	}
 	s := spinner.New("Loading...")
 	s.Start()
 	defer s.Stop()
@@ -171,6 +174,9 @@ type spinnerTransport struct {
 }
 
 func (t *spinnerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if spinner.IsSuppressed(req.Context()) {
+		return t.inner.RoundTrip(req)
+	}
 	s := spinner.New("Loading...")
 	s.Start()
 	defer s.Stop()

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -757,7 +757,7 @@ spinner and progress output (narrower than --quiet).`,
 
 	// Global flags
 	cmd.PersistentFlags().StringVarP(&profile, "profile", "p", "", "config profile to use (or JAMF_PROFILE env)")
-	cmd.PersistentFlags().StringVarP(&outputFmt, "output", "o", "json", "output format: table, json, csv, yaml, plain, xml (pretty), raw (classic commands default to xml)")
+	cmd.PersistentFlags().StringVarP(&outputFmt, "output", "o", "json", "output format: table, json, ndjson, csv, yaml, plain, xml (pretty), raw (classic commands default to xml)")
 	cmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "suppress non-error output")
 	cmd.PersistentFlags().BoolVar(&noHints, "no-hints", false, "suppress advisory hints (e.g. large-result narrowing tips); keeps spinner and progress output (or JAMF_CLI_NO_HINTS env)")
 	cmd.PersistentFlags().CountVarP(&verboseLevel, "verbose", "v", "show HTTP requests/responses (-vv adds headers, -vvv adds bodies)")

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -21,6 +21,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func TestIsFullDetailFormat(t *testing.T) {
+	// Structured machine formats carry full per-command detail in `commands`.
+	for _, f := range []string{"json", "ndjson", "yaml", "csv"} {
+		if !isFullDetailFormat(f) {
+			t.Errorf("isFullDetailFormat(%q) = false, want true", f)
+		}
+	}
+	// Human/compact formats stay compact unless --wide.
+	for _, f := range []string{"table", "plain", "xml", "raw", ""} {
+		if isFullDetailFormat(f) {
+			t.Errorf("isFullDetailFormat(%q) = true, want false", f)
+		}
+	}
+}
+
 func TestCommandsSubcommand_JSON(t *testing.T) {
 	// Reset global state
 	outputFmt = "json"

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -284,6 +284,12 @@ func (f *Formatter) printJSON(data any) error {
 // A slice yields one line per element; a single object yields one line.
 // Projection (--select/--compact/--field) has already been applied by Print.
 func (f *Formatter) printNDJSON(data any) error {
+	// A top-level JSON null (e.g. an empty paginated list whose accumulated
+	// results marshal to "null") yields no records — emit nothing rather than a
+	// literal "null" line.
+	if data == nil {
+		return nil
+	}
 	writeLine := func(v any) error {
 		b, err := json.Marshal(v) // compact (no indent)
 		if err != nil {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1011,7 +1011,11 @@ func (f *Formatter) PaginationProgress() *progress.Reporter {
 	case isStderrTTY() && !f.noColor:
 		mode = progress.Interactive
 	}
-	return progress.New(f.stderr, mode)
+	w := f.stderr
+	if w == nil {
+		w = os.Stderr
+	}
+	return progress.New(w, mode)
 }
 
 // IsTerminal reports whether the given file descriptor is a character device.

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -48,8 +48,9 @@ const (
 	FormatCSV       Format = "csv"
 	FormatYAML      Format = "yaml"
 	FormatPlain     Format = "plain"
-	FormatXML       Format = "xml" // Classic API native format — pretty-printed XML
-	FormatRaw       Format = "raw" // Exact wire bytes, no conversion or formatting
+	FormatXML       Format = "xml"    // Classic API native format — pretty-printed XML
+	FormatRaw       Format = "raw"    // Exact wire bytes, no conversion or formatting
+	FormatNDJSON    Format = "ndjson" // newline-delimited JSON: one compact object per line, no array
 )
 
 // nowFunc is the function used to get the current time. Override in tests.
@@ -175,6 +176,8 @@ func (f *Formatter) Print(data any) error {
 	switch f.format {
 	case FormatJSON:
 		err = f.printJSON(data)
+	case FormatNDJSON:
+		err = f.printNDJSON(data)
 	case FormatYAML:
 		err = f.printYAML(data)
 	case FormatCSV:
@@ -267,6 +270,39 @@ func (f *Formatter) printJSON(data any) error {
 	enc := json.NewEncoder(f.writer)
 	enc.SetIndent("", "  ")
 	return enc.Encode(data)
+}
+
+// printNDJSON writes one compact JSON object per line (no outer array).
+// A slice yields one line per element; a single object yields one line.
+// Projection (--select/--compact/--field) has already been applied by Print.
+func (f *Formatter) printNDJSON(data any) error {
+	writeLine := func(v any) error {
+		b, err := json.Marshal(v) // compact (no indent)
+		if err != nil {
+			return err
+		}
+		b = append(b, '\n')
+		_, err = f.writer.Write(b)
+		return err
+	}
+	switch v := data.(type) {
+	case []map[string]any:
+		for _, row := range v {
+			if err := writeLine(row); err != nil {
+				return err
+			}
+		}
+		return nil
+	case []any:
+		for _, row := range v {
+			if err := writeLine(row); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return writeLine(v)
+	}
 }
 
 func (f *Formatter) printYAML(data any) error {
@@ -502,7 +538,7 @@ func (f *Formatter) PrintRaw(data []byte) error {
 	// coerce via normalizeForTabular. Print's applyProjection handles both
 	// map[string]any and []map[string]any.
 	switch f.format {
-	case FormatJSON, FormatJSONMulti, FormatYAML:
+	case FormatJSON, FormatJSONMulti, FormatYAML, FormatNDJSON:
 		return f.Print(parsed)
 	default:
 		// Table mode: a single object renders as a detail view, not a 1-row

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -59,14 +59,15 @@ var nowFunc = time.Now
 
 // Formatter handles output formatting
 type Formatter struct {
-	format    Format
-	writer    io.Writer
-	stderr    io.Writer
-	noColor   bool
-	wide      bool
-	quiet     bool
-	noHints   bool
-	projector Projector
+	format          Format
+	writer          io.Writer
+	stderr          io.Writer
+	noColor         bool
+	explicitNoColor bool
+	wide            bool
+	quiet           bool
+	noHints         bool
+	projector       Projector
 }
 
 // SetWriter replaces the output destination.
@@ -98,6 +99,12 @@ func (f *Formatter) SetQuiet(q bool) {
 func (f *Formatter) SetNoHints(v bool) {
 	f.noHints = v
 }
+
+// SetExplicitNoColor records whether the user explicitly disabled color
+// (--no-color or NO_COLOR), as distinct from color being auto-disabled because
+// stdout is piped. Pagination progress uses this so a piped stdout still shows
+// the in-place stderr counter when stderr is a terminal.
+func (f *Formatter) SetExplicitNoColor(v bool) { f.explicitNoColor = v }
 
 // listHintThreshold is the minimum row count that triggers the
 // "narrow output" hint on stderr. Below this, lists are short enough
@@ -1008,7 +1015,7 @@ func (f *Formatter) PaginationProgress() *progress.Reporter {
 	switch {
 	case f.quiet:
 		mode = progress.Silent
-	case isStderrTTY() && !f.noColor:
+	case isStderrTTY() && !f.explicitNoColor:
 		mode = progress.Interactive
 	}
 	w := f.stderr

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
 
+	"github.com/Jamf-Concepts/jamf-cli/internal/progress"
 	"github.com/Jamf-Concepts/jamf-cli/internal/xmlconv"
 )
 
@@ -991,6 +992,26 @@ func (f *Formatter) formatStatusValue(value string) string {
 	}
 
 	return value
+}
+
+// isStderrTTY reports whether stderr is a terminal. Overridable in tests.
+var isStderrTTY = func() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+// PaginationProgress builds a progress reporter for an --all pagination loop,
+// choosing the rendering mode from the formatter's state: silent when quiet,
+// an in-place count line on an interactive color terminal, NDJSON page_fetch
+// events otherwise.
+func (f *Formatter) PaginationProgress() *progress.Reporter {
+	mode := progress.Events
+	switch {
+	case f.quiet:
+		mode = progress.Silent
+	case isStderrTTY() && !f.noColor:
+		mode = progress.Interactive
+	}
+	return progress.New(f.stderr, mode)
 }
 
 // IsTerminal reports whether the given file descriptor is a character device.

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1783,3 +1783,57 @@ func TestPaginationProgress_ExplicitNoColorUsesEvents(t *testing.T) {
 		t.Errorf("explicit --no-color must not emit in-place counter; got %q", out)
 	}
 }
+
+func TestPrintNDJSON_PrintRawArray(t *testing.T) {
+	// The --all production path calls PrintRaw with a JSON array assembled from
+	// all paginated pages. Each element must become a bare compact JSON line;
+	// no outer "[" or "]" wrapper should appear.
+	var buf bytes.Buffer
+	f := New("ndjson", true, false)
+	f.SetWriter(&buf)
+	if err := f.PrintRaw([]byte(`[{"id":"1"},{"id":"2"},{"id":"3"}]`)); err != nil {
+		t.Fatalf("PrintRaw: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d:\n%s", len(lines), buf.String())
+	}
+	for i, ln := range lines {
+		if strings.Contains(ln, "[") || strings.Contains(ln, "]") {
+			t.Errorf("line %d contains array bracket: %q", i, ln)
+		}
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(ln), &obj); err != nil {
+			t.Errorf("line %d is not a valid JSON object: %q (%v)", i, ln, err)
+		}
+	}
+}
+
+func TestPrintNDJSON_SelectProjection(t *testing.T) {
+	// ndjson must honour --select per record: projection runs in Print before
+	// format dispatch, so each NDJSON line should contain only selected fields.
+	var buf bytes.Buffer
+	f := New("ndjson", true, false)
+	f.SetWriter(&buf)
+	f.SetProjector(Projector{Select: []string{"id"}})
+	if err := f.PrintRaw([]byte(`[{"id":"1","name":"a"},{"id":"2","name":"b"}]`)); err != nil {
+		t.Fatalf("PrintRaw: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d:\n%s", len(lines), buf.String())
+	}
+	for i, ln := range lines {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(ln), &obj); err != nil {
+			t.Errorf("line %d not valid JSON: %q (%v)", i, ln, err)
+			continue
+		}
+		if _, ok := obj["id"]; !ok {
+			t.Errorf("line %d missing selected field 'id': %q", i, ln)
+		}
+		if _, ok := obj["name"]; ok {
+			t.Errorf("line %d contains unselected field 'name': %q", i, ln)
+		}
+	}
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1645,3 +1645,52 @@ func TestResolveFormat(t *testing.T) {
 		})
 	}
 }
+
+// --- NDJSON tests ---
+
+func TestPrintNDJSON_List(t *testing.T) {
+	var buf bytes.Buffer
+	f := New("ndjson", true, false)
+	f.SetWriter(&buf)
+	rows := []map[string]any{{"id": "1", "name": "a"}, {"id": "2", "name": "b"}}
+	if err := f.Print(rows); err != nil {
+		t.Fatalf("Print: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), buf.String())
+	}
+	for _, ln := range lines {
+		if strings.Contains(ln, "[") || strings.Contains(ln, "\n") {
+			t.Errorf("line is not a bare compact object: %q", ln)
+		}
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(ln), &obj); err != nil {
+			t.Errorf("line not valid JSON object: %q (%v)", ln, err)
+		}
+	}
+}
+
+func TestPrintNDJSON_SingleObject(t *testing.T) {
+	var buf bytes.Buffer
+	f := New("ndjson", true, false)
+	f.SetWriter(&buf)
+	if err := f.Print(map[string]any{"id": "1"}); err != nil {
+		t.Fatalf("Print: %v", err)
+	}
+	if got := strings.Count(buf.String(), "\n"); got != 1 {
+		t.Errorf("single object should be one line, got %d newlines: %q", got, buf.String())
+	}
+}
+
+func TestPrintNDJSON_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	f := New("ndjson", true, false)
+	f.SetWriter(&buf)
+	if err := f.Print([]map[string]any{}); err != nil {
+		t.Fatalf("Print: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("empty list should produce no output, got %q", buf.String())
+	}
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1694,3 +1694,15 @@ func TestPrintNDJSON_Empty(t *testing.T) {
 		t.Errorf("empty list should produce no output, got %q", buf.String())
 	}
 }
+
+func TestPaginationProgress_QuietIsSilent(t *testing.T) {
+	f, _, stderr := newTestFormatterWithStderr("json")
+	f.SetQuiet(true)
+	p := f.PaginationProgress()
+	p.Update(10, 100)
+	p.Stop()
+	// quiet => Silent reporter => no stderr writes
+	if stderr.Len() != 0 {
+		t.Errorf("quiet should produce no progress output, got %q", stderr.String())
+	}
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1706,3 +1706,15 @@ func TestPaginationProgress_QuietIsSilent(t *testing.T) {
 		t.Errorf("quiet should produce no progress output, got %q", stderr.String())
 	}
 }
+
+func TestPaginationProgress_NilStderrNoPanic(t *testing.T) {
+	orig := isStderrTTY
+	isStderrTTY = func() bool { return false } // force Events mode
+	defer func() { isStderrTTY = orig }()
+
+	f := New("json", false, false) // stderr is nil — production path
+	p := f.PaginationProgress()
+	// must not panic writing to a nil underlying writer
+	p.Update(1, 2)
+	p.Stop()
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1718,3 +1718,54 @@ func TestPaginationProgress_NilStderrNoPanic(t *testing.T) {
 	p.Update(1, 2)
 	p.Stop()
 }
+
+// TestPaginationProgress_PipedStdoutStillInteractive guards the regression where
+// piping stdout (which auto-sets noColor=true) wrongly forced Events mode even
+// when stderr was an interactive terminal.
+func TestPaginationProgress_PipedStdoutStillInteractive(t *testing.T) {
+	orig := isStderrTTY
+	isStderrTTY = func() bool { return true } // stderr is a terminal
+	defer func() { isStderrTTY = orig }()
+
+	f, _, stderr := newTestFormatterWithStderr("ndjson")
+	// Simulate the piped-stdout state: noColor auto-set to true, but the user
+	// never explicitly requested --no-color or NO_COLOR.
+	f.noColor = true
+	f.SetExplicitNoColor(false)
+
+	p := f.PaginationProgress()
+	p.Update(1, 2)
+	p.Stop()
+
+	out := stderr.String()
+	if !strings.Contains(out, "Fetched 1 / 2") {
+		t.Errorf("piped stdout + stderr TTY should use in-place counter; got %q", out)
+	}
+	if strings.Contains(out, `"event":"page_fetch"`) {
+		t.Errorf("piped stdout + stderr TTY must not emit NDJSON events; got %q", out)
+	}
+}
+
+// TestPaginationProgress_ExplicitNoColorUsesEvents ensures that --no-color or
+// NO_COLOR explicitly set by the user switches progress to Events mode.
+func TestPaginationProgress_ExplicitNoColorUsesEvents(t *testing.T) {
+	orig := isStderrTTY
+	isStderrTTY = func() bool { return true } // stderr is a terminal
+	defer func() { isStderrTTY = orig }()
+
+	f, _, stderr := newTestFormatterWithStderr("ndjson")
+	f.noColor = true
+	f.SetExplicitNoColor(true) // user explicitly passed --no-color / set NO_COLOR
+
+	p := f.PaginationProgress()
+	p.Update(1, 2)
+	p.Stop()
+
+	out := stderr.String()
+	if !strings.Contains(out, `"event":"page_fetch"`) {
+		t.Errorf("explicit --no-color should use Events mode; got %q", out)
+	}
+	if strings.Contains(out, "Fetched") {
+		t.Errorf("explicit --no-color must not emit in-place counter; got %q", out)
+	}
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1695,6 +1695,20 @@ func TestPrintNDJSON_Empty(t *testing.T) {
 	}
 }
 
+func TestPrintNDJSON_NullNoOutput(t *testing.T) {
+	// An empty paginated --all result marshals its nil accumulator to "null";
+	// ndjson must emit nothing, not a literal "null" line.
+	var buf bytes.Buffer
+	f := New("ndjson", true, false)
+	f.SetWriter(&buf)
+	if err := f.PrintRaw([]byte("null")); err != nil {
+		t.Fatalf("PrintRaw: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("top-level null should produce no output, got %q", buf.String())
+	}
+}
+
 func TestPaginationProgress_QuietIsSilent(t *testing.T) {
 	f, _, stderr := newTestFormatterWithStderr("json")
 	f.SetQuiet(true)

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -36,18 +36,18 @@ func (r *Reporter) Update(fetched, total int) {
 	switch r.mode {
 	case Interactive:
 		if total > 0 {
-			fmt.Fprintf(r.w, "\rFetched %d / %d\033[K", fetched, total)
+			_, _ = fmt.Fprintf(r.w, "\rFetched %d / %d\033[K", fetched, total)
 		} else {
-			fmt.Fprintf(r.w, "\rFetched %d\033[K", fetched)
+			_, _ = fmt.Fprintf(r.w, "\rFetched %d\033[K", fetched)
 		}
 	case Events:
-		fmt.Fprintf(r.w, `{"event":"page_fetch","fetched":%d,"total":%d}`+"\n", fetched, total)
+		_, _ = fmt.Fprintf(r.w, `{"event":"page_fetch","fetched":%d,"total":%d}`+"\n", fetched, total)
 	}
 }
 
 // Stop finalizes the reporter. In interactive mode it clears the in-place line.
 func (r *Reporter) Stop() {
 	if r.mode == Interactive {
-		fmt.Fprint(r.w, "\r\033[K")
+		_, _ = fmt.Fprint(r.w, "\r\033[K")
 	}
 }

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -1,0 +1,53 @@
+// Copyright 2026, Jamf Software LLC
+
+// Package progress renders determinate progress for long, countable operations
+// (e.g. --all pagination): an in-place count line on an interactive terminal, or
+// newline-delimited JSON page_fetch events when piped.
+package progress
+
+import (
+	"fmt"
+	"io"
+)
+
+// Mode selects how a Reporter renders.
+type Mode int
+
+const (
+	Silent      Mode = iota // emit nothing (e.g. --quiet)
+	Interactive             // in-place count line on a TTY
+	Events                  // NDJSON page_fetch events (piped / --no-color)
+)
+
+// Reporter renders determinate progress to w.
+type Reporter struct {
+	w    io.Writer
+	mode Mode
+}
+
+// New returns a Reporter writing to w in the given mode.
+func New(w io.Writer, mode Mode) *Reporter {
+	return &Reporter{w: w, mode: mode}
+}
+
+// Update reports that fetched items of total have been retrieved. total <= 0
+// means the total is unknown.
+func (r *Reporter) Update(fetched, total int) {
+	switch r.mode {
+	case Interactive:
+		if total > 0 {
+			fmt.Fprintf(r.w, "\rFetched %d / %d\033[K", fetched, total)
+		} else {
+			fmt.Fprintf(r.w, "\rFetched %d\033[K", fetched)
+		}
+	case Events:
+		fmt.Fprintf(r.w, `{"event":"page_fetch","fetched":%d,"total":%d}`+"\n", fetched, total)
+	}
+}
+
+// Stop finalizes the reporter. In interactive mode it clears the in-place line.
+func (r *Reporter) Stop() {
+	if r.mode == Interactive {
+		fmt.Fprint(r.w, "\r\033[K")
+	}
+}

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -21,8 +21,9 @@ const (
 
 // Reporter renders determinate progress to w.
 type Reporter struct {
-	w    io.Writer
-	mode Mode
+	w       io.Writer
+	mode    Mode
+	stopped bool
 }
 
 // New returns a Reporter writing to w in the given mode.
@@ -46,7 +47,12 @@ func (r *Reporter) Update(fetched, total int) {
 }
 
 // Stop finalizes the reporter. In interactive mode it clears the in-place line.
+// Stop is idempotent: subsequent calls after the first are no-ops.
 func (r *Reporter) Stop() {
+	if r.stopped {
+		return
+	}
+	r.stopped = true
 	if r.mode == Interactive {
 		_, _ = fmt.Fprint(r.w, "\r\033[K")
 	}

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -42,7 +42,13 @@ func (r *Reporter) Update(fetched, total int) {
 			_, _ = fmt.Fprintf(r.w, "\rFetched %d\033[K", fetched)
 		}
 	case Events:
-		_, _ = fmt.Fprintf(r.w, `{"event":"page_fetch","fetched":%d,"total":%d}`+"\n", fetched, total)
+		// total <= 0 means unknown — emit null rather than a misleading 0, so a
+		// machine consumer can distinguish "unknown total" from "zero results".
+		if total > 0 {
+			_, _ = fmt.Fprintf(r.w, `{"event":"page_fetch","fetched":%d,"total":%d}`+"\n", fetched, total)
+		} else {
+			_, _ = fmt.Fprintf(r.w, `{"event":"page_fetch","fetched":%d,"total":null}`+"\n", fetched)
+		}
 	}
 }
 

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -53,3 +53,15 @@ func TestReporter_InteractiveUnknownTotal(t *testing.T) {
 		t.Errorf("unknown total should omit the denominator, got %q", buf.String())
 	}
 }
+
+func TestReporter_StopIdempotent(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Interactive)
+	r.Update(50, 100)
+	r.Stop()
+	after1 := buf.String()
+	r.Stop() // second call must be a no-op
+	if buf.String() != after1 {
+		t.Errorf("second Stop() must not write anything; buffer grew from %q to %q", after1, buf.String())
+	}
+}

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -23,6 +23,20 @@ func TestReporter_Events(t *testing.T) {
 	}
 }
 
+func TestReporter_EventsUnknownTotal(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Events)
+	r.Update(100, 0) // unknown total
+	r.Stop()
+	out := buf.String()
+	if !strings.Contains(out, `"total":null`) || strings.Contains(out, `"total":0`) {
+		t.Errorf("unknown total should emit null, not 0: %q", out)
+	}
+	if !strings.Contains(out, `"fetched":100`) {
+		t.Errorf("event line missing fetched: %q", out)
+	}
+}
+
 func TestReporter_Silent(t *testing.T) {
 	var buf bytes.Buffer
 	r := New(&buf, Silent)

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026, Jamf Software LLC
+
+package progress
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestReporter_Events(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Events)
+	r.Update(100, 500)
+	r.Update(200, 500)
+	r.Stop()
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 event lines, got %d: %q", len(lines), buf.String())
+	}
+	if !strings.Contains(lines[0], `"event":"page_fetch"`) || !strings.Contains(lines[0], `"fetched":100`) || !strings.Contains(lines[0], `"total":500`) {
+		t.Errorf("bad event line: %q", lines[0])
+	}
+}
+
+func TestReporter_Silent(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Silent)
+	r.Update(100, 500)
+	r.Stop()
+	if buf.Len() != 0 {
+		t.Errorf("silent reporter must emit nothing, got %q", buf.String())
+	}
+}
+
+func TestReporter_Interactive(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Interactive)
+	r.Update(100, 500)
+	r.Stop()
+	out := buf.String()
+	if !strings.Contains(out, "\r") || !strings.Contains(out, "Fetched 100 / 500") {
+		t.Errorf("interactive output should carry an in-place count line, got %q", out)
+	}
+}
+
+func TestReporter_InteractiveUnknownTotal(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Interactive)
+	r.Update(100, 0)
+	r.Stop()
+	if !strings.Contains(buf.String(), "Fetched 100") || strings.Contains(buf.String(), "/ 0") {
+		t.Errorf("unknown total should omit the denominator, got %q", buf.String())
+	}
+}

--- a/internal/protect/output_test.go
+++ b/internal/protect/output_test.go
@@ -4,8 +4,11 @@ package protect
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"testing"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/progress"
 )
 
 // mockFormatter captures the raw bytes passed to PrintRaw.
@@ -21,6 +24,9 @@ func (m *mockFormatter) PrintRaw(data []byte) error {
 }
 func (m *mockFormatter) PrintBytes(data []byte) error { return m.PrintRaw(data) }
 func (m *mockFormatter) Format() string               { return "json" }
+func (m *mockFormatter) PaginationProgress() *progress.Reporter {
+	return progress.New(io.Discard, progress.Silent)
+}
 
 func TestPrintOne_MarshalsSingleItem(t *testing.T) {
 	type item struct {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/auth"
+	"github.com/Jamf-Concepts/jamf-cli/internal/progress"
 	"github.com/Jamf-Concepts/jamfplatform-go-sdk/jamfplatform"
 	"github.com/Jamf-Concepts/jamfprotect-go-sdk/jamfprotect"
 	"github.com/Jamf-Concepts/jamfschool-go-sdk/jamfschool"
@@ -69,6 +70,8 @@ type OutputFormatter interface {
 	PrintBytes(data []byte) error
 	// Format returns the current output format string (e.g. "json", "xml", "table").
 	Format() string
+	// PaginationProgress returns a reporter for --all pagination progress.
+	PaginationProgress() *progress.Reporter
 }
 
 // ProtectClient defines the interface for Jamf Protect API operations.

--- a/internal/spinner/spinner.go
+++ b/internal/spinner/spinner.go
@@ -3,6 +3,7 @@
 package spinner
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -10,6 +11,20 @@ import (
 
 	"golang.org/x/term"
 )
+
+type suppressKey struct{}
+
+// WithSuppressed marks ctx so spinner wrappers skip the animation for requests
+// made under it (used by paginated --all loops that show determinate progress).
+func WithSuppressed(ctx context.Context) context.Context {
+	return context.WithValue(ctx, suppressKey{}, true)
+}
+
+// IsSuppressed reports whether ctx was marked by WithSuppressed.
+func IsSuppressed(ctx context.Context) bool {
+	v, _ := ctx.Value(suppressKey{}).(bool)
+	return v
+}
 
 var frames = []rune("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
 

--- a/internal/spinner/spinner_test.go
+++ b/internal/spinner/spinner_test.go
@@ -3,6 +3,7 @@
 package spinner
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -157,5 +158,15 @@ func TestStopClearsLine_ActivePath(t *testing.T) {
 	output := collect()
 	if len(output) == 0 {
 		t.Error("expected spinner output on stderr")
+	}
+}
+
+func TestSuppressionContext(t *testing.T) {
+	ctx := context.Background()
+	if IsSuppressed(ctx) {
+		t.Error("fresh context should not be suppressed")
+	}
+	if !IsSuppressed(WithSuppressed(ctx)) {
+		t.Error("WithSuppressed context should report suppressed")
 	}
 }


### PR DESCRIPTION
## What

Adds two related improvements to large-list handling:
1. **`-o ndjson`** — line-delimited output: one compact JSON object per line, no array wrapper.
2. **Determinate `--all` pagination progress** for generated Pro list commands — replaces the indeterminate per-page spinner with a count.

## Surfaces

- **`-o ndjson`** — one compact object per line; honors `--select`/`--compact`/`--field`; empty/`null` → no output; single object → one line. Works across **all products** (Pro modern + classic, Protect, Platform, School), since output routes through the shared `output.Formatter`.
- **`--all` progress** (Pro generated lists): in-place `Fetched N / M` counter when stderr is a terminal; machine-readable `{"event":"page_fetch","fetched":N,"total":M}` on stderr when piped; silent under `--quiet`. The per-page "Loading…" spinner is suppressed during `--all`.

## Scope

- **ndjson format: all products.** **Determinate `--all` progress: Pro generated commands only** — Protect/School/Platform have no CLI-side `--all` loop (they fetch via SDK/REST), so they get the ndjson format but keep the per-request spinner.

## Design notes

- ndjson is **opt-in**; `json` stays the piped default. `--all=false` single-page unwraps `{results}` for ndjson only (gated to ndjson + paginated ops; json/table/`get` unchanged).
- Progress mode keys off **stderr being a TTY + explicit `--no-color`/`NO_COLOR`** (not the stdout-derived auto-`noColor`), so `cmd | jq` in a terminal still shows the counter.
- **No** true streaming-to-stdout (still materializes the page set); bounded-memory-at-scale is left to the future local data layer.

## Tests / verification

- **Unit:** `internal/progress` (modes, idempotent Stop, `total:null`), `internal/output` (ndjson Print/PrintRaw, PaginationProgress mode incl. piped-stdout / explicit-no-color / nil-stderr, empty-null), `generator/parser` (selectTableColumns ndjson guard, `--all` wiring, single-page unwrap, Stop-before-output), `isFullDetailFormat`.
- **Verified live** against a real instance: ndjson records + `page_fetch` events; `--quiet`/`--out-file`/`--compact`/`--field`; single `get`; `--all=false` unwrap; empty → 0 lines; Classic per-record; `json/yaml/csv --all` unaffected.
- `make test`, `make lint`, `make verify-generated` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)