### PR TITLE
feat(pro): retry-failed command for Jamf Protect deployment tasks

### DIFF
--- a/internal/commands/pro.go
+++ b/internal/commands/pro.go
@@ -85,6 +85,10 @@ func newProCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	// Also expose sync under packages — JCDS is the backing store for packages.
 	addSubcommand(cmd, []string{"packages"}, newJcdsSyncCmd(cliCtx))
 
+	// Add handwritten retry-failed to generated parent (orchestrates computer
+	// resolution + task lookup/filter before calling the retry endpoint).
+	addSubcommand(cmd, []string{"jamf-protect-deployment-tasks"}, newJamfProtectDeploymentRetryFailedCmd(cliCtx))
+
 	// Add device action subcommands to generated resource parents
 	addSubcommand(cmd, []string{"computers-inventory"}, newComputerEraseCmd(cliCtx))
 	addSubcommand(cmd, []string{"computers-inventory"}, newComputerRemoveMDMCmd(cliCtx))

--- a/internal/commands/pro_jamf_protect_deployment_tasks.go
+++ b/internal/commands/pro_jamf_protect_deployment_tasks.go
@@ -1,0 +1,288 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+	"github.com/Jamf-Concepts/jamf-cli/internal/resolve"
+)
+
+// isFailedTaskStatus reports whether a deployment task's status string
+// represents a failed install: status == GAVE_UP, confirmed against a live
+// tenant's real task data. The server-side RSQL "status" filter on this
+// endpoint 500s regardless of the value or quoting used (filtering on other
+// fields like "updated" works fine), so this match happens entirely
+// client-side after an unfiltered fetch.
+//
+// Do not confuse this with the filter param's own (unrelated, and separately
+// broken) validation enum of Installed/Pending/Failed/Acknowledged — that's
+// what `filter=status==X` validates X against before 500ing, not what the
+// task's actual "status" field contains. Real observed status values:
+// VERIFIED_INSTALL (success), GAVE_UP (failed), INSTALL_IN_PROGRESS
+// (pending), COMPLETE.
+func isFailedTaskStatus(status string) bool {
+	return strings.EqualFold(status, "GAVE_UP")
+}
+
+// newJamfProtectDeploymentRetryFailedCmd creates the `jamf-protect-deployment-tasks
+// retry-failed` subcommand. It is hand-written business logic wired onto the
+// generated "jamf-protect-deployment-tasks" command group (see pro.go):
+// the retry API takes deployment TASK ids, not computer ids, so retrying by
+// serial/management-id/all-failed requires resolving the computer and/or
+// listing+filtering tasks before calling the generated retry endpoint's
+// underlying POST.
+func newJamfProtectDeploymentRetryFailedCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var (
+		serial           string
+		managementID     string
+		udid             string
+		allFailed        bool
+		taskIDs          []string
+		includeSucceeded bool
+		yes              bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "retry-failed <deployment-id>",
+		Short: "Retry failed Jamf Protect install tasks for a deployment",
+		Long: `Retry failed Jamf Protect deployment install tasks (status GAVE_UP).
+Status matching happens client-side, not via the server's "status" filter,
+which 500s on this endpoint regardless of value.
+
+<deployment-id> is the deployment UUID for a Jamf Protect plan, found via
+"jamf-cli pro jamf-protect-plans list" (the "uuid" field) — not the config
+profile's numeric ID.
+
+Exactly one targeting mode is required:
+  --serial            retry the failed task for one computer, by serial number
+  --management-id      retry the failed task for one computer, by management ID (UUID)
+  --udid               retry the failed task for one computer, by UDID
+  --all-failed         retry every failed task in the deployment
+  --task-ids           retry specific deployment task IDs directly (advanced; skips lookup)
+
+--include-succeeded drops the default failed-only filter when resolving
+--serial/--management-id/--udid, matching that computer's task regardless of status.
+
+--all-failed can re-queue installs across many devices — it requires --yes.`,
+		Example: `  # Retry the failed install task for one computer, by serial number
+  jamf-cli pro jamf-protect-deployment-tasks retry-failed 24a7bb2a-9871-4895-9009-d1be07ed31b1 --serial C02X1234ABCD
+
+  # Retry by management ID (UUID)
+  jamf-cli pro jamf-protect-deployment-tasks retry-failed 24a7bb2a-9871-4895-9009-d1be07ed31b1 --management-id 6f2c1e3a-...
+
+  # Retry by UDID
+  jamf-cli pro jamf-protect-deployment-tasks retry-failed 24a7bb2a-9871-4895-9009-d1be07ed31b1 --udid 00008030-001A2D...
+
+  # Retry every failed task in the deployment
+  jamf-cli pro jamf-protect-deployment-tasks retry-failed 24a7bb2a-9871-4895-9009-d1be07ed31b1 --all-failed --yes
+
+  # Retry specific deployment task IDs directly (advanced)
+  jamf-cli pro jamf-protect-deployment-tasks retry-failed 24a7bb2a-9871-4895-9009-d1be07ed31b1 --task-ids 82,83
+
+  # Preview without executing
+  jamf-cli pro jamf-protect-deployment-tasks retry-failed 24a7bb2a-9871-4895-9009-d1be07ed31b1 --all-failed --dry-run`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deploymentID := args[0]
+			stderr := cmd.ErrOrStderr()
+
+			modesSet := 0
+			for _, set := range []bool{serial != "", managementID != "", udid != "", allFailed, len(taskIDs) > 0} {
+				if set {
+					modesSet++
+				}
+			}
+			if modesSet == 0 {
+				return fmt.Errorf("one of --serial, --management-id, --udid, --all-failed, or --task-ids is required")
+			}
+			if includeSucceeded && serial == "" && managementID == "" && udid == "" {
+				return fmt.Errorf("--include-succeeded requires --serial, --management-id, or --udid")
+			}
+
+			ctx := cmd.Context()
+
+			var (
+				ids        []string
+				targetDesc string
+				requireYes bool
+			)
+
+			switch {
+			case len(taskIDs) > 0:
+				ids = taskIDs
+				targetDesc = fmt.Sprintf("%d task ID(s) given directly", len(ids))
+
+			case allFailed:
+				requireYes = true
+				tasks, err := fetchDeploymentTasks(ctx, cliCtx.Client, deploymentID)
+				if err != nil {
+					return err
+				}
+				for _, t := range tasks {
+					if isFailedTaskStatus(extractField(t, "status")) {
+						ids = append(ids, extractField(t, "id"))
+					}
+				}
+				if len(ids) == 0 {
+					_, _ = fmt.Fprintln(stderr, "Nothing to retry: no failed tasks found for this deployment.")
+					return nil
+				}
+				targetDesc = fmt.Sprintf("all %d failed task(s) in the deployment", len(ids))
+
+			default: // --serial, --management-id, or --udid
+				d, err := resolveDeploymentTargetComputer(ctx, cliCtx.Client, serial, managementID, udid)
+				if err != nil {
+					return err
+				}
+
+				tasks, err := fetchDeploymentTasks(ctx, cliCtx.Client, deploymentID)
+				if err != nil {
+					return err
+				}
+
+				for _, t := range tasks {
+					if extractField(t, "computerId") != d.ID {
+						continue
+					}
+					if includeSucceeded || isFailedTaskStatus(extractField(t, "status")) {
+						ids = append(ids, extractField(t, "id"))
+					}
+				}
+				if len(ids) == 0 {
+					hint := ", or retry with --include-succeeded to see its current status"
+					if includeSucceeded {
+						hint = ""
+					}
+					return fmt.Errorf("no deployment task found for computer %s in deployment %s — check the deployment UUID, confirm the computer is scoped to this plan%s", resolve.FormatDeviceDesc(d), deploymentID, hint)
+				}
+				targetDesc = fmt.Sprintf("computer %s (%d task(s))", resolve.FormatDeviceDesc(d), len(ids))
+			}
+
+			if dryRun {
+				_, _ = fmt.Fprintf(stderr, "[dry-run] Would retry %s: task IDs %s\n", targetDesc, strings.Join(ids, ", "))
+				return nil
+			}
+
+			if requireYes && !yes {
+				_, _ = fmt.Fprintf(stderr, "This will retry %s. Use --yes to execute.\n", targetDesc)
+				return nil
+			}
+
+			return retryDeploymentTasks(ctx, cliCtx, stderr, deploymentID, ids, targetDesc)
+		},
+	}
+
+	cmd.Flags().StringVar(&serial, "serial", "", "target computer by serial number")
+	cmd.Flags().StringVar(&managementID, "management-id", "", "target computer by management ID (UUID)")
+	cmd.Flags().StringVar(&udid, "udid", "", "target computer by UDID")
+	cmd.Flags().BoolVar(&allFailed, "all-failed", false, "retry every failed task in the deployment")
+	cmd.Flags().StringSliceVar(&taskIDs, "task-ids", nil, "retry specific deployment task IDs directly (advanced)")
+	cmd.Flags().BoolVar(&includeSucceeded, "include-succeeded", false, "match the target computer's task regardless of status (use with --serial/--management-id/--udid)")
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip confirmation prompt (required for --all-failed)")
+	cmd.MarkFlagsMutuallyExclusive("serial", "management-id", "udid", "all-failed", "task-ids")
+
+	return cmd
+}
+
+// resolveDeploymentTargetComputer resolves exactly one of serial/managementID/udid
+// to a computer's full identifiers.
+func resolveDeploymentTargetComputer(ctx context.Context, client registry.HTTPClient, serial, managementID, udid string) (*resolve.DeviceIdentifiers, error) {
+	switch {
+	case serial != "":
+		return resolve.ResolveComputer(ctx, client, serial, "", "")
+	case managementID != "":
+		return resolve.ResolveComputerByManagementID(ctx, client, managementID)
+	default:
+		return resolve.ResolveComputerByUDID(ctx, client, udid)
+	}
+}
+
+// fetchDeploymentTasks pages through every task for a deployment, unfiltered.
+// Filtering happens entirely client-side (see isFailedTaskStatus): the
+// server-side RSQL filter cannot express computerId at all, and its "status"
+// filter 500s regardless of value, so there is no filter this call can
+// usefully send.
+func fetchDeploymentTasks(ctx context.Context, client registry.HTTPClient, deploymentID string) ([]map[string]any, error) {
+	const pageSize = 100
+	var all []map[string]any
+
+	for page := 0; ; page++ {
+		path := fmt.Sprintf("/v1/jamf-protect/deployments/%s/tasks?page=%d&page-size=%d",
+			url.PathEscape(deploymentID), page, pageSize)
+
+		resp, err := client.Do(ctx, "GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("fetching deployment tasks: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		var pageResp struct {
+			TotalCount int              `json:"totalCount"`
+			Results    []map[string]any `json:"results"`
+		}
+		if err := json.Unmarshal(body, &pageResp); err != nil {
+			return nil, fmt.Errorf("parsing deployment tasks response: %w", err)
+		}
+
+		all = append(all, pageResp.Results...)
+		if len(pageResp.Results) < pageSize || len(all) >= pageResp.TotalCount {
+			break
+		}
+	}
+
+	return all, nil
+}
+
+// retryDeploymentTasks POSTs the given deployment task IDs to the retry
+// endpoint and prints a summary on success.
+func retryDeploymentTasks(ctx context.Context, cliCtx *registry.CLIContext, stderr io.Writer, deploymentID string, ids []string, targetDesc string) error {
+	reqBody, err := json.Marshal(map[string]any{"ids": ids})
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/v1/jamf-protect/deployments/%s/tasks/retry", url.PathEscape(deploymentID))
+	resp, err := cliCtx.Client.Do(ctx, "POST", path, bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("retry failed: this tenant isn't registered with Jamf Protect (Cloud Services Connection not established): %s", strings.TrimSpace(string(body)))
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("retry failed: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	_, _ = fmt.Fprintf(stderr, "Retried %s.\n", targetDesc)
+	out, err := json.Marshal(map[string]any{
+		"deploymentId":   deploymentID,
+		"retriedTaskIds": ids,
+		"count":          len(ids),
+	})
+	if err != nil {
+		return err
+	}
+	return cliCtx.Output.PrintRaw(out)
+}

--- a/internal/commands/pro_jamf_protect_deployment_tasks_test.go
+++ b/internal/commands/pro_jamf_protect_deployment_tasks_test.go
@@ -1,0 +1,431 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+)
+
+// retryTasksMockClient serves computer resolution, deployment task listing,
+// and the retry POST for the retry-failed command tests.
+type retryTasksMockClient struct {
+	handler func(method, path string, body []byte) (int, string, error)
+	posts   []capturedPost
+}
+
+type capturedPost struct {
+	path string
+	body []byte
+}
+
+func (m *retryTasksMockClient) Do(_ context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	var b []byte
+	if body != nil {
+		var err error
+		b, err = io.ReadAll(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if method == "POST" {
+		m.posts = append(m.posts, capturedPost{path: path, body: b})
+	}
+	code, respBody, err := m.handler(method, path, b)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader(respBody)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func runRetryFailed(mock *retryTasksMockClient, args ...string) (string, error) {
+	cliCtx := &registry.CLIContext{Client: mock, Output: &discardOutput{}}
+	cmd := newJamfProtectDeploymentRetryFailedCmd(cliCtx)
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return stderr.String(), err
+}
+
+const failedTasksPage = `{"totalCount":2,"results":[
+  {"id":"82","computerId":"42","computerName":"Lab Mac 1","status":"GAVE_UP"},
+  {"id":"83","computerId":"99","computerName":"Lab Mac 2","status":"GAVE_UP"}
+]}`
+
+func computerBySerialResponse(id, serial, managementID string) string {
+	return fmt.Sprintf(`{"totalCount":1,"results":[{"id":"%s","udid":"","general":{"name":"Lab Mac","managementId":"%s"},"hardware":{"serialNumber":"%s"}}]}`, id, managementID, serial)
+}
+
+func computerByUDIDResponse(id, udid string) string {
+	return fmt.Sprintf(`{"totalCount":1,"results":[{"id":"%s","udid":"%s","general":{"name":"Lab Mac"},"hardware":{}}]}`, id, udid)
+}
+
+// --- Target-mode validation ---
+
+func TestRetryFailed_RequiresTargetMode(t *testing.T) {
+	mock := &retryTasksMockClient{handler: func(_, _ string, _ []byte) (int, string, error) {
+		return 0, "", fmt.Errorf("unexpected request")
+	}}
+	_, err := runRetryFailed(mock, "deploy-1")
+	if err == nil || !strings.Contains(err.Error(), "one of --serial, --management-id, --udid, --all-failed, or --task-ids is required") {
+		t.Fatalf("err = %v, want target-mode requirement", err)
+	}
+}
+
+func TestRetryFailed_MutuallyExclusiveTargetModes(t *testing.T) {
+	mock := &retryTasksMockClient{handler: func(_, _ string, _ []byte) (int, string, error) {
+		return 0, "", fmt.Errorf("unexpected request")
+	}}
+	_, err := runRetryFailed(mock, "deploy-1", "--serial", "C02X1234", "--all-failed")
+	if err == nil || !strings.Contains(err.Error(), "none of the others can be") {
+		t.Fatalf("err = %v, want mutually-exclusive error", err)
+	}
+}
+
+func TestRetryFailed_IncludeSucceeded_RequiresSerialOrManagementID(t *testing.T) {
+	mock := &retryTasksMockClient{handler: func(_, _ string, _ []byte) (int, string, error) {
+		return 0, "", fmt.Errorf("unexpected request")
+	}}
+	_, err := runRetryFailed(mock, "deploy-1", "--all-failed", "--include-succeeded", "--yes")
+	if err == nil || !strings.Contains(err.Error(), "--include-succeeded requires --serial, --management-id, or --udid") {
+		t.Fatalf("err = %v, want include-succeeded requirement", err)
+	}
+}
+
+// --- --task-ids: no lookup ---
+
+func TestRetryFailed_TaskIDs_PostsDirectlyWithoutLookup(t *testing.T) {
+	mock := &retryTasksMockClient{handler: func(method, path string, _ []byte) (int, string, error) {
+		if method == "GET" {
+			return 0, "", fmt.Errorf("unexpected GET %s — --task-ids must skip lookup", path)
+		}
+		return 204, "", nil
+	}}
+	_, err := runRetryFailed(mock, "deploy-1", "--task-ids", "82,83")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.posts) != 1 {
+		t.Fatalf("posts = %d, want 1", len(mock.posts))
+	}
+	var body struct {
+		IDs []string `json:"ids"`
+	}
+	if err := json.Unmarshal(mock.posts[0].body, &body); err != nil {
+		t.Fatalf("unmarshalling post body: %v", err)
+	}
+	if len(body.IDs) != 2 || body.IDs[0] != "82" || body.IDs[1] != "83" {
+		t.Errorf("ids = %v, want [82 83]", body.IDs)
+	}
+}
+
+// --- --all-failed ---
+
+func TestRetryFailed_AllFailed_NothingToRetry(t *testing.T) {
+	mock := &retryTasksMockClient{handler: func(method, path string, _ []byte) (int, string, error) {
+		if strings.Contains(path, "/tasks") && method == "GET" {
+			return 200, `{"totalCount":0,"results":[]}`, nil
+		}
+		return 0, "", fmt.Errorf("unexpected request: %s %s", method, path)
+	}}
+	stderr, err := runRetryFailed(mock, "deploy-1", "--all-failed", "--yes")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.posts) != 0 {
+		t.Errorf("expected no POST when nothing to retry, got %d", len(mock.posts))
+	}
+	if !strings.Contains(stderr, "Nothing to retry") {
+		t.Errorf("stderr = %q, want it to mention nothing to retry", stderr)
+	}
+}
+
+func TestRetryFailed_AllFailed_RequiresYes(t *testing.T) {
+	mock := &retryTasksMockClient{handler: func(method, path string, _ []byte) (int, string, error) {
+		if strings.Contains(path, "/tasks") && method == "GET" {
+			return 200, failedTasksPage, nil
+		}
+		return 0, "", fmt.Errorf("unexpected request: %s %s", method, path)
+	}}
+	stderr, err := runRetryFailed(mock, "deploy-1", "--all-failed")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.posts) != 0 {
+		t.Errorf("expected no POST without --yes, got %d", len(mock.posts))
+	}
+	if !strings.Contains(stderr, "Use --yes to execute") {
+		t.Errorf("stderr = %q, want it to prompt for --yes", stderr)
+	}
+}
+
+// mixedStatusTasksPage includes a successfully-installed task (VERIFIED_INSTALL,
+// the real status string observed on a live tenant) alongside failed ones, so
+// tests can verify isFailedTaskStatus actually excludes non-failed tasks
+// rather than trivially matching everything.
+const mixedStatusTasksPage = `{"totalCount":3,"results":[
+  {"id":"82","computerId":"42","computerName":"Lab Mac 1","status":"GAVE_UP"},
+  {"id":"83","computerId":"99","computerName":"Lab Mac 2","status":"GAVE_UP"},
+  {"id":"84","computerId":"55","computerName":"Lab Mac 3","status":"VERIFIED_INSTALL"}
+]}`
+
+func TestRetryFailed_AllFailed_WithYes_PostsAllFailedIDs(t *testing.T) {
+	mock := &retryTasksMockClient{handler: func(method, path string, _ []byte) (int, string, error) {
+		if strings.Contains(path, "/tasks/retry") {
+			return 204, "", nil
+		}
+		if strings.Contains(path, "/tasks") && method == "GET" {
+			if strings.Contains(path, "filter=") {
+				return 0, "", fmt.Errorf("expected no server-side filter (status filtering is broken server-side; must be client-side), got: %s", path)
+			}
+			return 200, mixedStatusTasksPage, nil
+		}
+		return 0, "", fmt.Errorf("unexpected request: %s %s", method, path)
+	}}
+	_, err := runRetryFailed(mock, "deploy-1", "--all-failed", "--yes")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.posts) != 1 {
+		t.Fatalf("posts = %d, want 1", len(mock.posts))
+	}
+	var body struct {
+		IDs []string `json:"ids"`
+	}
+	_ = json.Unmarshal(mock.posts[0].body, &body)
+	// Task 84 (VERIFIED_INSTALL) must be excluded — only the two Failed tasks retry.
+	if len(body.IDs) != 2 || body.IDs[0] != "82" || body.IDs[1] != "83" {
+		t.Errorf("ids = %v, want [82 83] (VERIFIED_INSTALL task 84 excluded)", body.IDs)
+	}
+}
+
+// --- --serial / --management-id: resolve then client-side match ---
+
+func TestRetryFailed_BySerial_FiltersToMatchingComputerClientSide(t *testing.T) {
+	mock := &retryTasksMockClient{handler: func(method, path string, _ []byte) (int, string, error) {
+		if strings.Contains(path, "/tasks/retry") {
+			return 204, "", nil
+		}
+		if strings.Contains(path, "computers-inventory") {
+			if !strings.Contains(path, "serialNumber") {
+				return 0, "", fmt.Errorf("expected serial filter, got: %s", path)
+			}
+			return 200, computerBySerialResponse("42", "C02X1234", "mgmt-1"), nil
+		}
+		if strings.Contains(path, "/tasks") && method == "GET" {
+			return 200, failedTasksPage, nil
+		}
+		return 0, "", fmt.Errorf("unexpected request: %s %s", method, path)
+	}}
+	_, err := runRetryFailed(mock, "deploy-1", "--serial", "C02X1234")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.posts) != 1 {
+		t.Fatalf("posts = %d, want 1", len(mock.posts))
+	}
+	var body struct {
+		IDs []string `json:"ids"`
+	}
+	_ = json.Unmarshal(mock.posts[0].body, &body)
+	// failedTasksPage has task 82 for computerId 42 and task 83 for computerId 99;
+	// only 82 should be retried for computer 42.
+	if len(body.IDs) != 1 || body.IDs[0] != "82" {
+		t.Errorf("ids = %v, want [82] (client-side computerId match)", body.IDs)
+	}
+}
+
+func TestRetryFailed_ByManagementID_Resolves(t *testing.T) {
+	mock := &retryTasksMockClient{handler: func(method, path string, _ []byte) (int, string, error) {
+		if strings.Contains(path, "/tasks/retry") {
+			return 204, "", nil
+		}
+		if strings.Contains(path, "computers-inventory") {
+			if !strings.Contains(path, "managementId") {
+				return 0, "", fmt.Errorf("expected managementId filter, got: %s", path)
+			}
+			return 200, computerBySerialResponse("99", "C02X9999", "mgmt-2"), nil
+		}
+		if strings.Contains(path, "/tasks") && method == "GET" {
+			return 200, failedTasksPage, nil
+		}
+		return 0, "", fmt.Errorf("unexpected request: %s %s", method, path)
+	}}
+	_, err := runRetryFailed(mock, "deploy-1", "--management-id", "mgmt-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.posts) != 1 {
+		t.Fatalf("posts = %d, want 1", len(mock.posts))
+	}
+	var body struct {
+		IDs []string `json:"ids"`
+	}
+	_ = json.Unmarshal(mock.posts[0].body, &body)
+	if len(body.IDs) != 1 || body.IDs[0] != "83" {
+		t.Errorf("ids = %v, want [83] (computerId 99)", body.IDs)
+	}
+}
+
+func TestRetryFailed_ByUDID_Resolves(t *testing.T) {
+	mock := &retryTasksMockClient{handler: func(method, path string, _ []byte) (int, string, error) {
+		if strings.Contains(path, "/tasks/retry") {
+			return 204, "", nil
+		}
+		if strings.Contains(path, "computers-inventory") {
+			if !strings.Contains(path, "udid") {
+				return 0, "", fmt.Errorf("expected udid filter, got: %s", path)
+			}
+			return 200, computerByUDIDResponse("42", "00008030-001A2D"), nil
+		}
+		if strings.Contains(path, "/tasks") && method == "GET" {
+			return 200, failedTasksPage, nil
+		}
+		return 0, "", fmt.Errorf("unexpected request: %s %s", method, path)
+	}}
+	_, err := runRetryFailed(mock, "deploy-1", "--udid", "00008030-001A2D")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.posts) != 1 {
+		t.Fatalf("posts = %d, want 1", len(mock.posts))
+	}
+	var body struct {
+		IDs []string `json:"ids"`
+	}
+	_ = json.Unmarshal(mock.posts[0].body, &body)
+	if len(body.IDs) != 1 || body.IDs[0] != "82" {
+		t.Errorf("ids = %v, want [82] (computerId 42)", body.IDs)
+	}
+}
+
+func TestRetryFailed_NoMatchingTask_ErrorsClearly(t *testing.T) {
+	mock := &retryTasksMockClient{handler: func(method, path string, _ []byte) (int, string, error) {
+		if strings.Contains(path, "computers-inventory") {
+			return 200, computerBySerialResponse("7", "C02XNOTASK", "mgmt-7"), nil
+		}
+		if strings.Contains(path, "/tasks") && method == "GET" {
+			return 200, failedTasksPage, nil
+		}
+		return 0, "", fmt.Errorf("unexpected request: %s %s", method, path)
+	}}
+	_, err := runRetryFailed(mock, "deploy-1", "--serial", "C02XNOTASK")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no deployment task found") {
+		t.Errorf("err = %v, want it to mention no matching task", err)
+	}
+	if len(mock.posts) != 0 {
+		t.Errorf("expected no POST when no task matches, got %d", len(mock.posts))
+	}
+}
+
+// --- --dry-run ---
+
+func TestRetryFailed_DryRun_DoesNotPost(t *testing.T) {
+	resetGlobals()
+	dryRun = true
+	defer func() { dryRun = false }()
+
+	mock := &retryTasksMockClient{handler: func(method, path string, _ []byte) (int, string, error) {
+		if strings.Contains(path, "/tasks") && method == "GET" {
+			return 200, failedTasksPage, nil
+		}
+		return 0, "", fmt.Errorf("unexpected request: %s %s", method, path)
+	}}
+	stderr, err := runRetryFailed(mock, "deploy-1", "--all-failed")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.posts) != 0 {
+		t.Errorf("expected no POST in dry-run, got %d", len(mock.posts))
+	}
+	if !strings.Contains(stderr, "[dry-run]") || !strings.Contains(stderr, "82") || !strings.Contains(stderr, "83") {
+		t.Errorf("stderr = %q, want dry-run preview listing task IDs", stderr)
+	}
+}
+
+// --- Retry POST error surfacing ---
+
+func TestRetryFailed_HTTP400_SurfacesCloudServicesMessage(t *testing.T) {
+	mock := &retryTasksMockClient{handler: func(method, path string, _ []byte) (int, string, error) {
+		if strings.Contains(path, "/tasks/retry") {
+			return 400, `{"httpStatus":400,"errors":[{"description":"Cloud Services Connection has not been established"}]}`, nil
+		}
+		return 0, "", fmt.Errorf("unexpected request: %s %s", method, path)
+	}}
+	_, err := runRetryFailed(mock, "deploy-1", "--task-ids", "82")
+	if err == nil || !strings.Contains(err.Error(), "isn't registered with Jamf Protect") {
+		t.Fatalf("err = %v, want the Cloud Services Connection hint", err)
+	}
+}
+
+// --- isFailedTaskStatus ---
+
+func TestIsFailedTaskStatus(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{"GAVE_UP", true},
+		{"gave_up", true},
+		{"VERIFIED_INSTALL", false},
+		{"INSTALL_IN_PROGRESS", false},
+		{"COMPLETE", false},
+		{"Failed", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isFailedTaskStatus(c.status); got != c.want {
+			t.Errorf("isFailedTaskStatus(%q) = %v, want %v", c.status, got, c.want)
+		}
+	}
+}
+
+// --- fetchDeploymentTasks pagination ---
+
+func TestFetchDeploymentTasks_PagesUntilExhausted(t *testing.T) {
+	page0 := make([]string, 100)
+	for i := range page0 {
+		page0[i] = fmt.Sprintf(`{"id":"%d","computerId":"1","status":"GAVE_UP"}`, i)
+	}
+	page0Body := fmt.Sprintf(`{"totalCount":101,"results":[%s]}`, strings.Join(page0, ","))
+	page1Body := `{"totalCount":101,"results":[{"id":"100","computerId":"1","status":"GAVE_UP"}]}`
+
+	var gets []string
+	mock := &retryTasksMockClient{handler: func(method, path string, _ []byte) (int, string, error) {
+		gets = append(gets, path)
+		if strings.Contains(path, "page=0") {
+			return 200, page0Body, nil
+		}
+		if strings.Contains(path, "page=1") {
+			return 200, page1Body, nil
+		}
+		return 0, "", fmt.Errorf("unexpected page request: %s", path)
+	}}
+
+	tasks, err := fetchDeploymentTasks(context.Background(), mock, "deploy-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 101 {
+		t.Errorf("len(tasks) = %d, want 101", len(tasks))
+	}
+	if len(gets) != 2 {
+		t.Errorf("GET calls = %d, want 2 (paginated)", len(gets))
+	}
+}

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -51,6 +51,20 @@ func ResolveComputer(ctx context.Context, client registry.HTTPClient, serial, na
 	}
 }
 
+// ResolveComputerByManagementID looks up a computer by its MDM management ID (UUID).
+func ResolveComputerByManagementID(ctx context.Context, client registry.HTTPClient, managementID string) (*DeviceIdentifiers, error) {
+	return resolveComputerByFilter(ctx, client,
+		fmt.Sprintf(`general.managementId=="%s"`, EscapeRSQL(managementID)),
+		fmt.Sprintf("management ID %q", managementID))
+}
+
+// ResolveComputerByUDID looks up a computer by its UDID.
+func ResolveComputerByUDID(ctx context.Context, client registry.HTTPClient, udid string) (*DeviceIdentifiers, error) {
+	return resolveComputerByFilter(ctx, client,
+		fmt.Sprintf(`udid=="%s"`, EscapeRSQL(udid)),
+		fmt.Sprintf("UDID %q", udid))
+}
+
 // ResolveMobileDevice looks up a mobile device by serial, name, or ID using
 // the v2 mobile-devices API and returns all identifier forms.
 func ResolveMobileDevice(ctx context.Context, client registry.HTTPClient, serial, name, id string) (*DeviceIdentifiers, error) {


### PR DESCRIPTION
## Summary

- Adds `pro jamf-protect-deployment-tasks retry-failed <deployment-id>`, targetable by `--serial`, `--management-id`, `--udid`, `--all-failed`, or `--task-ids` (exactly one required)
- Hand-written orchestration wired onto the existing generated `jamf-protect-deployment-tasks` command group (same pattern as `jcds` under `pro.go`) — the retry endpoint needs deployment task IDs, not computer IDs, so this resolves the target computer and/or lists deployment tasks and matches client-side before POSTing to the retry endpoint
- `--include-succeeded` drops the failed-only filter when targeting a specific computer; `--all-failed` requires `--yes` (can re-queue installs across many devices); global `--dry-run` works everywhere
- Adds `resolve.ResolveComputerByManagementID` and `resolve.ResolveComputerByUDID` alongside the existing serial/name/ID resolver

## Notes from live-tenant verification

Two things confirmed against a production tenant that don't match the endpoint's docs:
- The GET `.../tasks` endpoint's `filter=status==X` query param 500s regardless of value or quoting — filtering on other fields (e.g. `updated`) works fine. So `computerId` and failed-status matching (`status == GAVE_UP`) both happen client-side after an unfiltered, fully-paginated fetch, never via the server-side filter.
- HTTP 400 on the retry POST specifically means the tenant isn't registered with Jamf Protect (Cloud Services Connection not established) — surfaced as a specific error message.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite)
- [x] `make lint` (0 issues)
- [x] `make fmt` (no diff)
- [x] Unit tests cover: target-mode validation (exactly one required, mutual exclusivity), client-side computerId/status matching, `--all-failed` requiring `--yes`, dry-run, pagination across multiple pages, HTTP 400 surfacing
- [x] Manually verified against a live Jamf Pro tenant (`--serial`, `--udid`, `--all-failed` paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)