### PR TITLE
feat(backup): add --download-packages for JCDS-hosted package binaries

### DIFF
--- a/internal/commands/pro_backup.go
+++ b/internal/commands/pro_backup.go
@@ -13,9 +13,11 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/auth"
@@ -63,11 +65,12 @@ type backupMeta struct {
 
 func newBackupCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var (
-		outputDir   string
-		format      string
-		resources   string
-		includeIDs  bool
-		concurrency int
+		outputDir        string
+		format           string
+		resources        string
+		includeIDs       bool
+		concurrency      int
+		downloadPackages bool
 	)
 
 	cmd := &cobra.Command{
@@ -79,14 +82,21 @@ Each object is saved as an individual YAML or JSON file. Server-generated fields
 (id, timestamps) are stripped by default for clean version-control diffs.
 
 Partial failures are tolerated — objects that fail to fetch are recorded in
-_failures.yaml and the backup continues.`,
+_failures.yaml and the backup continues.
+
+--download-packages additionally downloads the package binaries backing the
+"packages" resource, saved to packages/files/. Only packages hosted on the
+Jamf Cloud Distribution Service (JCDS) can be downloaded this way — packages
+on other distribution points (on-prem file share, third-party cloud) have no
+reliable download path and are skipped with a warning.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runBackup(cmd.Context(), cliCtx, backupOptions{
-				OutputDir:   outputDir,
-				Format:      format,
-				Resources:   resources,
-				IncludeIDs:  includeIDs,
-				Concurrency: concurrency,
+				OutputDir:        outputDir,
+				Format:           format,
+				Resources:        resources,
+				IncludeIDs:       includeIDs,
+				Concurrency:      concurrency,
+				DownloadPackages: downloadPackages,
 			})
 		},
 	}
@@ -96,17 +106,19 @@ _failures.yaml and the backup continues.`,
 	cmd.Flags().StringVar(&resources, "resources", "", "comma-separated resource filter (e.g., policies,scripts)")
 	cmd.Flags().BoolVar(&includeIDs, "include-ids", false, "retain server-generated IDs in output")
 	cmd.Flags().IntVar(&concurrency, "concurrency", backupDefaultConcurrency, fmt.Sprintf("max parallel API requests (ceiling %d)", backupMaxConcurrency))
+	cmd.Flags().BoolVar(&downloadPackages, "download-packages", false, "also download package binaries hosted on JCDS to packages/files/")
 	_ = cmd.MarkFlagRequired("output")
 
 	return cmd
 }
 
 type backupOptions struct {
-	OutputDir   string
-	Format      string
-	Resources   string
-	IncludeIDs  bool
-	Concurrency int
+	OutputDir        string
+	Format           string
+	Resources        string
+	IncludeIDs       bool
+	Concurrency      int
+	DownloadPackages bool
 }
 
 func runBackup(ctx context.Context, cliCtx *registry.CLIContext, opts backupOptions) error {
@@ -180,6 +192,11 @@ func runBackup(ctx context.Context, cliCtx *registry.CLIContext, opts backupOpti
 
 	var failures []backupFailure
 	totalExported := 0
+
+	// packageFilenames collects the "filename" field of every exported package
+	// object so --download-packages can attempt a JCDS download after the
+	// metadata pass completes, without a redundant re-fetch of the list.
+	var packageFilenames []string
 
 	for _, def := range defs {
 		// Create output subdirectory
@@ -257,6 +274,12 @@ func runBackup(ctx context.Context, cliCtx *registry.CLIContext, opts backupOpti
 			// Add _meta block
 			obj["_meta"] = newMeta(def.FilterName)
 
+			if opts.DownloadPackages && def.FilterName == "packages" {
+				if fn, ok := obj["filename"].(string); ok && fn != "" {
+					packageFilenames = append(packageFilenames, fn)
+				}
+			}
+
 			slug := SlugifyName(r.Name)
 			slug = DeduplicateSlug(slug, slugSeen)
 
@@ -271,6 +294,13 @@ func runBackup(ctx context.Context, cliCtx *registry.CLIContext, opts backupOpti
 			}
 			totalExported++
 		}
+	}
+
+	// Package binaries — opt-in, JCDS-only (see backupPackageFiles).
+	if opts.DownloadPackages {
+		n, errs := backupPackageFiles(ctx, client, opts, packageFilenames)
+		totalExported += n
+		failures = append(failures, errs...)
 	}
 
 	// wantFilter reports whether a named resource should be included given the
@@ -649,6 +679,67 @@ func backupInventoryPreloadCSV(ctx context.Context, client registry.HTTPClient, 
 		return 0, []backupFailure{{Resource: "inventory-preloads", Path: outPath, Error: err.Error()}}
 	}
 	return 1, nil
+}
+
+// backupPackageFiles downloads the actual package binaries named in
+// filenames, gated behind --download-packages. Only packages hosted on the
+// Jamf Cloud Distribution Service (JCDS) can be reliably downloaded — on-prem
+// file-share and third-party cloud distribution points require credentials
+// or network access this CLI cannot assume, so a filename with no match in
+// /v1/jcds/files is skipped with a warning rather than treated as a failure.
+func backupPackageFiles(ctx context.Context, client registry.HTTPClient, opts backupOptions, filenames []string) (int, []backupFailure) {
+	if len(filenames) == 0 {
+		return 0, nil
+	}
+
+	jcdsFiles, err := jcdsListFiles(ctx, client)
+	if err != nil {
+		return 0, []backupFailure{{Resource: "packages", Path: "/v1/jcds/files", Error: err.Error()}}
+	}
+	jcdsSet := make(map[string]struct{}, len(jcdsFiles))
+	for _, f := range jcdsFiles {
+		jcdsSet[f.FileName] = struct{}{}
+	}
+
+	filesDir := filepath.Join(opts.OutputDir, "packages", "files")
+	if err := os.MkdirAll(filesDir, 0o755); err != nil {
+		return 0, []backupFailure{{Resource: "packages", Path: filesDir, Error: err.Error()}}
+	}
+
+	var (
+		mu         sync.Mutex
+		failures   []backupFailure
+		downloaded int
+	)
+	sem := make(chan struct{}, clampConcurrency(opts.Concurrency))
+	var g errgroup.Group
+
+	for _, name := range filenames {
+		if _, onJCDS := jcdsSet[name]; !onJCDS {
+			fmt.Fprintf(os.Stderr, "warning: package %q is not hosted on JCDS; skipping download\n", name)
+			continue
+		}
+
+		sem <- struct{}{}
+		g.Go(func() error {
+			defer func() { <-sem }()
+
+			outPath := filepath.Join(filesDir, name)
+			if err := jcdsDownloadFile(ctx, client, name, outPath); err != nil {
+				mu.Lock()
+				failures = append(failures, backupFailure{Resource: "packages", Path: name, Error: err.Error()})
+				mu.Unlock()
+				return nil
+			}
+			mu.Lock()
+			downloaded++
+			mu.Unlock()
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	return downloaded, failures
 }
 
 // backupBlueprints exports all blueprints via the Platform SDK.

--- a/internal/commands/pro_backup_test.go
+++ b/internal/commands/pro_backup_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -479,6 +480,195 @@ func TestBackup_InventoryPreloadFilter(t *testing.T) {
 	outPath := filepath.Join(outDir, "inventory-preloads", "inventory-preload-all.csv")
 	if _, err := os.Stat(outPath); os.IsNotExist(err) {
 		t.Error("inventory-preload-all.csv should exist")
+	}
+}
+
+func TestBackup_DownloadPackages(t *testing.T) {
+	fileContent := []byte("fake package binary")
+	fileSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(fileContent)
+	}))
+	defer fileSrv.Close()
+
+	mock := &backupMockClient{
+		responses: map[string]overviewMockResponse{
+			"/JSSResource/packages":      {200, `{"packages":[{"id":1,"name":"Pkg"}]}`},
+			"/JSSResource/packages/id/1": {200, `{"package":{"id":1,"name":"Pkg","filename":"pkg-a.pkg"}}`},
+			"/v1/jcds/files":             {200, `[{"fileName":"pkg-a.pkg","length":20,"md5":"x","region":"us","sha3":"y"}]`},
+			"/v1/jcds/files/pkg-a.pkg":   {200, fmt.Sprintf(`{"uri":%q}`, fileSrv.URL+"/pkg-a.pkg")},
+		},
+	}
+
+	oldURL := serverURL
+	serverURL = "https://test.jamfcloud.com"
+	defer func() { serverURL = oldURL }()
+
+	outDir := t.TempDir()
+	cliCtx := &registry.CLIContext{Client: mock}
+
+	err := runBackup(context.Background(), cliCtx, backupOptions{
+		OutputDir:        outDir,
+		Format:           "yaml",
+		Resources:        "packages",
+		Concurrency:      2,
+		DownloadPackages: true,
+	})
+	if err != nil {
+		t.Fatalf("runBackup error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(outDir, "packages", "files", "pkg-a.pkg"))
+	if err != nil {
+		t.Fatalf("reading downloaded package: %v", err)
+	}
+	if string(got) != string(fileContent) {
+		t.Errorf("content mismatch: got %q, want %q", got, fileContent)
+	}
+}
+
+func TestBackup_DownloadPackages_SkipsNonJCDS(t *testing.T) {
+	mock := &backupMockClient{
+		responses: map[string]overviewMockResponse{
+			"/JSSResource/packages":      {200, `{"packages":[{"id":1,"name":"Pkg"}]}`},
+			"/JSSResource/packages/id/1": {200, `{"package":{"id":1,"name":"Pkg","filename":"onprem.pkg"}}`},
+			"/v1/jcds/files":             {200, `[]`},
+		},
+	}
+
+	oldURL := serverURL
+	serverURL = "https://test.jamfcloud.com"
+	defer func() { serverURL = oldURL }()
+
+	outDir := t.TempDir()
+	cliCtx := &registry.CLIContext{Client: mock}
+
+	err := runBackup(context.Background(), cliCtx, backupOptions{
+		OutputDir:        outDir,
+		Format:           "yaml",
+		Resources:        "packages",
+		Concurrency:      2,
+		DownloadPackages: true,
+	})
+	if err != nil {
+		t.Fatalf("runBackup error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outDir, "packages", "files", "onprem.pkg")); !os.IsNotExist(err) {
+		t.Error("onprem.pkg should not have been downloaded — it has no JCDS match")
+	}
+
+	// Metadata for the package must still have been written even though the
+	// binary download was skipped.
+	if _, err := os.Stat(filepath.Join(outDir, "packages", "pkg.yaml")); err != nil {
+		t.Errorf("package metadata file should still exist: %v", err)
+	}
+}
+
+func TestBackup_DownloadPackages_DownloadFailure(t *testing.T) {
+	mock := &backupMockClient{
+		responses: map[string]overviewMockResponse{
+			"/JSSResource/packages":      {200, `{"packages":[{"id":1,"name":"Pkg"}]}`},
+			"/JSSResource/packages/id/1": {200, `{"package":{"id":1,"name":"Pkg","filename":"pkg-a.pkg"}}`},
+			"/v1/jcds/files":             {200, `[{"fileName":"pkg-a.pkg","length":20,"md5":"x","region":"us","sha3":"y"}]`},
+			// Pre-signed URL fetch fails — download should be recorded as a
+			// failure, not crash the backup.
+			"/v1/jcds/files/pkg-a.pkg": {500, `{"error":"server error"}`},
+		},
+	}
+
+	oldURL := serverURL
+	serverURL = "https://test.jamfcloud.com"
+	defer func() { serverURL = oldURL }()
+
+	outDir := t.TempDir()
+	cliCtx := &registry.CLIContext{Client: mock}
+
+	err := runBackup(context.Background(), cliCtx, backupOptions{
+		OutputDir:        outDir,
+		Format:           "yaml",
+		Resources:        "packages",
+		Concurrency:      2,
+		DownloadPackages: true,
+	})
+	if err == nil {
+		t.Fatal("runBackup should return error when a package download fails")
+	}
+	if got := exitcode.CodeFrom(err); got != exitcode.PartialFailure {
+		t.Fatalf("exit code = %d, want PartialFailure(%d)", got, exitcode.PartialFailure)
+	}
+
+	// Metadata must still be written even though the binary download failed.
+	if _, err := os.Stat(filepath.Join(outDir, "packages", "pkg.yaml")); err != nil {
+		t.Errorf("package metadata file should still exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "packages", "files", "pkg-a.pkg")); !os.IsNotExist(err) {
+		t.Error("pkg-a.pkg should not exist on disk after a failed download")
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "_failures.yaml")); err != nil {
+		t.Errorf("_failures.yaml should exist: %v", err)
+	}
+}
+
+func TestBackup_DownloadPackages_ResourceFilteredOut(t *testing.T) {
+	// --resources excludes "packages" entirely; --download-packages must not
+	// touch /v1/jcds/files at all (no mock registered for it — a call would
+	// surface as a failure and fail this test).
+	mock := &backupMockClient{
+		responses: map[string]overviewMockResponse{
+			"/JSSResource/policies":      {200, `{"policies":[{"id":1,"name":"Good"}]}`},
+			"/JSSResource/policies/id/1": {200, `{"policy":{"general":{"id":1,"name":"Good"}}}`},
+		},
+	}
+
+	oldURL := serverURL
+	serverURL = "https://test.jamfcloud.com"
+	defer func() { serverURL = oldURL }()
+
+	outDir := t.TempDir()
+	cliCtx := &registry.CLIContext{Client: mock}
+
+	err := runBackup(context.Background(), cliCtx, backupOptions{
+		OutputDir:        outDir,
+		Format:           "yaml",
+		Resources:        "policies",
+		Concurrency:      2,
+		DownloadPackages: true,
+	})
+	if err != nil {
+		t.Fatalf("runBackup error: %v", err)
+	}
+}
+
+func TestBackup_NoDownloadPackagesByDefault(t *testing.T) {
+	mock := &backupMockClient{
+		responses: map[string]overviewMockResponse{
+			"/JSSResource/packages":      {200, `{"packages":[{"id":1,"name":"Pkg"}]}`},
+			"/JSSResource/packages/id/1": {200, `{"package":{"id":1,"name":"Pkg","filename":"pkg-a.pkg"}}`},
+		},
+	}
+
+	oldURL := serverURL
+	serverURL = "https://test.jamfcloud.com"
+	defer func() { serverURL = oldURL }()
+
+	outDir := t.TempDir()
+	cliCtx := &registry.CLIContext{Client: mock}
+
+	// DownloadPackages left false (default) — /v1/jcds/files must never be hit,
+	// so no mock response is registered for it; a call would error the mock.
+	err := runBackup(context.Background(), cliCtx, backupOptions{
+		OutputDir:   outDir,
+		Format:      "yaml",
+		Resources:   "packages",
+		Concurrency: 2,
+	})
+	if err != nil {
+		t.Fatalf("runBackup error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outDir, "packages", "files")); !os.IsNotExist(err) {
+		t.Error("packages/files directory should not exist when --download-packages is not set")
 	}
 }
 

--- a/internal/commands/pro_jcds.go
+++ b/internal/commands/pro_jcds.go
@@ -77,6 +77,28 @@ func (e *jcdsHTTPStatusError) Error() string {
 	return fmt.Sprintf("HTTP %d", e.StatusCode)
 }
 
+// jcdsListFiles fetches the full JCDS file list (name, length, hashes, region).
+func jcdsListFiles(ctx context.Context, client registry.HTTPClient) ([]jcdsFileData, error) {
+	resp, err := client.Do(ctx, "GET", "/v1/jcds/files", nil)
+	if err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("reading file list: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var jcdsFiles []jcdsFileData
+	if err := json.Unmarshal(body, &jcdsFiles); err != nil {
+		return nil, fmt.Errorf("parsing file list: %w", err)
+	}
+	return jcdsFiles, nil
+}
+
 // jcdsFetchPresignedURL fetches a fresh pre-signed download URL from the JCDS API.
 func jcdsFetchPresignedURL(ctx context.Context, client registry.HTTPClient, fileName string) (string, error) {
 	apiPath := "/v1/jcds/files/" + url.PathEscape(fileName)
@@ -270,22 +292,9 @@ Designed for scheduled runs on file-share distribution points.`,
 			}
 
 			// Fetch JCDS file list.
-			resp, err := cliCtx.Client.Do(reqCtx, "GET", "/v1/jcds/files", nil)
+			jcdsFiles, err := jcdsListFiles(reqCtx, cliCtx.Client)
 			if err != nil {
 				return err
-			}
-			body, err := io.ReadAll(resp.Body)
-			_ = resp.Body.Close()
-			if err != nil {
-				return fmt.Errorf("reading file list: %w", err)
-			}
-			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-				return fmt.Errorf("API error %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-			}
-
-			var jcdsFiles []jcdsFileData
-			if err := json.Unmarshal(body, &jcdsFiles); err != nil {
-				return fmt.Errorf("parsing file list: %w", err)
 			}
 
 			// Build JCDS filename set for existence checks.


### PR DESCRIPTION
## Summary
- Closes #268.
- `backup` previously only exported package *metadata* — this adds an opt-in `--download-packages` flag that also downloads each package's binary to `packages/files/`.
- Only JCDS-hosted packages can be downloaded reliably (no line-of-sight/credentials assumption for on-prem or third-party cloud distribution points). Packages with no match in `/v1/jcds/files` are skipped with a warning, not counted as a failure — this matches the scope discussed with @mattdjerome on the issue.
- Real download failures (e.g. transient API errors) are recorded in `_failures.yaml` like any other backup failure, and participate in the existing partial-failure exit code.

## Implementation
- Reuses the existing `jcdsDownloadFile`/`jcdsFileData` helpers in `pro_jcds.go` (presigned-URL fetch + 403-retry-once logic) instead of reimplementing them.
- Extracted the `GET /v1/jcds/files` + unmarshal step (previously inlined in `jcds sync`) into a shared `jcdsListFiles` helper, now used by both `jcds sync` and the new backup path.

## Test plan
- [x] `make build && make lint && make test` all pass
- [x] New tests: happy-path download, skip-when-not-on-JCDS, download-failure handling, no-op when `packages` is excluded via `--resources`, and default-off behavior when the flag isn't passed