### PR TITLE
fix(scope): PUT top-level Classic endpoint instead of /subset/Scope

### DIFF
--- a/docs/solutions/conventions/scope-put-avoid-subset-2026-07-08.md
+++ b/docs/solutions/conventions/scope-put-avoid-subset-2026-07-08.md
@@ -1,0 +1,69 @@
+---
+title: "Classic API scope add/remove must PUT the top-level endpoint, not /subset/Scope"
+date: 2026-07-08
+category: conventions
+module: internal/scope
+problem_type: platform-gateway-limitation
+severity: high
+applies_when:
+  - "Writing a Classic API mutation that targets a /subset/{Name} sub-resource"
+  - "Adding or touching internal/scope PutScope-style read-modify-write flows"
+tags:
+  - classic-api
+  - platform-gateway
+  - scope
+  - subset-endpoint
+---
+
+# Classic API scope add/remove must PUT the top-level endpoint, not `/subset/Scope`
+
+## Context
+
+`jamf-cli pro classic-macos-config-profiles scope add ... --computer-group ...`
+returned HTTP 403 `BAD_PERMISSIONS` (issue #267) even for a token with full
+config-profile privileges. `PutScope` built its request against
+`/JSSResource/{path}/id/{id}/subset/Scope` — a Classic API shortcut endpoint
+that PUTs (and previously PUT-only) just the `<scope>` element instead of the
+whole document.
+
+The 403 only reproduced under `auth-method: platform` (Jamf Platform Gateway).
+The gateway's Classic API proxy (`/api/proclassic/tenant/{id}/...`) does a pure
+path-prefix rewrite (`internal/client/rewritePathForGateway`) — it doesn't
+block or mangle `/subset/...` paths syntactically. The 403 is server-side: the
+gateway's proxy only forwards top-level Classic resource paths, not
+`/subset/{Name}` sub-resources, regardless of the caller's privileges.
+
+A handful of resources (`restrictedsoftware`, `vppassignments`,
+`vppinvitations`) already special-cased this with a per-resource
+`NoSubsetPut` flag (`no_subset_put: true` in `specs/classic/resources.yaml`)
+because the Classic API itself 404s `/subset/Scope` for them even without a
+gateway in the picture — but every other scopeable resource (policies, config
+profiles, mac/mobile apps, ebooks) still used the subset shortcut, so they all
+broke identically under platform gateway auth.
+
+## Guidance
+
+`PutScope` (`internal/scope/scope.go`) now unconditionally does a
+fetch-splice-PUT against the **top-level** endpoint
+(`/JSSResource/{path}/id/{id}`) for every scopeable Classic resource — GET the
+full document, replace the `<scope>` element via `replaceScopeInXML`, PUT the
+whole document back. There is no subset-vs-full branch anymore; the
+`Resource.NoSubsetPut` field (and the manifest's `no_subset_put` key) were
+removed as dead weight once the shortcut path was dropped entirely.
+
+This works identically against the direct Jamf Pro API and through the
+platform gateway, since top-level Classic paths are proxied. The cost is one
+extra GET+larger PUT body versus the old subset shortcut, which is negligible
+for scope mutations.
+
+**When adding a new Classic mutation:** never build a request against
+`/subset/{Name}` if there's any chance it needs to work through the platform
+gateway. Fetch top-level, patch the specific element client-side, PUT the
+whole document back — the same pattern as `PutScope`/`replaceScopeInXML`.
+
+## Related
+
+See `docs/solutions/conventions/classic-api-name-path-encoding-2026-06-18.md`
+for another platform-gateway proxy limitation (the `+`-in-name defect) that
+required a similar "avoid the shortcut, use what the gateway actually
+proxies" workaround.

--- a/generator/classic/generator.go
+++ b/generator/classic/generator.go
@@ -377,9 +377,6 @@ func New{{ .GoName }}Cmd(ctx *registry.CLIContext) *cobra.Command {
 		{{- if scopeResolveByList . }}
 		ResolveByList: true,
 		{{- end }}
-		{{- if .NoSubsetPut }}
-		NoSubsetPut:   true,
-		{{- end }}
 	}))
 {{- end }}
 

--- a/generator/classic/parser.go
+++ b/generator/classic/parser.go
@@ -27,7 +27,6 @@ type manifestResource struct {
 	Operations  []string `yaml:"operations"`
 	Lookups     []string `yaml:"lookups"`
 	Scope       bool     `yaml:"scope"`
-	NoSubsetPut bool     `yaml:"no_subset_put"`
 	IDPath      string   `yaml:"id_path"`
 	ListSubset  string   `yaml:"list_subset"`
 	GroupsPath  string   `yaml:"groups_path"`
@@ -115,7 +114,6 @@ func buildResource(entry manifestResource) (ClassicResource, error) {
 		Operations:       operations,
 		Lookups:          lookups,
 		HasScope:         entry.Scope,
-		NoSubsetPut:      entry.NoSubsetPut,
 		IDPath:           idPath,
 		IsConfigProfile:  entry.Path == "osxconfigurationprofiles" || entry.Path == "mobiledeviceconfigurationprofiles",
 		HasCustomPayload: entry.Path == "osxconfigurationprofiles",

--- a/generator/classic/types.go
+++ b/generator/classic/types.go
@@ -15,7 +15,6 @@ type ClassicResource struct {
 	Operations       []string // ["list", "get", "create", "update", "delete"]
 	Lookups          []string // ["id", "name", "serialnumber", "macaddress", "udid"]
 	HasScope         bool     // true if the resource supports scope operations
-	NoSubsetPut      bool     // true if the resource does not support /subset/Scope PUT (use full-doc PUT)
 	IDPath           string   // path segment between base path and ID value; defaults to "id" (e.g. "groupid" → /accounts/groupid/{id})
 	IsConfigProfile  bool     // true for macOS and mobile device configuration profile resources
 	HasCustomPayload bool     // true only for osxconfigurationprofiles (supports --custom-payload-file)

--- a/internal/commands/pro/generated/classic_restricted_software.go
+++ b/internal/commands/pro/generated/classic_restricted_software.go
@@ -41,7 +41,6 @@ func NewClassicRestrictedSoftwareCmd(ctx *registry.CLIContext) *cobra.Command {
 	cmd.AddCommand(scope.NewScopeCmd(ctx, scope.Resource{
 		APIPath:     "restrictedsoftware",
 		SingularKey: "restricted_software",
-		NoSubsetPut: true,
 	}))
 
 	return cmd

--- a/internal/commands/pro/generated/classic_vpp_assignments.go
+++ b/internal/commands/pro/generated/classic_vpp_assignments.go
@@ -39,7 +39,6 @@ func NewClassicVppAssignmentsCmd(ctx *registry.CLIContext) *cobra.Command {
 		APIPath:       "vppassignments",
 		SingularKey:   "vpp_assignment",
 		ResolveByList: true,
-		NoSubsetPut:   true,
 	}))
 
 	return cmd

--- a/internal/commands/pro/generated/classic_vpp_invitations.go
+++ b/internal/commands/pro/generated/classic_vpp_invitations.go
@@ -37,7 +37,6 @@ func NewClassicVppInvitationsCmd(ctx *registry.CLIContext) *cobra.Command {
 		APIPath:       "vppinvitations",
 		SingularKey:   "vpp_invitation",
 		ResolveByList: true,
-		NoSubsetPut:   true,
 	}))
 
 	return cmd

--- a/internal/commands/pro/generated/provenance.go
+++ b/internal/commands/pro/generated/provenance.go
@@ -175,5 +175,5 @@ var Sources = []SpecSource{
 	{File: "specs/VppLocations.yaml", SHA256: "d9b41c79c0cdba81706b16c8e6d0b86b8048d40d6d55ec66618af0ac00c533d0"},
 	{File: "specs/VppSubscriptions.yaml", SHA256: "184b834aeb0d21cf190050294f7869d57b482bbe1834ad5a1bd79dcfdeef7a55"},
 	{File: "specs/_MonolithLibrary.yaml", SHA256: "f42fd86835b98fd0f608f9e598d776b6424554abcb3d4c88353e9276138c20f8"},
-	{File: "specs/classic/resources.yaml", SHA256: "7265b075fcec1b81ed12ab77c7e587dbd397f739433e0b49ddc975548343376f"},
+	{File: "specs/classic/resources.yaml", SHA256: "883cdf0bdc1fa5714d45bd5b4ea8636bcb7edfb395ecbd5009ba74bbe80d3e16"},
 }

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -133,37 +133,13 @@ func resolveNameToID(ctx context.Context, client registry.HTTPClient, apiPath, s
 	return "", fmt.Errorf("%s %q not found", singularKey, name)
 }
 
-// PutScope writes an updated scope back to the Classic API. Uses the subset/Scope
-// endpoint by default; falls back to a full document PUT when res.NoSubsetPut is set.
+// PutScope writes an updated scope back to the Classic API. It fetches the
+// full resource document, splices in the updated scope, and PUTs the whole
+// document back to the top-level endpoint — the /subset/Scope shortcut is
+// skipped entirely, since the Jamf Platform Gateway's Classic API proxy does
+// not proxy /subset/* sub-resources (only top-level Classic paths), which
+// otherwise surfaces as a 403 on scope add/remove under platform gateway auth.
 func PutScope(ctx context.Context, client registry.HTTPClient, res Resource, id string, s *ScopeXML) error {
-	if res.NoSubsetPut {
-		return putFullDocument(ctx, client, res, id, s)
-	}
-
-	envelope := scopeUpdateXML{
-		XMLName: xml.Name{Local: res.SingularKey},
-		Scope:   *s,
-	}
-
-	data, err := xml.MarshalIndent(envelope, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshalling scope XML: %w", err)
-	}
-	xmlBody := append([]byte(xml.Header), data...)
-
-	path := fmt.Sprintf("/JSSResource/%s/id/%s/subset/Scope", res.APIPath, url.PathEscape(id))
-	resp, err := client.Do(ctx, "PUT", path, bytes.NewReader(xmlBody))
-	if err != nil {
-		return fmt.Errorf("updating scope: %w", err)
-	}
-	_ = resp.Body.Close()
-	return nil
-}
-
-// putFullDocument fetches the full resource XML, splices in the updated scope,
-// and PUTs the whole document back. Used for Classic API resources that do not
-// support the /subset/Scope endpoint (e.g. vppassignments).
-func putFullDocument(ctx context.Context, client registry.HTTPClient, res Resource, id string, s *ScopeXML) error {
 	fetchPath := fmt.Sprintf("/JSSResource/%s/id/%s", res.APIPath, url.PathEscape(id))
 	resp, err := client.Do(ctx, "GET", fetchPath, nil)
 	if err != nil {

--- a/internal/scope/scope_test.go
+++ b/internal/scope/scope_test.go
@@ -3,7 +3,10 @@
 package scope
 
 import (
+	"context"
 	"encoding/xml"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -134,29 +137,41 @@ func TestScopeXML_MarshalRoundTrip(t *testing.T) {
 	}
 }
 
-func TestScopeUpdateXML_Marshal(t *testing.T) {
-	s := ScopeXML{
-		ComputerGroups: ScopeItemSlice{
-			Items:    []NamedItem{{Name: "Test"}},
-			ElemName: "computer_group",
-		},
+// mockPutClient records every request path it receives and returns a fixed
+// document body for GET.
+type mockPutClient struct {
+	getBody  string
+	requests []string // "METHOD path"
+}
+
+func (m *mockPutClient) Do(_ context.Context, method, path string, _ io.Reader) (*http.Response, error) {
+	m.requests = append(m.requests, method+" "+path)
+	if method == "GET" {
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(m.getBody))}, nil
 	}
-	envelope := scopeUpdateXML{
-		XMLName: xml.Name{Local: "policy"},
-		Scope:   s,
+	return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("{}"))}, nil
+}
+
+func TestPutScope_UsesTopLevelEndpoint_NoSubsetPath(t *testing.T) {
+	client := &mockPutClient{getBody: `<policy><general><id>5</id></general><scope><all_computers>false</all_computers></scope></policy>`}
+	res := Resource{APIPath: "policies", SingularKey: "policy"}
+	s := &ScopeXML{AllComputers: true}
+
+	if err := PutScope(context.Background(), client, res, "5", s); err != nil {
+		t.Fatalf("PutScope: %v", err)
 	}
 
-	data, err := xml.Marshal(envelope)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
+	want := []string{"GET /JSSResource/policies/id/5", "PUT /JSSResource/policies/id/5"}
+	if len(client.requests) != len(want) {
+		t.Fatalf("requests = %v, want %v", client.requests, want)
 	}
-	xmlStr := string(data)
-
-	if !strings.Contains(xmlStr, "<policy>") {
-		t.Error("missing <policy> wrapper")
-	}
-	if !strings.Contains(xmlStr, "<scope>") {
-		t.Error("missing <scope>")
+	for i, r := range client.requests {
+		if r != want[i] {
+			t.Errorf("request[%d] = %q, want %q", i, r, want[i])
+		}
+		if strings.Contains(r, "subset") {
+			t.Errorf("request[%d] hit a /subset/ path — not proxied by the Jamf Platform Gateway: %q", i, r)
+		}
 	}
 }
 

--- a/internal/scope/types.go
+++ b/internal/scope/types.go
@@ -16,7 +16,6 @@ type Resource struct {
 	APIPath       string // URL segment under /JSSResource/, e.g. "policies"
 	SingularKey   string // XML root key for a single object, e.g. "policy"
 	ResolveByList bool   // when true, resolve name→ID by listing all (no /name/ endpoint)
-	NoSubsetPut   bool   // when true, PUT full document instead of /subset/Scope
 }
 
 // ScopeTarget holds a resolved flag name and value from a scope add/remove command.
@@ -209,12 +208,6 @@ type classicResourceXML struct {
 		Name string `xml:"name"`
 	} `xml:"general"`
 	Scope ScopeXML `xml:"scope"`
-}
-
-// scopeUpdateXML wraps a scope for a Classic API subset PUT.
-type scopeUpdateXML struct {
-	XMLName xml.Name
-	Scope   ScopeXML `xml:"scope"`
 }
 
 // flagToElemName maps a CLI flag to the XML child element name used when

--- a/specs/classic/resources.yaml
+++ b/specs/classic/resources.yaml
@@ -204,9 +204,6 @@ resources:
     cli_name: classic-restricted-software
     singular: restricted_software
     scope: true
-    # Classic API has no /subset/Scope endpoint for restricted_software (404).
-    # Fetch the full document, splice in the updated scope, PUT the whole doc.
-    no_subset_put: true
 
   - name: allowedfileextensions
     path: allowedfileextensions
@@ -343,7 +340,6 @@ resources:
     singular: vpp_assignment
     lookups: [id]
     scope: true
-    no_subset_put: true
 
   - name: vppinvitations
     path: vppinvitations
@@ -353,7 +349,6 @@ resources:
     operations: [list, get, create, delete]
     lookups: [id]
     scope: true
-    no_subset_put: true
 
   - name: gsxconnection
     path: gsxconnection


### PR DESCRIPTION
## What

Fixes #267. `pro classic-*-config-profiles scope add/remove` (and every other Classic `scope` command) returned HTTP 403 `BAD_PERMISSIONS` under `auth-method: platform` (Jamf Platform Gateway), even with full privileges.

## Why

`PutScope` PUT the `/subset/Scope` shortcut endpoint by default. The Platform Gateway's Classic API proxy only forwards top-level Classic resource paths — it doesn't proxy `/subset/{Name}` sub-resources at all, which the gateway backend rejects with a 403 regardless of the token's privileges. The rewrite logic itself (`rewritePathForGateway`) is a pure prefix substitution and doesn't block or mangle the path — this is a server-side gateway limitation.

A few resources (`restrictedsoftware`, `vppassignments`, `vppinvitations`) already worked around this with a per-resource `NoSubsetPut` flag, because the Classic API itself 404s `/subset/Scope` for them even without a gateway. Every other scopeable resource (policies, config profiles, mac/mobile apps, ebooks) still used the shortcut and broke identically under platform auth.

## How

Simplified rather than adding transport detection: `PutScope` now **always** does the fetch-splice-PUT flow against the top-level endpoint (`GET /JSSResource/{path}/id/{id}` → splice `<scope>` → `PUT` the whole document back) — the same flow already proven for the `NoSubsetPut` resources, now the only path. Removed the now-dead `NoSubsetPut` field from `scope.Resource`, the classic generator template/parser, and the three `no_subset_put: true` manifest entries.

No transport-detection plumbing needed — this works identically against the direct Pro API and through the gateway, since top-level Classic paths are proxied either way.

## Testing

- `make test`, `make lint` (0 issues), `make verify-generated` all green.
- Added `TestPutScope_UsesTopLevelEndpoint_NoSubsetPath` asserting no `/subset/` path is ever hit.
- **Live-verified against the same tenant via both transports:**
  - `-p platform-nmartin` (gateway): `scope add`/`scope remove` on a macOS config profile — previously 403, now succeeds and persists.
  - `-p pro-nmartin` (direct): same profile, confirms cross-transport consistency; also re-verified `restrictedsoftware` scope add/remove (a former `NoSubsetPut` resource) still works after the flag's removal.
  - All test scope mutations were added then removed, restoring original state.
- Added `docs/solutions/conventions/scope-put-avoid-subset-2026-07-08.md` documenting the gateway limitation for future Classic mutation work.

## Isolation from #270

Branched off `main`, not off `feat/update-set-fetch-merge-put` (#270) — no overlap with that PR's generated-command changes; this only touches the Classic `scope` package, its generator wiring, and 3 classic-generated files that dropped a dead field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)