### PR TITLE
Handle duplicate computer serial numbers (fix silent --serial resolution + surface duplicates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ See the [Setup Guide](https://github.com/Jamf-Concepts/jamf-cli/wiki/Setup-Guide
 - **`--field`** — Extract a single field from any response: `jamf-cli pro comp list --field id`
 - **`apply`** — Name-based upsert: creates if new, replaces if existing (with confirmation)
 - **`patch`** — JSON Merge Patch (RFC 7386): update individual fields without a full replace. Use `--set key=value` for scalar fields or pipe a merge-patch document. Accepts `--name`, `--serial`, `--udid` (resource-dependent) in place of an ID. `--scaffold` prints the patchable field template
-- **`--name` flag** — `get`, `update`, `delete`, and `patch` commands all accept `--name` (and resource-specific alternates like `--serial`, `--udid`) in place of a positional ID
+- **`--name` flag** — `get`, `update`, `delete`, and `patch` commands all accept `--name` (and resource-specific alternates like `--serial`, `--udid`) in place of a positional ID. When the value matches more than one record (e.g. two computers sharing a serial after a logic-board swap), the lookup fails with a usage error under `--no-input` (or a non-terminal stdin) and prompts interactively otherwise — it never silently picks one. Run `jamf-cli pro report duplicate-serials` to list the colliding records
 - **`--scaffold`** — Print JSON templates for create/update commands with example values
 - **Five output formats** — `table`, `json`, `csv`, `yaml`, `plain`
 - **Auto-pagination** — `--all` fetches every page; `--limit` caps results

--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -1902,13 +1902,15 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 			var resolvedPatchID string
 {{ range $.LookupFields }}
 			if flag{{ toCamel .Flag }} != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "{{ nameLookupPath $ }}", "{{ .RSQLField }}", "{{ lookupIDField $ }}", flag{{ toCamel .Flag }})
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "{{ nameLookupPath $ }}", "{{ .RSQLField }}", "{{ lookupIDField $ }}", flag{{ toCamel .Flag }}, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --{{ .Flag }} %q: %w", flag{{ toCamel .Flag }}, err)
 				}
 				resolvedPatchID = rid
 			} else {{ end }}if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "{{ nameLookupPath $ }}", "{{ $.NameField }}", "{{ lookupIDField $ }}", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "{{ nameLookupPath $ }}", "{{ $.NameField }}", "{{ lookupIDField $ }}", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1939,7 +1941,8 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 					return fmt.Errorf("no {{ $.NameSingular }} found with --{{ .Flag }} %q", flag{{ toCamel .Flag }})
 				}
 {{- else }}
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "{{ nameLookupPath $ }}", "{{ .RSQLField }}", "{{ lookupIDField $ }}", flag{{ toCamel .Flag }})
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "{{ nameLookupPath $ }}", "{{ .RSQLField }}", "{{ lookupIDField $ }}", flag{{ toCamel .Flag }}, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --{{ .Flag }} %q: %w", flag{{ toCamel .Flag }}, err)
 				}
@@ -1959,7 +1962,8 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 					return fmt.Errorf("no {{ $.NameSingular }} found with {{ $.NameField }} %q", flagName)
 				}
 {{- else }}
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "{{ nameLookupPath $ }}", "{{ $.NameField }}", "{{ lookupIDField $ }}", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "{{ nameLookupPath $ }}", "{{ $.NameField }}", "{{ lookupIDField $ }}", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -2918,25 +2922,26 @@ func batchDeleteError(cmd *cobra.Command, succeeded, failed int, firstErr error,
 		fmt.Sprintf("%d of %d %s failed", failed, succeeded+failed, noun))
 }
 
-// resolveNameToID looks up a resource by name using a filtered list call and
-// returns its ID. This enables --name as an alternative to positional ID args
-// on get commands. The nameField parameter specifies the filter field
-// (usually "name", but some resources use "displayName"). The idField parameter
-// specifies which response property holds the identifier (usually "id", but some
-// resources use "templateId", "groupId", etc.).
-func resolveNameToID(ctx context.Context, client registry.HTTPClient, listPath, nameField, idField, name string) (string, error) {
-	filterPath := fmt.Sprintf("%s?filter=%s&page-size=1",
-		listPath, url.QueryEscape(fmt.Sprintf(` + "`" + `%s=="%s"` + "`" + `, nameField, name)))
+// lookupMatchingIDs looks up resources whose nameField equals name and returns
+// every matching resource's idField value. It fetches up to 100 candidates so
+// callers can detect duplicate-name/serial collisions (e.g. two computer records
+// sharing a serial after a logic-board swap), and re-fetches unfiltered when an
+// endpoint ignores the RSQL filter param (e.g. prestages). The name is escaped
+// to prevent RSQL injection. Returns an empty slice when nothing matches.
+func lookupMatchingIDs(ctx context.Context, client registry.HTTPClient, listPath, nameField, idField, name string) ([]string, error) {
+	escapedName := strings.ReplaceAll(name, ` + "`" + `"` + "`" + `, ` + "`" + `\"` + "`" + `)
+	filterPath := fmt.Sprintf("%s?filter=%s&page-size=100",
+		listPath, url.QueryEscape(fmt.Sprintf(` + "`" + `%s=="%s"` + "`" + `, nameField, escapedName)))
 
 	resp, err := client.Do(ctx, "GET", filterPath, nil)
 	if err != nil {
-		return "", fmt.Errorf("looking up %q: %w", name, err)
+		return nil, fmt.Errorf("looking up %q: %w", name, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
 	if err != nil {
-		return "", fmt.Errorf("reading lookup response: %w", err)
+		return nil, fmt.Errorf("reading lookup response: %w", err)
 	}
 
 	// Paginated response: {"totalCount": N, "results": [{...}]}
@@ -2948,18 +2953,18 @@ func resolveNameToID(ctx context.Context, client registry.HTTPClient, listPath, 
 		// Some endpoints return plain arrays instead of paginated objects
 		var arr []json.RawMessage
 		if jsonErr := json.Unmarshal(body, &arr); jsonErr != nil {
-			return "", fmt.Errorf("parsing lookup response: %w", err)
+			return nil, fmt.Errorf("parsing lookup response: %w", err)
 		}
 		data.Results = arr
 		data.TotalCount = len(arr)
 	}
 
 	if data.TotalCount == 0 || len(data.Results) == 0 {
-		return "", fmt.Errorf("no resource found with name %q", name)
+		return nil, nil
 	}
 
 	// Client-side filter: some endpoints ignore RSQL filter params (e.g. prestages).
-	// Always verify the returned result actually matches the requested name.
+	// Always verify the returned results actually match the requested name.
 	results := filterResultsByName(data.Results, nameField, name)
 	if len(results) == 0 && data.TotalCount > len(data.Results) {
 		// RSQL was likely ignored and we only got the first page. Re-fetch all results.
@@ -2976,19 +2981,61 @@ func resolveNameToID(ctx context.Context, client registry.HTTPClient, listPath, 
 			}
 		}
 	}
-	if len(results) == 0 {
+
+	ids := make([]string, 0, len(results))
+	for _, raw := range results {
+		var obj map[string]any
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			continue
+		}
+		if id := extractIDString(obj, idField); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
+
+// pickMatchingID collapses a set of lookup candidates to a single ID. One match
+// returns immediately. Several matches (duplicate names/serials) error under
+// --no-input, otherwise prompt the user to choose — so an ambiguous lookup can
+// never silently target the wrong record.
+func pickMatchingID(ids []string, name string, noInput bool) (string, error) {
+	if len(ids) == 1 {
+		return ids[0], nil
+	}
+	if noInput {
+		return "", fmt.Errorf("multiple resources found matching %q (IDs: %s); resolve the duplicates or target a specific ID", name, strings.Join(ids, ", "))
+	}
+	fmt.Fprintf(os.Stderr, "Multiple resources found matching %q:\n", name)
+	for i, id := range ids {
+		fmt.Fprintf(os.Stderr, "  [%d] ID: %s\n", i+1, id)
+	}
+	fmt.Fprintf(os.Stderr, "Enter number to select (or 0 to cancel): ")
+	var choice int
+	if _, err := fmt.Fscan(os.Stdin, &choice); err != nil || choice < 1 || choice > len(ids) {
+		return "", fmt.Errorf("aborted")
+	}
+	return ids[choice-1], nil
+}
+
+// resolveNameToID looks up a resource by name (or serial/udid) and returns its
+// single matching ID. This enables --name/--serial/--udid as an alternative to
+// positional ID args on get/update/patch commands. The nameField parameter
+// specifies the filter field (usually "name", but some resources use
+// "displayName"). The idField parameter specifies which response property holds
+// the identifier (usually "id", but some resources use "templateId", "groupId",
+// etc.). Errors when nothing matches, and — unlike a naive first-match lookup —
+// errors (or prompts) when several records share the value, so duplicate serial
+// numbers can never silently target the wrong record.
+func resolveNameToID(ctx context.Context, client registry.HTTPClient, listPath, nameField, idField, name string, noInput bool) (string, error) {
+	ids, err := lookupMatchingIDs(ctx, client, listPath, nameField, idField, name)
+	if err != nil {
+		return "", err
+	}
+	if len(ids) == 0 {
 		return "", fmt.Errorf("no resource found with name %q", name)
 	}
-
-	var first map[string]any
-	if err := json.Unmarshal(results[0], &first); err != nil {
-		return "", fmt.Errorf("parsing lookup result: %w", err)
-	}
-
-	if id := extractIDString(first, idField); id != "" {
-		return id, nil
-	}
-	return "", fmt.Errorf("resource %q has no %s field", name, idField)
+	return pickMatchingID(ids, name, noInput)
 }
 
 // extractIDString extracts the named identifier field from a JSON object as a string.
@@ -3343,95 +3390,19 @@ func extractJSONField(data []byte, field string) (string, error) {
 	return s, nil
 }
 
-// resolveNameToIDForApply looks up a resource by name and returns its ID.
-// Unlike resolveNameToID, it fetches enough results to detect collisions.
-// Returns ("", nil) when no resource is found (caller should create).
-// Returns (id, nil) when exactly one match is found.
-// Returns ("", error) when multiple matches or lookup fails.
+// resolveNameToIDForApply is resolveNameToID for upsert flows: a no-match returns
+// ("", nil) so the caller creates the resource instead of erroring. Collisions
+// are handled identically to resolveNameToID (error under --no-input, else prompt),
+// so a duplicate name never silently replaces the wrong record.
 func resolveNameToIDForApply(ctx context.Context, client registry.HTTPClient, listPath, nameField, idField, name string, noInput bool) (string, error) {
-	// Escape double quotes in name to prevent RSQL injection
-	escapedName := strings.ReplaceAll(name, ` + "`" + `"` + "`" + `, ` + "`" + `\"` + "`" + `)
-	filterPath := fmt.Sprintf("%s?filter=%s&page-size=100",
-		listPath, url.QueryEscape(fmt.Sprintf(` + "`" + `%s=="%s"` + "`" + `, nameField, escapedName)))
-
-	resp, err := client.Do(ctx, "GET", filterPath, nil)
+	ids, err := lookupMatchingIDs(ctx, client, listPath, nameField, idField, name)
 	if err != nil {
-		return "", fmt.Errorf("looking up %q: %w", name, err)
+		return "", err
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return "", fmt.Errorf("reading lookup response: %w", err)
-	}
-
-	var data struct {
-		TotalCount int               ` + "`" + `json:"totalCount"` + "`" + `
-		Results    []json.RawMessage ` + "`" + `json:"results"` + "`" + `
-	}
-	if err := json.Unmarshal(body, &data); err != nil {
-		var arr []json.RawMessage
-		if jsonErr := json.Unmarshal(body, &arr); jsonErr != nil {
-			return "", fmt.Errorf("parsing lookup response: %w", err)
-		}
-		data.Results = arr
-		data.TotalCount = len(arr)
-	}
-
-	if data.TotalCount == 0 || len(data.Results) == 0 {
+	if len(ids) == 0 {
 		return "", nil // Not found — caller should create
 	}
-
-	// Client-side filter: some endpoints ignore RSQL filter params (e.g. prestages).
-	// Always apply exact name matching to guard against false positives.
-	results := filterResultsByName(data.Results, nameField, name)
-	if len(results) == 0 {
-		return "", nil // Not found — caller should create
-	}
-
-	// Parse results to extract IDs
-	type applyMatch struct {
-		id string
-	}
-	var matches []applyMatch
-	for _, raw := range results {
-		var obj map[string]any
-		if err := json.Unmarshal(raw, &obj); err != nil {
-			continue
-		}
-		if id := extractIDString(obj, idField); id != "" {
-			matches = append(matches, applyMatch{id: id})
-		}
-	}
-
-	if len(matches) == 0 {
-		return "", nil
-	}
-
-	if len(matches) == 1 {
-		return matches[0].id, nil
-	}
-
-	// Collision: multiple resources with the same name
-	if noInput {
-		ids := make([]string, len(matches))
-		for i, m := range matches {
-			ids[i] = m.id
-		}
-		return "", fmt.Errorf("multiple resources found with name %q (IDs: %s); resolve duplicates or use update with a specific ID", name, strings.Join(ids, ", "))
-	}
-
-	// Interactive: prompt user to pick
-	fmt.Fprintf(os.Stderr, "Multiple resources found with name %q:\n", name)
-	for i, m := range matches {
-		fmt.Fprintf(os.Stderr, "  [%d] ID: %s\n", i+1, m.id)
-	}
-	fmt.Fprintf(os.Stderr, "Enter number to replace (or 0 to cancel): ")
-	var choice int
-	if _, err := fmt.Fscan(os.Stdin, &choice); err != nil || choice < 1 || choice > len(matches) {
-		return "", fmt.Errorf("aborted")
-	}
-	return matches[choice-1].id, nil
+	return pickMatchingID(ids, name, noInput)
 }
 
 

--- a/generator/parser/generator.go
+++ b/generator/parser/generator.go
@@ -358,6 +358,24 @@ func (g *Generator) Generate(resource *Resource) (string, error) {
 			}
 			return collectionPath(r.Operations)
 		},
+		// lookupFieldPath is nameLookupPath with a lookup field's Section query
+		// param appended (e.g. "?section=HARDWARE" for --serial), so the response
+		// actually carries the field being filtered on and the client-side
+		// exact-match safety net in filterResultsByName can verify it.
+		"lookupFieldPath": func(r *Resource, lf LookupField) string {
+			base := r.NameLookupPath
+			if base == "" {
+				base = collectionPath(r.Operations)
+			}
+			if lf.Section == "" {
+				return base
+			}
+			sep := "?"
+			if strings.Contains(base, "?") {
+				sep = "&"
+			}
+			return base + sep + "section=" + lf.Section
+		},
 		// lookupIDField returns the ID field to extract from nameLookupPath responses.
 		// Falls back to IDField when no separate lookup ID field is configured.
 		"lookupIDField": func(r *Resource) string {
@@ -1728,7 +1746,7 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 					} else {
 						var rid string
 {{ range $.LookupFields }}					if rid == "" {
-							id, lookupErr := resolveNameToIDForApply(reqCtx, ctx.Client, "{{ nameLookupPath $ }}", "{{ .RSQLField }}", "{{ lookupIDField $ }}", entry, noInputBulk)
+							id, lookupErr := resolveNameToIDForApply(reqCtx, ctx.Client, "{{ lookupFieldPath $ . }}", "{{ .RSQLField }}", "{{ lookupIDField $ }}", entry, noInputBulk)
 							if lookupErr != nil {
 								return fmt.Errorf("resolving %q via {{ .Flag }}: %w", entry, lookupErr)
 							}
@@ -1903,7 +1921,7 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 {{ range $.LookupFields }}
 			if flag{{ toCamel .Flag }} != "" {
 				noInput, _ := cmd.Flags().GetBool("no-input")
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "{{ nameLookupPath $ }}", "{{ .RSQLField }}", "{{ lookupIDField $ }}", flag{{ toCamel .Flag }}, noInput)
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "{{ lookupFieldPath $ . }}", "{{ .RSQLField }}", "{{ lookupIDField $ }}", flag{{ toCamel .Flag }}, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --{{ .Flag }} %q: %w", flag{{ toCamel .Flag }}, err)
 				}
@@ -1933,7 +1951,7 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 			if flag{{ toCamel .Flag }} != "" {
 {{- if $opIsDestructive }}
 				noInputLookup, _ := cmd.Flags().GetBool("no-input")
-				rid, err := resolveNameToIDForApply(reqCtx, ctx.Client, "{{ nameLookupPath $ }}", "{{ .RSQLField }}", "{{ lookupIDField $ }}", flag{{ toCamel .Flag }}, noInputLookup)
+				rid, err := resolveNameToIDForApply(reqCtx, ctx.Client, "{{ lookupFieldPath $ . }}", "{{ .RSQLField }}", "{{ lookupIDField $ }}", flag{{ toCamel .Flag }}, noInputLookup)
 				if err != nil {
 					return fmt.Errorf("looking up --{{ .Flag }} %q: %w", flag{{ toCamel .Flag }}, err)
 				}
@@ -1942,7 +1960,7 @@ func new{{ $.GoName }}{{ toCamel .Name }}Cmd(ctx *registry.CLIContext) *cobra.Co
 				}
 {{- else }}
 				noInput, _ := cmd.Flags().GetBool("no-input")
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "{{ nameLookupPath $ }}", "{{ .RSQLField }}", "{{ lookupIDField $ }}", flag{{ toCamel .Flag }}, noInput)
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "{{ lookupFieldPath $ . }}", "{{ .RSQLField }}", "{{ lookupIDField $ }}", flag{{ toCamel .Flag }}, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --{{ .Flag }} %q: %w", flag{{ toCamel .Flag }}, err)
 				}
@@ -2891,6 +2909,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/exitcode"
@@ -2929,9 +2948,18 @@ func batchDeleteError(cmd *cobra.Command, succeeded, failed int, firstErr error,
 // endpoint ignores the RSQL filter param (e.g. prestages). The name is escaped
 // to prevent RSQL injection. Returns an empty slice when nothing matches.
 func lookupMatchingIDs(ctx context.Context, client registry.HTTPClient, listPath, nameField, idField, name string) ([]string, error) {
-	escapedName := strings.ReplaceAll(name, ` + "`" + `"` + "`" + `, ` + "`" + `\"` + "`" + `)
-	filterPath := fmt.Sprintf("%s?filter=%s&page-size=100",
-		listPath, url.QueryEscape(fmt.Sprintf(` + "`" + `%s=="%s"` + "`" + `, nameField, escapedName)))
+	// Escape backslashes before quotes so a value ending in ` + "`" + `\` + "`" + ` can't
+	// neutralize the closing quote and break out of the RSQL string literal.
+	escapedName := strings.ReplaceAll(name, ` + "`" + `\` + "`" + `, ` + "`" + `\\` + "`" + `)
+	escapedName = strings.ReplaceAll(escapedName, ` + "`" + `"` + "`" + `, ` + "`" + `\"` + "`" + `)
+	// listPath may already carry a query string (e.g. "?section=HARDWARE" so the
+	// filtered field is present in the response) — append with & in that case.
+	sep := "?"
+	if strings.Contains(listPath, "?") {
+		sep = "&"
+	}
+	filterPath := fmt.Sprintf("%s%sfilter=%s&page-size=100",
+		listPath, sep, url.QueryEscape(fmt.Sprintf(` + "`" + `%s=="%s"` + "`" + `, nameField, escapedName)))
 
 	resp, err := client.Do(ctx, "GET", filterPath, nil)
 	if err != nil {
@@ -2968,7 +2996,7 @@ func lookupMatchingIDs(ctx context.Context, client registry.HTTPClient, listPath
 	results := filterResultsByName(data.Results, nameField, name)
 	if len(results) == 0 && data.TotalCount > len(data.Results) {
 		// RSQL was likely ignored and we only got the first page. Re-fetch all results.
-		allPath := fmt.Sprintf("%s?page-size=%d", listPath, data.TotalCount)
+		allPath := fmt.Sprintf("%s%spage-size=%d", listPath, sep, data.TotalCount)
 		allResp, err := client.Do(ctx, "GET", allPath, nil)
 		if err == nil {
 			allBody, _ := io.ReadAll(io.LimitReader(allResp.Body, 8<<20))
@@ -2983,14 +3011,24 @@ func lookupMatchingIDs(ctx context.Context, client registry.HTTPClient, listPath
 	}
 
 	ids := make([]string, 0, len(results))
+	skipped := 0
 	for _, raw := range results {
 		var obj map[string]any
 		if err := json.Unmarshal(raw, &obj); err != nil {
+			skipped++
 			continue
 		}
-		if id := extractIDString(obj, idField); id != "" {
-			ids = append(ids, id)
+		id := extractIDString(obj, idField)
+		if id == "" {
+			skipped++
+			continue
 		}
+		ids = append(ids, id)
+	}
+	// A matching record we can't resolve to an ID would silently shrink the
+	// candidate set and defeat collision detection — surface it instead.
+	if skipped > 0 {
+		return ids, fmt.Errorf("%d record(s) matched %q but could not be resolved to an ID (missing %q field); target a specific ID", skipped, name, idField)
 	}
 	return ids, nil
 }
@@ -3003,8 +3041,13 @@ func pickMatchingID(ids []string, name string, noInput bool) (string, error) {
 	if len(ids) == 1 {
 		return ids[0], nil
 	}
-	if noInput {
-		return "", fmt.Errorf("multiple resources found matching %q (IDs: %s); resolve the duplicates or target a specific ID", name, strings.Join(ids, ", "))
+	// Ambiguous — several records share the value. Only prompt when a human can
+	// actually answer: --no-input, or a non-terminal stdin (CI, pipes, non-pty
+	// SSH, process supervisors) must fail fast rather than block on a read that
+	// will never be satisfied. Usage exit code marks it as a fix-the-invocation
+	// condition, distinct from a generic failure, per agent_context.md.
+	if noInput || !term.IsTerminal(int(os.Stdin.Fd())) {
+		return "", exitcode.New(exitcode.Usage, fmt.Sprintf("multiple resources found matching %q (IDs: %s); resolve the duplicates or target a specific ID", name, strings.Join(ids, ", ")))
 	}
 	fmt.Fprintf(os.Stderr, "Multiple resources found matching %q:\n", name)
 	for i, id := range ids {

--- a/generator/parser/parser.go
+++ b/generator/parser/parser.go
@@ -49,7 +49,11 @@ func ApplyNameOverrides(resources []*Resource) {
 // (after DeduplicateVersioned and ApplyNameOverrides).
 var resourceLookupFields = map[string][]LookupField{
 	"computers-inventory": {
-		{Flag: "serial", RSQLField: "hardware.serialNumber", Desc: "Look up computer by serial number"},
+		// hardware.serialNumber lives in the HARDWARE section, which the default
+		// (GENERAL) response omits — request it so filterResultsByName can verify
+		// the match rather than trusting the server's RSQL filter blindly. udid and
+		// id are top-level and always present, so udid needs no section.
+		{Flag: "serial", RSQLField: "hardware.serialNumber", Desc: "Look up computer by serial number", Section: "HARDWARE"},
 		{Flag: "udid", RSQLField: "udid", Desc: "Look up computer by UDID"},
 	},
 	// /v2/mobile-devices/detail (the lookup path) uses top-level "serialNumber"

--- a/generator/parser/types.go
+++ b/generator/parser/types.go
@@ -8,6 +8,7 @@ type LookupField struct {
 	Flag      string // CLI flag name (e.g. "serial")
 	RSQLField string // RSQL filter field path (e.g. "hardware.serialNumber")
 	Desc      string // Flag description shown in --help
+	Section   string // Optional inventory section to request so the RSQLField is present in the response (e.g. "HARDWARE"); empty when the field is in the default section.
 }
 
 // FileField declares a resource field whose value is sourced from a local file

--- a/internal/commands/agent_context.md
+++ b/internal/commands/agent_context.md
@@ -54,6 +54,12 @@ React to a non-zero exit without parsing the message:
 Errors print a one-line remediation hint and, with `-o json`, a structured error
 envelope.
 
+An ambiguous `--name`/`--serial`/`--udid` lookup (the value matches more than one
+record — e.g. duplicate computer serials after a logic-board swap) exits `usage`
+(2), not `general` (1): re-run against a specific `<id>`, or query
+`jamf-cli pro report duplicate-serials` to list the colliding records. Under
+`--no-input` or a non-terminal stdin this fails fast rather than prompting.
+
 ## Destructive commands
 
 Commands that delete, erase, wipe, lock, restart, shut down, unmanage, or flush

--- a/internal/commands/pro/generated/account_groups.go
+++ b/internal/commands/pro/generated/account_groups.go
@@ -207,7 +207,8 @@ func newAccountGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/account-groups", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/account-groups", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/adcs_settings.go
+++ b/internal/commands/pro/generated/adcs_settings.go
@@ -65,7 +65,8 @@ func newAdcsSettingsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/adcs-settings", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/adcs-settings", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -418,7 +419,8 @@ func newAdcsSettingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/adcs-settings", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/adcs-settings", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -588,7 +590,8 @@ func newAdcsSettingsAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/adcs-settings", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/adcs-settings", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -812,7 +815,8 @@ func newAdcsSettingsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedPatchID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/adcs-settings", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/adcs-settings", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -905,7 +909,8 @@ func newAdcsSettingsDependenciesCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/adcs-settings", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/adcs-settings", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/advanced_mobile_device_searches.go
+++ b/internal/commands/pro/generated/advanced_mobile_device_searches.go
@@ -101,7 +101,8 @@ func newAdvancedMobileDeviceSearchesGetCmd(ctx *registry.CLIContext) *cobra.Comm
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/advanced-mobile-device-searches", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/advanced-mobile-device-searches", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -255,7 +256,8 @@ func newAdvancedMobileDeviceSearchesUpdateCmd(ctx *registry.CLIContext) *cobra.C
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/advanced-mobile-device-searches", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/advanced-mobile-device-searches", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/advanced_user_content_searches.go
+++ b/internal/commands/pro/generated/advanced_user_content_searches.go
@@ -99,7 +99,8 @@ func newAdvancedUserContentSearchesGetCmd(ctx *registry.CLIContext) *cobra.Comma
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/advanced-user-content-searches", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/advanced-user-content-searches", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -253,7 +254,8 @@ func newAdvancedUserContentSearchesUpdateCmd(ctx *registry.CLIContext) *cobra.Co
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/advanced-user-content-searches", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/advanced-user-content-searches", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/api_integrations.go
+++ b/internal/commands/pro/generated/api_integrations.go
@@ -216,7 +216,8 @@ func newApiIntegrationsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/api-integrations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/api-integrations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -370,7 +371,8 @@ func newApiIntegrationsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/api-integrations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/api-integrations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -693,7 +695,8 @@ func newApiIntegrationsClientCredentialsCmd(ctx *registry.CLIContext) *cobra.Com
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/api-integrations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/api-integrations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/api_roles.go
+++ b/internal/commands/pro/generated/api_roles.go
@@ -215,7 +215,8 @@ func newApiRolesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/api-roles", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/api-roles", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -359,7 +360,8 @@ func newApiRolesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/api-roles", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/api-roles", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/app_installer_deployments.go
+++ b/internal/commands/pro/generated/app_installer_deployments.go
@@ -206,7 +206,8 @@ func newAppInstallerDeploymentsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-installers/deployments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-installers/deployments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -370,7 +371,8 @@ func newAppInstallerDeploymentsUpdateCmd(ctx *registry.CLIContext) *cobra.Comman
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-installers/deployments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-installers/deployments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -693,7 +695,8 @@ func newAppInstallerDeploymentsComputersCmd(ctx *registry.CLIContext) *cobra.Com
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-installers/deployments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-installers/deployments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -747,7 +750,8 @@ func newAppInstallerDeploymentsInstallationRetryCmd(ctx *registry.CLIContext) *c
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-installers/deployments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-installers/deployments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -818,7 +822,8 @@ func newAppInstallerDeploymentsInstallationSummaryCmd(ctx *registry.CLIContext) 
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-installers/deployments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-installers/deployments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/app_installer_titles.go
+++ b/internal/commands/pro/generated/app_installer_titles.go
@@ -195,7 +195,8 @@ func newAppInstallerTitlesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-installers/titles", "titleName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-installers/titles", "titleName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/app_requests.go
+++ b/internal/commands/pro/generated/app_requests.go
@@ -100,7 +100,8 @@ func newAppRequestsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-request/form-input-fields", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/app-request/form-input-fields", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/buildings.go
+++ b/internal/commands/pro/generated/buildings.go
@@ -220,7 +220,8 @@ func newBuildingsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/buildings", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/buildings", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -374,7 +375,8 @@ func newBuildingsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/buildings", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/buildings", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -805,7 +807,8 @@ func newBuildingsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/buildings", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/buildings", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -975,7 +978,8 @@ func newBuildingsAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/buildings", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/buildings", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1194,7 +1198,8 @@ func newBuildingsHistoryExportCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/buildings", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/buildings", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/categories.go
+++ b/internal/commands/pro/generated/categories.go
@@ -218,7 +218,8 @@ func newCategoriesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/categories", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/categories", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -362,7 +363,8 @@ func newCategoriesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/categories", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/categories", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -793,7 +795,8 @@ func newCategoriesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/categories", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/categories", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -963,7 +966,8 @@ func newCategoriesAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/categories", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/categories", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/certificate_authorities.go
+++ b/internal/commands/pro/generated/certificate_authorities.go
@@ -56,7 +56,8 @@ func newCertificateAuthoritiesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/certificate-authority", "name", "algorithmOid", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/certificate-authority", "name", "algorithmOid", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -262,7 +263,8 @@ func newCertificateAuthoritiesDerByIdCmd(ctx *registry.CLIContext) *cobra.Comman
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/certificate-authority", "name", "algorithmOid", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/certificate-authority", "name", "algorithmOid", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -338,7 +340,8 @@ func newCertificateAuthoritiesPemByIdCmd(ctx *registry.CLIContext) *cobra.Comman
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/certificate-authority", "name", "algorithmOid", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/certificate-authority", "name", "algorithmOid", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/classic_ldaps.go
+++ b/internal/commands/pro/generated/classic_ldaps.go
@@ -49,7 +49,8 @@ func newClassicLdapsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/classic-ldap", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/classic-ldap", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/cloud_azures.go
+++ b/internal/commands/pro/generated/cloud_azures.go
@@ -59,7 +59,8 @@ func newCloudAzuresGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/cloud-azure", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/cloud-azure", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -203,7 +204,8 @@ func newCloudAzuresUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/cloud-azure", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/cloud-azure", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/cloud_id_p_configurations.go
+++ b/internal/commands/pro/generated/cloud_id_p_configurations.go
@@ -205,7 +205,8 @@ func newCloudIdPConfigurationsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/cloud-idp", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/cloud-idp", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/cloud_ldaps.go
+++ b/internal/commands/pro/generated/cloud_ldaps.go
@@ -59,7 +59,8 @@ func newCloudLdapsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/cloud-ldaps", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/cloud-ldaps", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -205,7 +206,8 @@ func newCloudLdapsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/cloud-ldaps", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/cloud-ldaps", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/computer_extension_attributes.go
+++ b/internal/commands/pro/generated/computer_extension_attributes.go
@@ -222,7 +222,8 @@ func newComputerExtensionAttributesGetCmd(ctx *registry.CLIContext) *cobra.Comma
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/computer-extension-attributes", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/computer-extension-attributes", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -400,7 +401,8 @@ func newComputerExtensionAttributesUpdateCmd(ctx *registry.CLIContext) *cobra.Co
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/computer-extension-attributes", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/computer-extension-attributes", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -804,7 +806,8 @@ func newComputerExtensionAttributesHistoryCmd(ctx *registry.CLIContext) *cobra.C
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/computer-extension-attributes", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/computer-extension-attributes", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -974,7 +977,8 @@ func newComputerExtensionAttributesAddHistoryNoteCmd(ctx *registry.CLIContext) *
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/computer-extension-attributes", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/computer-extension-attributes", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1099,7 +1103,8 @@ func newComputerExtensionAttributesDataDependencyCmd(ctx *registry.CLIContext) *
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/computer-extension-attributes", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/computer-extension-attributes", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1153,7 +1158,8 @@ func newComputerExtensionAttributesDownloadCmd(ctx *registry.CLIContext) *cobra.
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/computer-extension-attributes", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/computer-extension-attributes", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/computer_groups.go
+++ b/internal/commands/pro/generated/computer_groups.go
@@ -49,7 +49,8 @@ func newComputerGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-groups/smart-group-membership", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-groups/smart-group-membership", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/computer_groups_smart_groups.go
+++ b/internal/commands/pro/generated/computer_groups_smart_groups.go
@@ -216,7 +216,8 @@ func newComputerGroupsSmartGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-groups/smart-groups", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-groups/smart-groups", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -370,7 +371,8 @@ func newComputerGroupsSmartGroupsUpdateCmd(ctx *registry.CLIContext) *cobra.Comm
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-groups/smart-groups", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-groups/smart-groups", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/computer_groups_static_groups.go
+++ b/internal/commands/pro/generated/computer_groups_static_groups.go
@@ -215,7 +215,8 @@ func newComputerGroupsStaticGroupsGetCmd(ctx *registry.CLIContext) *cobra.Comman
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-groups/static-groups", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-groups/static-groups", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -368,7 +369,8 @@ func newComputerGroupsStaticGroupsUpdateCmd(ctx *registry.CLIContext) *cobra.Com
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-groups/static-groups", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-groups/static-groups", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/computer_prestages.go
+++ b/internal/commands/pro/generated/computer_prestages.go
@@ -210,7 +210,8 @@ func newComputerPrestagesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-prestages", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-prestages", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -435,7 +436,8 @@ func newComputerPrestagesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-prestages", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computer-prestages", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/computers_inventory.go
+++ b/internal/commands/pro/generated/computers_inventory.go
@@ -246,7 +246,7 @@ func newComputersInventoryGetCmd(ctx *registry.CLIContext) *cobra.Command {
 
 			if flagSerial != "" {
 				noInput, _ := cmd.Flags().GetBool("no-input")
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory?section=HARDWARE", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
@@ -440,7 +440,7 @@ func newComputersInventoryDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 					} else {
 						var rid string
 						if rid == "" {
-							id, lookupErr := resolveNameToIDForApply(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", entry, noInputBulk)
+							id, lookupErr := resolveNameToIDForApply(reqCtx, ctx.Client, "/v3/computers-inventory?section=HARDWARE", "hardware.serialNumber", "id", entry, noInputBulk)
 							if lookupErr != nil {
 								return fmt.Errorf("resolving %q via serial: %w", entry, lookupErr)
 							}
@@ -597,7 +597,7 @@ func newComputersInventoryDeleteCmd(ctx *registry.CLIContext) *cobra.Command {
 
 			if flagSerial != "" {
 				noInputLookup, _ := cmd.Flags().GetBool("no-input")
-				rid, err := resolveNameToIDForApply(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInputLookup)
+				rid, err := resolveNameToIDForApply(reqCtx, ctx.Client, "/v3/computers-inventory?section=HARDWARE", "hardware.serialNumber", "id", flagSerial, noInputLookup)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
@@ -770,7 +770,7 @@ func newComputersInventoryPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 
 			if flagSerial != "" {
 				noInput, _ := cmd.Flags().GetBool("no-input")
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory?section=HARDWARE", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
@@ -1029,7 +1029,7 @@ func newComputersInventoryUploadCmd(ctx *registry.CLIContext) *cobra.Command {
 
 			if flagSerial != "" {
 				noInput, _ := cmd.Flags().GetBool("no-input")
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory?section=HARDWARE", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
@@ -1127,7 +1127,7 @@ func newComputersInventoryDownloadCmd(ctx *registry.CLIContext) *cobra.Command {
 
 			if flagSerial != "" {
 				noInput, _ := cmd.Flags().GetBool("no-input")
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory?section=HARDWARE", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
@@ -1216,7 +1216,7 @@ func newComputersInventoryFilevaultByIdCmd(ctx *registry.CLIContext) *cobra.Comm
 
 			if flagSerial != "" {
 				noInput, _ := cmd.Flags().GetBool("no-input")
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory?section=HARDWARE", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
@@ -1290,7 +1290,7 @@ func newComputersInventoryViewDeviceLockPinCmd(ctx *registry.CLIContext) *cobra.
 
 			if flagSerial != "" {
 				noInput, _ := cmd.Flags().GetBool("no-input")
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory?section=HARDWARE", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
@@ -1364,7 +1364,7 @@ func newComputersInventoryViewRecoveryLockPasswordCmd(ctx *registry.CLIContext) 
 
 			if flagSerial != "" {
 				noInput, _ := cmd.Flags().GetBool("no-input")
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory?section=HARDWARE", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}

--- a/internal/commands/pro/generated/computers_inventory.go
+++ b/internal/commands/pro/generated/computers_inventory.go
@@ -245,19 +245,22 @@ func newComputersInventoryGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			var resolvedID string
 
 			if flagSerial != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
 				resolvedID = rid
 			} else if flagUdid != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --udid %q: %w", flagUdid, err)
 				}
 				resolvedID = rid
 			} else if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -766,19 +769,22 @@ func newComputersInventoryPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var resolvedPatchID string
 
 			if flagSerial != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
 				resolvedPatchID = rid
 			} else if flagUdid != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --udid %q: %w", flagUdid, err)
 				}
 				resolvedPatchID = rid
 			} else if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1022,19 +1028,22 @@ func newComputersInventoryUploadCmd(ctx *registry.CLIContext) *cobra.Command {
 			var resolvedID string
 
 			if flagSerial != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
 				resolvedID = rid
 			} else if flagUdid != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --udid %q: %w", flagUdid, err)
 				}
 				resolvedID = rid
 			} else if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1117,19 +1126,22 @@ func newComputersInventoryDownloadCmd(ctx *registry.CLIContext) *cobra.Command {
 			var resolvedID string
 
 			if flagSerial != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
 				resolvedID = rid
 			} else if flagUdid != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --udid %q: %w", flagUdid, err)
 				}
 				resolvedID = rid
 			} else if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1203,19 +1215,22 @@ func newComputersInventoryFilevaultByIdCmd(ctx *registry.CLIContext) *cobra.Comm
 			var resolvedID string
 
 			if flagSerial != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
 				resolvedID = rid
 			} else if flagUdid != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --udid %q: %w", flagUdid, err)
 				}
 				resolvedID = rid
 			} else if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1274,19 +1289,22 @@ func newComputersInventoryViewDeviceLockPinCmd(ctx *registry.CLIContext) *cobra.
 			var resolvedID string
 
 			if flagSerial != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
 				resolvedID = rid
 			} else if flagUdid != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --udid %q: %w", flagUdid, err)
 				}
 				resolvedID = rid
 			} else if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1345,19 +1363,22 @@ func newComputersInventoryViewRecoveryLockPasswordCmd(ctx *registry.CLIContext) 
 			var resolvedID string
 
 			if flagSerial != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "hardware.serialNumber", "id", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
 				resolvedID = rid
 			} else if flagUdid != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "udid", "id", flagUdid, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --udid %q: %w", flagUdid, err)
 				}
 				resolvedID = rid
 			} else if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/computers-inventory", "general.name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/departments.go
+++ b/internal/commands/pro/generated/departments.go
@@ -218,7 +218,8 @@ func newDepartmentsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/departments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/departments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -360,7 +361,8 @@ func newDepartmentsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/departments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/departments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -791,7 +793,8 @@ func newDepartmentsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/departments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/departments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -961,7 +964,8 @@ func newDepartmentsAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/departments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/departments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/device_compliance_informations.go
+++ b/internal/commands/pro/generated/device_compliance_informations.go
@@ -89,7 +89,8 @@ func newDeviceComplianceInformationsGetCmd(ctx *registry.CLIContext) *cobra.Comm
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/conditional-access/device-compliance-information/computer", "name", "deviceId", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/conditional-access/device-compliance-information/computer", "name", "deviceId", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/device_enrollment_instances.go
+++ b/internal/commands/pro/generated/device_enrollment_instances.go
@@ -216,7 +216,8 @@ func newDeviceEnrollmentInstancesGetCmd(ctx *registry.CLIContext) *cobra.Command
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -403,7 +404,8 @@ func newDeviceEnrollmentInstancesUpdateCmd(ctx *registry.CLIContext) *cobra.Comm
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -733,7 +735,8 @@ func newDeviceEnrollmentInstancesHistoryCmd(ctx *registry.CLIContext) *cobra.Com
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -903,7 +906,8 @@ func newDeviceEnrollmentInstancesAddHistoryNoteCmd(ctx *registry.CLIContext) *co
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1032,7 +1036,8 @@ func newDeviceEnrollmentInstancesDevicesCmd(ctx *registry.CLIContext) *cobra.Com
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1096,7 +1101,8 @@ func newDeviceEnrollmentInstancesDisownCmd(ctx *registry.CLIContext) *cobra.Comm
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/device-enrollments", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/digi_cert_settings.go
+++ b/internal/commands/pro/generated/digi_cert_settings.go
@@ -61,7 +61,8 @@ func newDigiCertSettingsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/digicert/trust-lifecycle-manager", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/digicert/trust-lifecycle-manager", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -483,7 +484,8 @@ func newDigiCertSettingsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedPatchID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/digicert/trust-lifecycle-manager", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/digicert/trust-lifecycle-manager", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -576,7 +578,8 @@ func newDigiCertSettingsConnectionStatusCmd(ctx *registry.CLIContext) *cobra.Com
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/digicert/trust-lifecycle-manager", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/digicert/trust-lifecycle-manager", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -630,7 +633,8 @@ func newDigiCertSettingsDependenciesCmd(ctx *registry.CLIContext) *cobra.Command
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/digicert/trust-lifecycle-manager", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/digicert/trust-lifecycle-manager", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/distribution_points.go
+++ b/internal/commands/pro/generated/distribution_points.go
@@ -219,7 +219,8 @@ func newDistributionPointsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/distribution-points", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/distribution-points", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -403,7 +404,8 @@ func newDistributionPointsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/distribution-points", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/distribution-points", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -834,7 +836,8 @@ func newDistributionPointsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/distribution-points", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/distribution-points", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1004,7 +1007,8 @@ func newDistributionPointsAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.Com
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/distribution-points", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/distribution-points", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1117,7 +1121,8 @@ func newDistributionPointsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedPatchID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/distribution-points", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/distribution-points", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/dock_items.go
+++ b/internal/commands/pro/generated/dock_items.go
@@ -59,7 +59,8 @@ func newDockItemsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/dock-items", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/dock-items", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -205,7 +206,8 @@ func newDockItemsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/dock-items", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/dock-items", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/ebooks.go
+++ b/internal/commands/pro/generated/ebooks.go
@@ -203,7 +203,8 @@ func newEbooksGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/ebooks", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/ebooks", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -257,7 +258,8 @@ func newEbooksScopeCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/ebooks", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/ebooks", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/enrollment_customizations.go
+++ b/internal/commands/pro/generated/enrollment_customizations.go
@@ -216,7 +216,8 @@ func newEnrollmentCustomizationsGetCmd(ctx *registry.CLIContext) *cobra.Command 
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/enrollment-customizations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/enrollment-customizations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -364,7 +365,8 @@ func newEnrollmentCustomizationsUpdateCmd(ctx *registry.CLIContext) *cobra.Comma
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/enrollment-customizations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/enrollment-customizations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -697,7 +699,8 @@ func newEnrollmentCustomizationsHistoryCmd(ctx *registry.CLIContext) *cobra.Comm
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/enrollment-customizations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/enrollment-customizations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -863,7 +866,8 @@ func newEnrollmentCustomizationsAddHistoryNoteCmd(ctx *registry.CLIContext) *cob
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/enrollment-customizations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/enrollment-customizations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -994,7 +998,8 @@ func newEnrollmentCustomizationsDownloadCmd(ctx *registry.CLIContext) *cobra.Com
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/enrollment-customizations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/enrollment-customizations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1063,7 +1068,8 @@ func newEnrollmentCustomizationsPrestagesCmd(ctx *registry.CLIContext) *cobra.Co
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/enrollment-customizations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/enrollment-customizations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/enrollment_languages.go
+++ b/internal/commands/pro/generated/enrollment_languages.go
@@ -211,7 +211,8 @@ func newEnrollmentLanguagesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/enrollment/languages", "name", "languageCode", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/enrollment/languages", "name", "languageCode", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -324,7 +325,8 @@ func newEnrollmentLanguagesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/enrollment/languages", "name", "languageCode", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/enrollment/languages", "name", "languageCode", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/enrollment_settings.go
+++ b/internal/commands/pro/generated/enrollment_settings.go
@@ -220,7 +220,8 @@ func newEnrollmentSettingsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/enrollment/access-groups", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/enrollment/access-groups", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -376,7 +377,8 @@ func newEnrollmentSettingsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/enrollment/access-groups", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/enrollment/access-groups", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/groups.go
+++ b/internal/commands/pro/generated/groups.go
@@ -212,7 +212,8 @@ func newGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/groups", "groupName", "groupPlatformId", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/groups", "groupName", "groupPlatformId", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -502,7 +503,8 @@ func newGroupsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedPatchID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/groups", "groupName", "groupPlatformId", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/groups", "groupName", "groupPlatformId", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/icons.go
+++ b/internal/commands/pro/generated/icons.go
@@ -53,7 +53,8 @@ func newIconsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/icon", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/icon", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -167,7 +168,8 @@ func newIconsDownloadCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/icon", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/icon", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/inventory_preloads.go
+++ b/internal/commands/pro/generated/inventory_preloads.go
@@ -225,7 +225,8 @@ func newInventoryPreloadsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/inventory-preload/records", "serialNumber", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/inventory-preload/records", "serialNumber", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -413,7 +414,8 @@ func newInventoryPreloadsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/inventory-preload/records", "serialNumber", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/inventory-preload/records", "serialNumber", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/jamf_connects.go
+++ b/internal/commands/pro/generated/jamf_connects.go
@@ -220,7 +220,8 @@ func newJamfConnectsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/jamf-connect/config-profiles", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/jamf-connect/config-profiles", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/jamf_remote_assist_session_histories.go
+++ b/internal/commands/pro/generated/jamf_remote_assist_session_histories.go
@@ -210,7 +210,8 @@ func newJamfRemoteAssistSessionHistoriesGetCmd(ctx *registry.CLIContext) *cobra.
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/jamf-remote-assist/session", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/jamf-remote-assist/session", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/jcds.go
+++ b/internal/commands/pro/generated/jcds.go
@@ -98,7 +98,8 @@ func newJcdsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/jcds/files", "name", "fileName", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/jcds/files", "name", "fileName", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/log_flushings.go
+++ b/internal/commands/pro/generated/log_flushings.go
@@ -97,7 +97,8 @@ func newLogFlushingsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/log-flushing/task", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/log-flushing/task", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/managed_software_updates.go
+++ b/internal/commands/pro/generated/managed_software_updates.go
@@ -51,7 +51,8 @@ func newManagedSoftwareUpdatesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/managed-software-updates/update-statuses/computer-groups", "name", "osUpdatesStatusId", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/managed-software-updates/update-statuses/computer-groups", "name", "osUpdatesStatusId", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/managed_software_updates_plans.go
+++ b/internal/commands/pro/generated/managed_software_updates_plans.go
@@ -217,7 +217,8 @@ func newManagedSoftwareUpdatesPlansGetCmd(ctx *registry.CLIContext) *cobra.Comma
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/managed-software-updates/plans", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/managed-software-updates/plans", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -567,7 +568,8 @@ func newManagedSoftwareUpdatesPlansDeclarationsCmd(ctx *registry.CLIContext) *co
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/managed-software-updates/plans", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/managed-software-updates/plans", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -621,7 +623,8 @@ func newManagedSoftwareUpdatesPlansEventsCmd(ctx *registry.CLIContext) *cobra.Co
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/managed-software-updates/plans", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/managed-software-updates/plans", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/mdm_renewals.go
+++ b/internal/commands/pro/generated/mdm_renewals.go
@@ -56,7 +56,8 @@ func newMdmRenewalsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/mdm-renewal/device-common-details", "name", "clientManagementId", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/mdm-renewal/device-common-details", "name", "clientManagementId", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/mobile_device_extension_attributes.go
+++ b/internal/commands/pro/generated/mobile_device_extension_attributes.go
@@ -218,7 +218,8 @@ func newMobileDeviceExtensionAttributesGetCmd(ctx *registry.CLIContext) *cobra.C
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/mobile-device-extension-attributes", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/mobile-device-extension-attributes", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -380,7 +381,8 @@ func newMobileDeviceExtensionAttributesUpdateCmd(ctx *registry.CLIContext) *cobr
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/mobile-device-extension-attributes", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/mobile-device-extension-attributes", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -714,7 +716,8 @@ func newMobileDeviceExtensionAttributesHistoryCmd(ctx *registry.CLIContext) *cob
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/mobile-device-extension-attributes", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/mobile-device-extension-attributes", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -884,7 +887,8 @@ func newMobileDeviceExtensionAttributesAddHistoryNoteCmd(ctx *registry.CLIContex
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/mobile-device-extension-attributes", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/mobile-device-extension-attributes", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -956,7 +960,8 @@ func newMobileDeviceExtensionAttributesDataDependencyCmd(ctx *registry.CLIContex
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/mobile-device-extension-attributes", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/mobile-device-extension-attributes", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/mobile_device_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups.go
@@ -103,7 +103,8 @@ func newMobileDeviceGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-device-groups", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-device-groups", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_smart_groups.go
@@ -216,7 +216,8 @@ func newMobileDeviceGroupsSmartGroupsGetCmd(ctx *registry.CLIContext) *cobra.Com
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-device-groups/smart-groups", "groupName", "groupId", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-device-groups/smart-groups", "groupName", "groupId", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -370,7 +371,8 @@ func newMobileDeviceGroupsSmartGroupsUpdateCmd(ctx *registry.CLIContext) *cobra.
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-device-groups/smart-groups", "groupName", "groupId", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-device-groups/smart-groups", "groupName", "groupId", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/mobile_device_groups_static_groups.go
+++ b/internal/commands/pro/generated/mobile_device_groups_static_groups.go
@@ -216,7 +216,8 @@ func newMobileDeviceGroupsStaticGroupsGetCmd(ctx *registry.CLIContext) *cobra.Co
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-device-groups/static-groups", "groupName", "groupId", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-device-groups/static-groups", "groupName", "groupId", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -583,7 +584,8 @@ func newMobileDeviceGroupsStaticGroupsPatchCmd(ctx *registry.CLIContext) *cobra.
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedPatchID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-device-groups/static-groups", "groupName", "groupId", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-device-groups/static-groups", "groupName", "groupId", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/mobile_device_prestages.go
+++ b/internal/commands/pro/generated/mobile_device_prestages.go
@@ -216,7 +216,8 @@ func newMobileDevicePrestagesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/mobile-device-prestages", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/mobile-device-prestages", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -457,7 +458,8 @@ func newMobileDevicePrestagesUpdateCmd(ctx *registry.CLIContext) *cobra.Command 
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/mobile-device-prestages", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/mobile-device-prestages", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1028,7 +1030,8 @@ func newMobileDevicePrestagesHistoryCmd(ctx *registry.CLIContext) *cobra.Command
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/mobile-device-prestages", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/mobile-device-prestages", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1194,7 +1197,8 @@ func newMobileDevicePrestagesAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/mobile-device-prestages", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/mobile-device-prestages", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1266,7 +1270,8 @@ func newMobileDevicePrestagesAttachmentsCmd(ctx *registry.CLIContext) *cobra.Com
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/mobile-device-prestages", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/mobile-device-prestages", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1321,7 +1326,8 @@ func newMobileDevicePrestagesUploadCmd(ctx *registry.CLIContext) *cobra.Command 
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/mobile-device-prestages", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v3/mobile-device-prestages", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/mobile_devices.go
+++ b/internal/commands/pro/generated/mobile_devices.go
@@ -227,19 +227,22 @@ func newMobileDevicesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			var resolvedID string
 
 			if flagSerial != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-devices/detail", "serialNumber", "mobileDeviceId", flagSerial)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-devices/detail", "serialNumber", "mobileDeviceId", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
 				resolvedID = rid
 			} else if flagUdid != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-devices/detail", "udid", "mobileDeviceId", flagUdid)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-devices/detail", "udid", "mobileDeviceId", flagUdid, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --udid %q: %w", flagUdid, err)
 				}
 				resolvedID = rid
 			} else if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-devices/detail", "displayName", "mobileDeviceId", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-devices/detail", "displayName", "mobileDeviceId", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -332,19 +335,22 @@ func newMobileDevicesPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			var resolvedPatchID string
 
 			if flagSerial != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-devices/detail", "serialNumber", "mobileDeviceId", flagSerial)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-devices/detail", "serialNumber", "mobileDeviceId", flagSerial, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --serial %q: %w", flagSerial, err)
 				}
 				resolvedPatchID = rid
 			} else if flagUdid != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-devices/detail", "udid", "mobileDeviceId", flagUdid)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-devices/detail", "udid", "mobileDeviceId", flagUdid, noInput)
 				if err != nil {
 					return fmt.Errorf("looking up --udid %q: %w", flagUdid, err)
 				}
 				resolvedPatchID = rid
 			} else if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-devices/detail", "displayName", "mobileDeviceId", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/mobile-devices/detail", "displayName", "mobileDeviceId", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/packages.go
+++ b/internal/commands/pro/generated/packages.go
@@ -222,7 +222,8 @@ func newPackagesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/packages", "packageName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/packages", "packageName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -426,7 +427,8 @@ func newPackagesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/packages", "packageName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/packages", "packageName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -857,7 +859,8 @@ func newPackagesHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/packages", "packageName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/packages", "packageName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1027,7 +1030,8 @@ func newPackagesAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/packages", "packageName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/packages", "packageName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1246,7 +1250,8 @@ func newPackagesHistoryExportCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/packages", "packageName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/packages", "packageName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1364,7 +1369,8 @@ func newPackagesUploadCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/packages", "packageName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/packages", "packageName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/patch_policies.go
+++ b/internal/commands/pro/generated/patch_policies.go
@@ -567,7 +567,8 @@ func newPatchPoliciesDashboardCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-policies", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-policies", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -621,7 +622,8 @@ func newPatchPoliciesCreateDashboardCmd(ctx *registry.CLIContext) *cobra.Command
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-policies", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-policies", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/patch_software_title_configurations.go
+++ b/internal/commands/pro/generated/patch_software_title_configurations.go
@@ -111,7 +111,8 @@ func newPatchSoftwareTitleConfigurationsGetCmd(ctx *registry.CLIContext) *cobra.
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -462,7 +463,8 @@ func newPatchSoftwareTitleConfigurationsHistoryCmd(ctx *registry.CLIContext) *co
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -632,7 +634,8 @@ func newPatchSoftwareTitleConfigurationsAddHistoryNoteCmd(ctx *registry.CLIConte
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -731,7 +734,8 @@ func newPatchSoftwareTitleConfigurationsPatchCmd(ctx *registry.CLIContext) *cobr
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedPatchID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -830,7 +834,8 @@ func newPatchSoftwareTitleConfigurationsDefinitionsCmd(ctx *registry.CLIContext)
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -993,7 +998,8 @@ func newPatchSoftwareTitleConfigurationsDependenciesCmd(ctx *registry.CLIContext
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1056,7 +1062,8 @@ func newPatchSoftwareTitleConfigurationsExportReportCmd(ctx *registry.CLIContext
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1135,7 +1142,8 @@ func newPatchSoftwareTitleConfigurationsExtensionAttributesCmd(ctx *registry.CLI
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1189,7 +1197,8 @@ func newPatchSoftwareTitleConfigurationsCreateDashboardCmd(ctx *registry.CLICont
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1260,7 +1269,8 @@ func newPatchSoftwareTitleConfigurationsDashboardCmd(ctx *registry.CLIContext) *
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1320,7 +1330,8 @@ func newPatchSoftwareTitleConfigurationsPatchReportCmd(ctx *registry.CLIContext)
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1483,7 +1494,8 @@ func newPatchSoftwareTitleConfigurationsPatchSummaryCmd(ctx *registry.CLIContext
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1537,7 +1549,8 @@ func newPatchSoftwareTitleConfigurationsVersionsCmd(ctx *registry.CLIContext) *c
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/patch-software-title-configurations", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/registry.go
+++ b/internal/commands/pro/generated/registry.go
@@ -209,25 +209,26 @@ func batchDeleteError(cmd *cobra.Command, succeeded, failed int, firstErr error,
 		fmt.Sprintf("%d of %d %s failed", failed, succeeded+failed, noun))
 }
 
-// resolveNameToID looks up a resource by name using a filtered list call and
-// returns its ID. This enables --name as an alternative to positional ID args
-// on get commands. The nameField parameter specifies the filter field
-// (usually "name", but some resources use "displayName"). The idField parameter
-// specifies which response property holds the identifier (usually "id", but some
-// resources use "templateId", "groupId", etc.).
-func resolveNameToID(ctx context.Context, client registry.HTTPClient, listPath, nameField, idField, name string) (string, error) {
-	filterPath := fmt.Sprintf("%s?filter=%s&page-size=1",
-		listPath, url.QueryEscape(fmt.Sprintf(`%s=="%s"`, nameField, name)))
+// lookupMatchingIDs looks up resources whose nameField equals name and returns
+// every matching resource's idField value. It fetches up to 100 candidates so
+// callers can detect duplicate-name/serial collisions (e.g. two computer records
+// sharing a serial after a logic-board swap), and re-fetches unfiltered when an
+// endpoint ignores the RSQL filter param (e.g. prestages). The name is escaped
+// to prevent RSQL injection. Returns an empty slice when nothing matches.
+func lookupMatchingIDs(ctx context.Context, client registry.HTTPClient, listPath, nameField, idField, name string) ([]string, error) {
+	escapedName := strings.ReplaceAll(name, `"`, `\"`)
+	filterPath := fmt.Sprintf("%s?filter=%s&page-size=100",
+		listPath, url.QueryEscape(fmt.Sprintf(`%s=="%s"`, nameField, escapedName)))
 
 	resp, err := client.Do(ctx, "GET", filterPath, nil)
 	if err != nil {
-		return "", fmt.Errorf("looking up %q: %w", name, err)
+		return nil, fmt.Errorf("looking up %q: %w", name, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
 	if err != nil {
-		return "", fmt.Errorf("reading lookup response: %w", err)
+		return nil, fmt.Errorf("reading lookup response: %w", err)
 	}
 
 	// Paginated response: {"totalCount": N, "results": [{...}]}
@@ -239,18 +240,18 @@ func resolveNameToID(ctx context.Context, client registry.HTTPClient, listPath, 
 		// Some endpoints return plain arrays instead of paginated objects
 		var arr []json.RawMessage
 		if jsonErr := json.Unmarshal(body, &arr); jsonErr != nil {
-			return "", fmt.Errorf("parsing lookup response: %w", err)
+			return nil, fmt.Errorf("parsing lookup response: %w", err)
 		}
 		data.Results = arr
 		data.TotalCount = len(arr)
 	}
 
 	if data.TotalCount == 0 || len(data.Results) == 0 {
-		return "", fmt.Errorf("no resource found with name %q", name)
+		return nil, nil
 	}
 
 	// Client-side filter: some endpoints ignore RSQL filter params (e.g. prestages).
-	// Always verify the returned result actually matches the requested name.
+	// Always verify the returned results actually match the requested name.
 	results := filterResultsByName(data.Results, nameField, name)
 	if len(results) == 0 && data.TotalCount > len(data.Results) {
 		// RSQL was likely ignored and we only got the first page. Re-fetch all results.
@@ -267,19 +268,61 @@ func resolveNameToID(ctx context.Context, client registry.HTTPClient, listPath, 
 			}
 		}
 	}
-	if len(results) == 0 {
+
+	ids := make([]string, 0, len(results))
+	for _, raw := range results {
+		var obj map[string]any
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			continue
+		}
+		if id := extractIDString(obj, idField); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
+
+// pickMatchingID collapses a set of lookup candidates to a single ID. One match
+// returns immediately. Several matches (duplicate names/serials) error under
+// --no-input, otherwise prompt the user to choose — so an ambiguous lookup can
+// never silently target the wrong record.
+func pickMatchingID(ids []string, name string, noInput bool) (string, error) {
+	if len(ids) == 1 {
+		return ids[0], nil
+	}
+	if noInput {
+		return "", fmt.Errorf("multiple resources found matching %q (IDs: %s); resolve the duplicates or target a specific ID", name, strings.Join(ids, ", "))
+	}
+	fmt.Fprintf(os.Stderr, "Multiple resources found matching %q:\n", name)
+	for i, id := range ids {
+		fmt.Fprintf(os.Stderr, "  [%d] ID: %s\n", i+1, id)
+	}
+	fmt.Fprintf(os.Stderr, "Enter number to select (or 0 to cancel): ")
+	var choice int
+	if _, err := fmt.Fscan(os.Stdin, &choice); err != nil || choice < 1 || choice > len(ids) {
+		return "", fmt.Errorf("aborted")
+	}
+	return ids[choice-1], nil
+}
+
+// resolveNameToID looks up a resource by name (or serial/udid) and returns its
+// single matching ID. This enables --name/--serial/--udid as an alternative to
+// positional ID args on get/update/patch commands. The nameField parameter
+// specifies the filter field (usually "name", but some resources use
+// "displayName"). The idField parameter specifies which response property holds
+// the identifier (usually "id", but some resources use "templateId", "groupId",
+// etc.). Errors when nothing matches, and — unlike a naive first-match lookup —
+// errors (or prompts) when several records share the value, so duplicate serial
+// numbers can never silently target the wrong record.
+func resolveNameToID(ctx context.Context, client registry.HTTPClient, listPath, nameField, idField, name string, noInput bool) (string, error) {
+	ids, err := lookupMatchingIDs(ctx, client, listPath, nameField, idField, name)
+	if err != nil {
+		return "", err
+	}
+	if len(ids) == 0 {
 		return "", fmt.Errorf("no resource found with name %q", name)
 	}
-
-	var first map[string]any
-	if err := json.Unmarshal(results[0], &first); err != nil {
-		return "", fmt.Errorf("parsing lookup result: %w", err)
-	}
-
-	if id := extractIDString(first, idField); id != "" {
-		return id, nil
-	}
-	return "", fmt.Errorf("resource %q has no %s field", name, idField)
+	return pickMatchingID(ids, name, noInput)
 }
 
 // extractIDString extracts the named identifier field from a JSON object as a string.
@@ -634,95 +677,19 @@ func extractJSONField(data []byte, field string) (string, error) {
 	return s, nil
 }
 
-// resolveNameToIDForApply looks up a resource by name and returns its ID.
-// Unlike resolveNameToID, it fetches enough results to detect collisions.
-// Returns ("", nil) when no resource is found (caller should create).
-// Returns (id, nil) when exactly one match is found.
-// Returns ("", error) when multiple matches or lookup fails.
+// resolveNameToIDForApply is resolveNameToID for upsert flows: a no-match returns
+// ("", nil) so the caller creates the resource instead of erroring. Collisions
+// are handled identically to resolveNameToID (error under --no-input, else prompt),
+// so a duplicate name never silently replaces the wrong record.
 func resolveNameToIDForApply(ctx context.Context, client registry.HTTPClient, listPath, nameField, idField, name string, noInput bool) (string, error) {
-	// Escape double quotes in name to prevent RSQL injection
-	escapedName := strings.ReplaceAll(name, `"`, `\"`)
-	filterPath := fmt.Sprintf("%s?filter=%s&page-size=100",
-		listPath, url.QueryEscape(fmt.Sprintf(`%s=="%s"`, nameField, escapedName)))
-
-	resp, err := client.Do(ctx, "GET", filterPath, nil)
+	ids, err := lookupMatchingIDs(ctx, client, listPath, nameField, idField, name)
 	if err != nil {
-		return "", fmt.Errorf("looking up %q: %w", name, err)
+		return "", err
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return "", fmt.Errorf("reading lookup response: %w", err)
-	}
-
-	var data struct {
-		TotalCount int               `json:"totalCount"`
-		Results    []json.RawMessage `json:"results"`
-	}
-	if err := json.Unmarshal(body, &data); err != nil {
-		var arr []json.RawMessage
-		if jsonErr := json.Unmarshal(body, &arr); jsonErr != nil {
-			return "", fmt.Errorf("parsing lookup response: %w", err)
-		}
-		data.Results = arr
-		data.TotalCount = len(arr)
-	}
-
-	if data.TotalCount == 0 || len(data.Results) == 0 {
+	if len(ids) == 0 {
 		return "", nil // Not found — caller should create
 	}
-
-	// Client-side filter: some endpoints ignore RSQL filter params (e.g. prestages).
-	// Always apply exact name matching to guard against false positives.
-	results := filterResultsByName(data.Results, nameField, name)
-	if len(results) == 0 {
-		return "", nil // Not found — caller should create
-	}
-
-	// Parse results to extract IDs
-	type applyMatch struct {
-		id string
-	}
-	var matches []applyMatch
-	for _, raw := range results {
-		var obj map[string]any
-		if err := json.Unmarshal(raw, &obj); err != nil {
-			continue
-		}
-		if id := extractIDString(obj, idField); id != "" {
-			matches = append(matches, applyMatch{id: id})
-		}
-	}
-
-	if len(matches) == 0 {
-		return "", nil
-	}
-
-	if len(matches) == 1 {
-		return matches[0].id, nil
-	}
-
-	// Collision: multiple resources with the same name
-	if noInput {
-		ids := make([]string, len(matches))
-		for i, m := range matches {
-			ids[i] = m.id
-		}
-		return "", fmt.Errorf("multiple resources found with name %q (IDs: %s); resolve duplicates or use update with a specific ID", name, strings.Join(ids, ", "))
-	}
-
-	// Interactive: prompt user to pick
-	fmt.Fprintf(os.Stderr, "Multiple resources found with name %q:\n", name)
-	for i, m := range matches {
-		fmt.Fprintf(os.Stderr, "  [%d] ID: %s\n", i+1, m.id)
-	}
-	fmt.Fprintf(os.Stderr, "Enter number to replace (or 0 to cancel): ")
-	var choice int
-	if _, err := fmt.Fscan(os.Stdin, &choice); err != nil || choice < 1 || choice > len(matches) {
-		return "", fmt.Errorf("aborted")
-	}
-	return matches[choice-1].id, nil
+	return pickMatchingID(ids, name, noInput)
 }
 
 // fieldFilter describes the writable fields a PUT request body accepts, derived

--- a/internal/commands/pro/generated/registry.go
+++ b/internal/commands/pro/generated/registry.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/exitcode"
@@ -216,9 +217,18 @@ func batchDeleteError(cmd *cobra.Command, succeeded, failed int, firstErr error,
 // endpoint ignores the RSQL filter param (e.g. prestages). The name is escaped
 // to prevent RSQL injection. Returns an empty slice when nothing matches.
 func lookupMatchingIDs(ctx context.Context, client registry.HTTPClient, listPath, nameField, idField, name string) ([]string, error) {
-	escapedName := strings.ReplaceAll(name, `"`, `\"`)
-	filterPath := fmt.Sprintf("%s?filter=%s&page-size=100",
-		listPath, url.QueryEscape(fmt.Sprintf(`%s=="%s"`, nameField, escapedName)))
+	// Escape backslashes before quotes so a value ending in `\` can't
+	// neutralize the closing quote and break out of the RSQL string literal.
+	escapedName := strings.ReplaceAll(name, `\`, `\\`)
+	escapedName = strings.ReplaceAll(escapedName, `"`, `\"`)
+	// listPath may already carry a query string (e.g. "?section=HARDWARE" so the
+	// filtered field is present in the response) — append with & in that case.
+	sep := "?"
+	if strings.Contains(listPath, "?") {
+		sep = "&"
+	}
+	filterPath := fmt.Sprintf("%s%sfilter=%s&page-size=100",
+		listPath, sep, url.QueryEscape(fmt.Sprintf(`%s=="%s"`, nameField, escapedName)))
 
 	resp, err := client.Do(ctx, "GET", filterPath, nil)
 	if err != nil {
@@ -255,7 +265,7 @@ func lookupMatchingIDs(ctx context.Context, client registry.HTTPClient, listPath
 	results := filterResultsByName(data.Results, nameField, name)
 	if len(results) == 0 && data.TotalCount > len(data.Results) {
 		// RSQL was likely ignored and we only got the first page. Re-fetch all results.
-		allPath := fmt.Sprintf("%s?page-size=%d", listPath, data.TotalCount)
+		allPath := fmt.Sprintf("%s%spage-size=%d", listPath, sep, data.TotalCount)
 		allResp, err := client.Do(ctx, "GET", allPath, nil)
 		if err == nil {
 			allBody, _ := io.ReadAll(io.LimitReader(allResp.Body, 8<<20))
@@ -270,14 +280,24 @@ func lookupMatchingIDs(ctx context.Context, client registry.HTTPClient, listPath
 	}
 
 	ids := make([]string, 0, len(results))
+	skipped := 0
 	for _, raw := range results {
 		var obj map[string]any
 		if err := json.Unmarshal(raw, &obj); err != nil {
+			skipped++
 			continue
 		}
-		if id := extractIDString(obj, idField); id != "" {
-			ids = append(ids, id)
+		id := extractIDString(obj, idField)
+		if id == "" {
+			skipped++
+			continue
 		}
+		ids = append(ids, id)
+	}
+	// A matching record we can't resolve to an ID would silently shrink the
+	// candidate set and defeat collision detection — surface it instead.
+	if skipped > 0 {
+		return ids, fmt.Errorf("%d record(s) matched %q but could not be resolved to an ID (missing %q field); target a specific ID", skipped, name, idField)
 	}
 	return ids, nil
 }
@@ -290,8 +310,13 @@ func pickMatchingID(ids []string, name string, noInput bool) (string, error) {
 	if len(ids) == 1 {
 		return ids[0], nil
 	}
-	if noInput {
-		return "", fmt.Errorf("multiple resources found matching %q (IDs: %s); resolve the duplicates or target a specific ID", name, strings.Join(ids, ", "))
+	// Ambiguous — several records share the value. Only prompt when a human can
+	// actually answer: --no-input, or a non-terminal stdin (CI, pipes, non-pty
+	// SSH, process supervisors) must fail fast rather than block on a read that
+	// will never be satisfied. Usage exit code marks it as a fix-the-invocation
+	// condition, distinct from a generic failure, per agent_context.md.
+	if noInput || !term.IsTerminal(int(os.Stdin.Fd())) {
+		return "", exitcode.New(exitcode.Usage, fmt.Sprintf("multiple resources found matching %q (IDs: %s); resolve the duplicates or target a specific ID", name, strings.Join(ids, ", ")))
 	}
 	fmt.Fprintf(os.Stderr, "Multiple resources found matching %q:\n", name)
 	for i, id := range ids {

--- a/internal/commands/pro/generated/resolve_name_test.go
+++ b/internal/commands/pro/generated/resolve_name_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026, Jamf Software LLC
+
+package generated
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// resolveNameMockClient returns a fixed body for every request, letting the
+// name-resolution helpers be driven with synthetic list responses.
+type resolveNameMockClient struct {
+	body   string
+	status int
+}
+
+func (m *resolveNameMockClient) Do(_ context.Context, _, _ string, _ io.Reader) (*http.Response, error) {
+	status := m.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(m.body)),
+	}, nil
+}
+
+// Two computer records sharing a serial number — the motherboard-swap scenario
+// from issue #273.
+const dupSerialBody = `{"totalCount":2,"results":[` +
+	`{"id":"42","hardware":{"serialNumber":"C02X1234"}},` +
+	`{"id":"88","hardware":{"serialNumber":"C02X1234"}}]}`
+
+const oneSerialBody = `{"totalCount":1,"results":[` +
+	`{"id":"42","hardware":{"serialNumber":"C02X1234"}}]}`
+
+const noMatchBody = `{"totalCount":0,"results":[]}`
+
+const (
+	serialPath  = "/v3/computers-inventory"
+	serialField = "hardware.serialNumber"
+)
+
+// resolveNameToID must never silently target one of several duplicate records:
+// under --no-input a collision is a hard error naming every candidate ID.
+func TestResolveNameToID_DuplicateSerialErrors(t *testing.T) {
+	client := &resolveNameMockClient{body: dupSerialBody}
+	_, err := resolveNameToID(context.Background(), client, serialPath, serialField, "id", "C02X1234", true)
+	if err == nil {
+		t.Fatal("expected error for duplicate serial, got nil")
+	}
+	for _, want := range []string{"multiple resources found", "42", "88"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+}
+
+func TestResolveNameToID_SingleMatch(t *testing.T) {
+	client := &resolveNameMockClient{body: oneSerialBody}
+	id, err := resolveNameToID(context.Background(), client, serialPath, serialField, "id", "C02X1234", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "42" {
+		t.Errorf("id = %q, want 42", id)
+	}
+}
+
+func TestResolveNameToID_NoMatchErrors(t *testing.T) {
+	client := &resolveNameMockClient{body: noMatchBody}
+	_, err := resolveNameToID(context.Background(), client, serialPath, serialField, "id", "NOPE", true)
+	if err == nil || !strings.Contains(err.Error(), "no resource found") {
+		t.Fatalf("expected 'no resource found' error, got %v", err)
+	}
+}
+
+// resolveNameToIDForApply shares the same collision guard as resolveNameToID.
+func TestResolveNameToIDForApply_DuplicateSerialErrors(t *testing.T) {
+	client := &resolveNameMockClient{body: dupSerialBody}
+	_, err := resolveNameToIDForApply(context.Background(), client, serialPath, serialField, "id", "C02X1234", true)
+	if err == nil || !strings.Contains(err.Error(), "multiple resources found") {
+		t.Fatalf("expected collision error, got %v", err)
+	}
+}
+
+// The one behavioral difference: a no-match returns ("", nil) so apply creates.
+func TestResolveNameToIDForApply_NoMatchReturnsEmpty(t *testing.T) {
+	client := &resolveNameMockClient{body: noMatchBody}
+	id, err := resolveNameToIDForApply(context.Background(), client, serialPath, serialField, "id", "NOPE", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "" {
+		t.Errorf("id = %q, want empty (caller should create)", id)
+	}
+}
+
+// The shared core surfaces every duplicate so callers can decide what to do.
+func TestLookupMatchingIDs_ReturnsAllDuplicates(t *testing.T) {
+	client := &resolveNameMockClient{body: dupSerialBody}
+	ids, err := lookupMatchingIDs(context.Background(), client, serialPath, serialField, "id", "C02X1234")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "42" || ids[1] != "88" {
+		t.Errorf("ids = %v, want [42 88]", ids)
+	}
+}

--- a/internal/commands/pro/generated/resolve_name_test.go
+++ b/internal/commands/pro/generated/resolve_name_test.go
@@ -4,20 +4,27 @@ package generated
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/exitcode"
 )
 
-// resolveNameMockClient returns a fixed body for every request, letting the
-// name-resolution helpers be driven with synthetic list responses.
+// resolveNameMockClient returns a fixed body for every request, recording every
+// request path so tests can assert how the lookup URL was constructed.
 type resolveNameMockClient struct {
 	body   string
 	status int
+	paths  []string
 }
 
-func (m *resolveNameMockClient) Do(_ context.Context, _, _ string, _ io.Reader) (*http.Response, error) {
+func (m *resolveNameMockClient) Do(_ context.Context, _, path string, _ io.Reader) (*http.Response, error) {
+	m.paths = append(m.paths, path)
 	status := m.status
 	if status == 0 {
 		status = http.StatusOK
@@ -56,6 +63,121 @@ func TestResolveNameToID_DuplicateSerialErrors(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q missing %q", err, want)
 		}
+	}
+	// A collision is a fix-the-invocation condition, not a generic failure —
+	// agents keying off the exit code must see Usage, not the General fallback.
+	if code := exitcode.CodeFrom(err); code != exitcode.Usage {
+		t.Errorf("exit code = %d, want %d (Usage)", code, exitcode.Usage)
+	}
+}
+
+// Without --no-input, an ambiguous lookup must still fail fast when stdin isn't
+// a terminal (CI, pipes, non-pty SSH) instead of blocking forever on a prompt
+// read that will never be answered.
+func TestPickMatchingID_NonTTYFailsFast(t *testing.T) {
+	r, w, err := os.Pipe() // a pipe is never a terminal
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+	defer func() { _ = w.Close() }()
+	orig := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = orig }()
+
+	_, err = pickMatchingID([]string{"42", "88"}, "C02X1234", false)
+	if err == nil {
+		t.Fatal("expected error on non-TTY collision, got nil")
+	}
+	if !strings.Contains(err.Error(), "multiple resources found") {
+		t.Errorf("error %q missing collision text", err)
+	}
+	if code := exitcode.CodeFrom(err); code != exitcode.Usage {
+		t.Errorf("exit code = %d, want %d (Usage)", code, exitcode.Usage)
+	}
+}
+
+// The RSQL filter must neutralize both quotes and backslashes so a value
+// ending in a backslash can't break out of the string literal.
+func TestLookupMatchingIDs_EscapesBackslashAndQuote(t *testing.T) {
+	client := &resolveNameMockClient{body: noMatchBody}
+	if _, err := lookupMatchingIDs(context.Background(), client, "/policies", "name", "id", `a\"b`); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(client.paths) == 0 {
+		t.Fatal("no request captured")
+	}
+	// url.QueryEscape encodes the fragment; decode the filter value back and
+	// assert the backslash was doubled and the quote escaped before encoding.
+	got := client.paths[0]
+	// filter=name=="a\\\"b"  →  after QueryEscape the raw filter param must
+	// contain the escaped sequence; assert the pre-encode form round-trips.
+	const wantFilter = `name=="a\\\"b"`
+	q := got[strings.Index(got, "filter=")+len("filter="):]
+	if amp := strings.IndexByte(q, '&'); amp >= 0 {
+		q = q[:amp]
+	}
+	dec, err := url.QueryUnescape(q)
+	if err != nil {
+		t.Fatalf("decoding filter: %v", err)
+	}
+	if dec != wantFilter {
+		t.Errorf("filter = %q, want %q", dec, wantFilter)
+	}
+}
+
+// A matching record whose ID can't be extracted must surface an error rather
+// than silently shrink the candidate set (which would defeat collision
+// detection — the exact failure mode this resolver exists to prevent).
+func TestLookupMatchingIDs_UnextractableIDErrors(t *testing.T) {
+	// Two records share the serial; the second has no id field.
+	body := `{"totalCount":2,"results":[` +
+		`{"id":"42","hardware":{"serialNumber":"C02X1234"}},` +
+		`{"hardware":{"serialNumber":"C02X1234"}}]}`
+	client := &resolveNameMockClient{body: body}
+	ids, err := lookupMatchingIDs(context.Background(), client, serialPath, serialField, "id", "C02X1234")
+	if err == nil {
+		t.Fatal("expected error when a candidate has no extractable ID, got nil")
+	}
+	if !strings.Contains(err.Error(), "could not be resolved to an ID") {
+		t.Errorf("error %q missing skip explanation", err)
+	}
+	// The well-formed candidate is still returned alongside the error.
+	if len(ids) != 1 || ids[0] != "42" {
+		t.Errorf("ids = %v, want [42]", ids)
+	}
+}
+
+// When the filtered field is present in the response, the client-side safety
+// net must narrow to exact matches — not blindly trust the server's filter.
+func TestFilterResultsByName_NarrowsOnHardwareSection(t *testing.T) {
+	results := []json.RawMessage{
+		json.RawMessage(`{"id":"1","hardware":{"serialNumber":"C02X1234"}}`),
+		json.RawMessage(`{"id":"2","hardware":{"serialNumber":"OTHER999"}}`),
+	}
+	filtered := filterResultsByName(results, "hardware.serialNumber", "C02X1234")
+	if len(filtered) != 1 {
+		t.Fatalf("got %d results, want 1 (mismatch excluded)", len(filtered))
+	}
+	if !strings.Contains(string(filtered[0]), `"id":"1"`) {
+		t.Errorf("kept wrong record: %s", filtered[0])
+	}
+}
+
+// A listPath that already carries a query string (e.g. ?section=HARDWARE) must
+// join the filter with & rather than a second ?.
+func TestLookupMatchingIDs_SectionQueryJoin(t *testing.T) {
+	client := &resolveNameMockClient{body: oneSerialBody}
+	if _, err := lookupMatchingIDs(context.Background(), client,
+		"/v3/computers-inventory?section=HARDWARE", serialField, "id", "C02X1234"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := client.paths[0]
+	if strings.Count(got, "?") != 1 {
+		t.Errorf("path %q has %d '?' separators, want exactly 1", got, strings.Count(got, "?"))
+	}
+	if !strings.Contains(got, "section=HARDWARE&filter=") {
+		t.Errorf("path %q did not join section and filter with &", got)
 	}
 }
 

--- a/internal/commands/pro/generated/return_to_service_configurations.go
+++ b/internal/commands/pro/generated/return_to_service_configurations.go
@@ -99,7 +99,8 @@ func newReturnToServiceConfigurationsGetCmd(ctx *registry.CLIContext) *cobra.Com
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/return-to-service", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/return-to-service", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -243,7 +244,8 @@ func newReturnToServiceConfigurationsUpdateCmd(ctx *registry.CLIContext) *cobra.
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/return-to-service", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/return-to-service", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/schedulers.go
+++ b/internal/commands/pro/generated/schedulers.go
@@ -89,7 +89,8 @@ func newSchedulersTriggersCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/scheduler/jobs", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/scheduler/jobs", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/scripts.go
+++ b/internal/commands/pro/generated/scripts.go
@@ -218,7 +218,8 @@ func newScriptsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/scripts", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/scripts", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -400,7 +401,8 @@ func newScriptsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/scripts", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/scripts", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -707,7 +709,8 @@ func newScriptsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/scripts", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/scripts", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -877,7 +880,8 @@ func newScriptsAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/scripts", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/scripts", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -956,7 +960,8 @@ func newScriptsDownloadCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/scripts", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/scripts", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/self_service_branding_ios_resource.go
+++ b/internal/commands/pro/generated/self_service_branding_ios_resource.go
@@ -210,7 +210,8 @@ func newSelfServiceBrandingIosGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/self-service/branding/ios", "brandingName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/self-service/branding/ios", "brandingName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -362,7 +363,8 @@ func newSelfServiceBrandingIosUpdateCmd(ctx *registry.CLIContext) *cobra.Command
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/self-service/branding/ios", "brandingName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/self-service/branding/ios", "brandingName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/self_service_branding_macos.go
+++ b/internal/commands/pro/generated/self_service_branding_macos.go
@@ -210,7 +210,8 @@ func newSelfServiceBrandingMacosGetCmd(ctx *registry.CLIContext) *cobra.Command 
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/self-service/branding/macos", "brandingName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/self-service/branding/macos", "brandingName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -364,7 +365,8 @@ func newSelfServiceBrandingMacosUpdateCmd(ctx *registry.CLIContext) *cobra.Comma
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/self-service/branding/macos", "brandingName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/self-service/branding/macos", "brandingName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/sites.go
+++ b/internal/commands/pro/generated/sites.go
@@ -90,7 +90,8 @@ func newSitesObjectsCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/sites", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/sites", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/static_computer_groups.go
+++ b/internal/commands/pro/generated/static_computer_groups.go
@@ -215,7 +215,8 @@ func newStaticComputerGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/computer-groups/static-groups", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/computer-groups/static-groups", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -368,7 +369,8 @@ func newStaticComputerGroupsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/computer-groups/static-groups", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v2/computer-groups/static-groups", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/static_user_groups.go
+++ b/internal/commands/pro/generated/static_user_groups.go
@@ -89,7 +89,8 @@ func newStaticUserGroupsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/static-user-groups", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/static-user-groups", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/supervision_identities.go
+++ b/internal/commands/pro/generated/supervision_identities.go
@@ -220,7 +220,8 @@ func newSupervisionIdentitiesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/supervision-identities", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/supervision-identities", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -363,7 +364,8 @@ func newSupervisionIdentitiesUpdateCmd(ctx *registry.CLIContext) *cobra.Command 
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/supervision-identities", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/supervision-identities", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -755,7 +757,8 @@ func newSupervisionIdentitiesDownloadCmd(ctx *registry.CLIContext) *cobra.Comman
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/supervision-identities", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/supervision-identities", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/team_viewer_remote_administrations.go
+++ b/internal/commands/pro/generated/team_viewer_remote_administrations.go
@@ -65,7 +65,8 @@ func newTeamViewerRemoteAdministrationsGetCmd(ctx *registry.CLIContext) *cobra.C
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -408,7 +409,8 @@ func newTeamViewerRemoteAdministrationsSessionsCmd(ctx *registry.CLIContext) *co
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -565,7 +567,8 @@ func newTeamViewerRemoteAdministrationsCloseCmd(ctx *registry.CLIContext) *cobra
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -636,7 +639,8 @@ func newTeamViewerRemoteAdministrationsResendNotificationCmd(ctx *registry.CLICo
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -707,7 +711,8 @@ func newTeamViewerRemoteAdministrationsSessionsStatusCmd(ctx *registry.CLIContex
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -784,7 +789,8 @@ func newTeamViewerRemoteAdministrationsPatchCmd(ctx *registry.CLIContext) *cobra
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedPatchID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -877,7 +883,8 @@ func newTeamViewerRemoteAdministrationsStatusCmd(ctx *registry.CLIContext) *cobr
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/preview/remote-administration-configurations/team-viewer", "displayName", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/user_accounts.go
+++ b/internal/commands/pro/generated/user_accounts.go
@@ -215,7 +215,8 @@ func newUserAccountsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/accounts", "username", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/accounts", "username", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -381,7 +382,8 @@ func newUserAccountsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/accounts", "username", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/accounts", "username", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/user_preferences.go
+++ b/internal/commands/pro/generated/user_preferences.go
@@ -55,7 +55,8 @@ func newUserPreferencesGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/user/preferences/settings", "username", "key", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/user/preferences/settings", "username", "key", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -116,7 +117,8 @@ func newUserPreferencesUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/user/preferences/settings", "username", "key", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/user/preferences/settings", "username", "key", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/users.go
+++ b/internal/commands/pro/generated/users.go
@@ -221,7 +221,8 @@ func newUsersGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/users", "username", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/users", "username", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -386,7 +387,8 @@ func newUsersUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/users", "username", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/users", "username", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/venafis.go
+++ b/internal/commands/pro/generated/venafis.go
@@ -67,7 +67,8 @@ func newVenafisGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -416,7 +417,8 @@ func newVenafisHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -586,7 +588,8 @@ func newVenafisAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -682,7 +685,8 @@ func newVenafisPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedPatchID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -775,7 +779,8 @@ func newVenafisConnectionStatusCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -829,7 +834,8 @@ func newVenafisDependentProfilesCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -890,7 +896,8 @@ func newVenafisJamfPublicKeyCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -959,7 +966,8 @@ func newVenafisRegenerateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1037,7 +1045,8 @@ func newVenafisProxyTrustStoreCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/pki/venafi", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/vpp_locations.go
+++ b/internal/commands/pro/generated/vpp_locations.go
@@ -220,7 +220,8 @@ func newVppLocationsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -590,7 +591,8 @@ func newVppLocationsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -760,7 +762,8 @@ func newVppLocationsAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -859,7 +862,8 @@ func newVppLocationsPatchCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedPatchID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -971,7 +975,8 @@ func newVppLocationsContentCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1134,7 +1139,8 @@ func newVppLocationsReclaimCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -1205,7 +1211,8 @@ func newVppLocationsRevokeLicensesCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-locations", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro/generated/vpp_subscriptions.go
+++ b/internal/commands/pro/generated/vpp_subscriptions.go
@@ -212,7 +212,8 @@ func newVppSubscriptionsGetCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-subscriptions", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-subscriptions", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -366,7 +367,8 @@ func newVppSubscriptionsUpdateCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-subscriptions", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-subscriptions", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -700,7 +702,8 @@ func newVppSubscriptionsHistoryCmd(ctx *registry.CLIContext) *cobra.Command {
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-subscriptions", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-subscriptions", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}
@@ -870,7 +873,8 @@ func newVppSubscriptionsAddHistoryNoteCmd(ctx *registry.CLIContext) *cobra.Comma
 			// Resolve resource ID from positional arg, --name, or lookup flags
 			var resolvedID string
 			if flagName != "" {
-				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-subscriptions", "name", "id", flagName)
+				noInput, _ := cmd.Flags().GetBool("no-input")
+				rid, err := resolveNameToID(reqCtx, ctx.Client, "/v1/volume-purchasing-subscriptions", "name", "id", flagName, noInput)
 				if err != nil {
 					return err
 				}

--- a/internal/commands/pro_audit.go
+++ b/internal/commands/pro_audit.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -91,6 +92,7 @@ func allAuditChecks() []auditCheck {
 		{Category: "hygiene", Name: "Empty smart groups", Run: checkEmptySmartGroups},
 		{Category: "hygiene", Name: "Policies with no scope", Run: checkPoliciesNoScope},
 		{Category: "hygiene", Name: "Empty categories", Run: checkEmptyCategories},
+		{Category: "hygiene", Name: "Duplicate serial numbers", Run: checkDuplicateSerials},
 
 		// Enrollment
 		{Category: "enrollment", Name: "DEP token expiry", Run: checkDEPTokenExpiry},
@@ -383,6 +385,55 @@ func checkEmptyCategories(ctx context.Context, client registry.HTTPClient, _ int
 		Name:           "Categories audit",
 		AffectedCount:  len(cats),
 		Recommendation: "Review categories for unused entries; consider consolidating",
+	}, nil
+}
+
+// checkDuplicateSerials flags serial numbers shared by more than one computer
+// record. A replaced logic board re-enrolls as a fresh record, so the old and
+// new records collide on serial — which breaks every serial-based lookup
+// (get/update/patch --serial, device actions) since the CLI can no longer
+// resolve the serial to a single device. Jamf smart groups cannot surface this
+// (their criteria are per-record, not cross-record), so the audit is the only
+// place to catch it. Blank serials are ignored — many pending/placeholder
+// records legitimately share an empty serial.
+func checkDuplicateSerials(ctx context.Context, client registry.HTTPClient, _ int) (*auditResult, error) {
+	all, err := FetchAllPaginated(ctx, client, "/v3/computers-inventory?section=HARDWARE", 100)
+	if err != nil {
+		return nil, err
+	}
+
+	counts := make(map[string]int)
+	for _, comp := range all {
+		hw, _ := comp["hardware"].(map[string]any)
+		if hw == nil {
+			continue
+		}
+		serial, _ := hw["serialNumber"].(string)
+		serial = strings.TrimSpace(serial)
+		if serial == "" {
+			continue
+		}
+		counts[serial]++
+	}
+
+	duplicatedSerials := 0
+	affectedRecords := 0
+	for _, n := range counts {
+		if n > 1 {
+			duplicatedSerials++
+			affectedRecords += n
+		}
+	}
+	if affectedRecords == 0 {
+		return nil, nil
+	}
+
+	return &auditResult{
+		Category:       "hygiene",
+		Severity:       severityWarning,
+		Name:           "Duplicate serial numbers",
+		AffectedCount:  affectedRecords,
+		Recommendation: fmt.Sprintf("%d serial(s) map to multiple computer records (typically a logic-board swap); delete the stale record for each so serial-based lookups resolve to one device", duplicatedSerials),
 	}, nil
 }
 

--- a/internal/commands/pro_audit.go
+++ b/internal/commands/pro_audit.go
@@ -433,7 +433,7 @@ func checkDuplicateSerials(ctx context.Context, client registry.HTTPClient, _ in
 		Severity:       severityWarning,
 		Name:           "Duplicate serial numbers",
 		AffectedCount:  affectedRecords,
-		Recommendation: fmt.Sprintf("%d serial(s) map to multiple computer records (typically a logic-board swap); delete the stale record for each so serial-based lookups resolve to one device", duplicatedSerials),
+		Recommendation: fmt.Sprintf("%d serial(s) map to multiple computer records (typically a logic-board swap); run 'pro report duplicate-serials' to list the affected records, then delete the stale record for each so serial-based lookups resolve to one device", duplicatedSerials),
 	}, nil
 }
 

--- a/internal/commands/pro_audit_test.go
+++ b/internal/commands/pro_audit_test.go
@@ -510,6 +510,18 @@ func TestCheckDuplicateSerials_AllUnique(t *testing.T) {
 	}
 }
 
+func TestCheckDuplicateSerials_FetchError(t *testing.T) {
+	client := &overviewMockClient{
+		responses: map[string]overviewMockResponse{
+			"/v3/computers-inventory": {500, `{}`},
+		},
+	}
+
+	if _, err := checkDuplicateSerials(context.Background(), client, 0); err == nil {
+		t.Fatal("expected error on fetch failure, got nil")
+	}
+}
+
 func TestRunAudit_FilterByCategory(t *testing.T) {
 	// Only set up compliance mocks
 	mock := &overviewMockClient{

--- a/internal/commands/pro_audit_test.go
+++ b/internal/commands/pro_audit_test.go
@@ -457,6 +457,59 @@ func TestCheckEmptyCategories_None(t *testing.T) {
 	}
 }
 
+// --- Duplicate serials test ---
+
+func TestCheckDuplicateSerials_Found(t *testing.T) {
+	client := &overviewMockClient{
+		responses: map[string]overviewMockResponse{
+			// C02X shared by two records (logic-board swap), C02Z unique.
+			"/v3/computers-inventory": {200, `{"totalCount":4,"results":[
+				{"id":"1","hardware":{"serialNumber":"C02X1234"}},
+				{"id":"2","hardware":{"serialNumber":"C02X1234"}},
+				{"id":"3","hardware":{"serialNumber":"C02Z9999"}},
+				{"id":"4","hardware":{"serialNumber":""}}
+			]}`},
+		},
+	}
+
+	result, err := checkDuplicateSerials(context.Background(), client, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected finding for duplicate serials")
+		return
+	}
+	if result.AffectedCount != 2 {
+		t.Errorf("affected = %d, want 2 (both records sharing C02X1234)", result.AffectedCount)
+	}
+	if result.Severity != severityWarning {
+		t.Errorf("severity = %q, want %q", result.Severity, severityWarning)
+	}
+}
+
+func TestCheckDuplicateSerials_AllUnique(t *testing.T) {
+	client := &overviewMockClient{
+		responses: map[string]overviewMockResponse{
+			// Blank serials must never count as duplicates of each other.
+			"/v3/computers-inventory": {200, `{"totalCount":3,"results":[
+				{"id":"1","hardware":{"serialNumber":"C02X1234"}},
+				{"id":"2","hardware":{"serialNumber":"C02Z9999"}},
+				{"id":"3","hardware":{"serialNumber":""}},
+				{"id":"4","hardware":{"serialNumber":""}}
+			]}`},
+		},
+	}
+
+	result, err := checkDuplicateSerials(context.Background(), client, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result when all serials unique (blanks ignored), got %+v", result)
+	}
+}
+
 func TestRunAudit_FilterByCategory(t *testing.T) {
 	// Only set up compliance mocks
 	mock := &overviewMockClient{

--- a/internal/commands/pro_report.go
+++ b/internal/commands/pro_report.go
@@ -25,7 +25,8 @@ Available subcommands:
   policy-status      Policy execution status and health checks
   profile-status     Configuration profile deployment failures
   app-status         Managed app deployment failures
-  update-status      Managed software update deployment status`,
+  update-status      Managed software update deployment status
+  duplicate-serials  Computer records sharing a serial number`,
 	}
 
 	cmd.AddCommand(newReportPatchStatusCmd(cliCtx))
@@ -38,6 +39,7 @@ Available subcommands:
 	cmd.AddCommand(newReportProfileStatusCmd(cliCtx))
 	cmd.AddCommand(newReportAppStatusCmd(cliCtx))
 	cmd.AddCommand(newReportUpdateStatusCmd(cliCtx))
+	cmd.AddCommand(newReportDuplicateSerialsCmd(cliCtx))
 
 	// Platform API reports
 	cmd.AddCommand(newReportBlueprintStatusCmd(cliCtx))

--- a/internal/commands/pro_report_serials.go
+++ b/internal/commands/pro_report_serials.go
@@ -1,0 +1,118 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/output"
+	"github.com/Jamf-Concepts/jamf-cli/internal/registry"
+)
+
+func newReportDuplicateSerialsCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "duplicate-serials",
+		Short: "Computer records sharing a serial number",
+		Long: `List computer records that share a serial number with another record.
+
+A replaced logic board re-enrolls as a fresh record, so the old and new records
+collide on serial number. Duplicates break every serial-based lookup
+(get/update/patch --serial and device actions) because the serial no longer
+resolves to a single device. Jamf smart groups cannot surface this — their
+criteria are evaluated per record, not across the fleet.
+
+Only serials shared by two or more records are listed, grouped so duplicates of
+the same serial appear together. Delete the stale record for each serial to
+restore unambiguous lookups.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rows, err := runReportDuplicateSerials(cmd.Context(), cliCtx.Client)
+			if err != nil {
+				return err
+			}
+			formatter := output.New(outputFmt, noColor, wide)
+			return formatter.Print(rows)
+		},
+	}
+	return cmd
+}
+
+// runReportDuplicateSerials fetches all computer records, groups them by serial
+// number, and returns one row per record for every serial shared by more than
+// one record. Blank serials are ignored — pending/placeholder records commonly
+// share an empty serial. Rows are ordered by serial, then by numeric ID, so
+// duplicates cluster together.
+func runReportDuplicateSerials(ctx context.Context, client registry.HTTPClient) ([]map[string]any, error) {
+	computers, err := FetchAllPaginated(ctx, client, "/v3/computers-inventory?section=GENERAL&section=HARDWARE", 100)
+	if err != nil {
+		return nil, fmt.Errorf("fetching computer inventory: %w", err)
+	}
+
+	type record struct {
+		id          string
+		name        string
+		lastContact string
+	}
+	bySerial := make(map[string][]record)
+	for _, c := range computers {
+		hw, _ := c["hardware"].(map[string]any)
+		if hw == nil {
+			continue
+		}
+		serial, _ := hw["serialNumber"].(string)
+		serial = strings.TrimSpace(serial)
+		if serial == "" {
+			continue
+		}
+		rec := record{id: extractID(c)}
+		if gen, ok := c["general"].(map[string]any); ok {
+			rec.name, _ = gen["name"].(string)
+			rec.lastContact, _ = gen["lastContactTime"].(string)
+		}
+		if rec.name == "" {
+			rec.name = rec.id
+		}
+		bySerial[serial] = append(bySerial[serial], rec)
+	}
+
+	// Keep only serials with more than one record, sorted for stable output.
+	dupSerials := make([]string, 0)
+	for serial, recs := range bySerial {
+		if len(recs) > 1 {
+			dupSerials = append(dupSerials, serial)
+		}
+	}
+	sort.Strings(dupSerials)
+
+	rows := make([]map[string]any, 0)
+	for _, serial := range dupSerials {
+		recs := bySerial[serial]
+		sort.Slice(recs, func(i, j int) bool {
+			return idLess(recs[i].id, recs[j].id)
+		})
+		for _, rec := range recs {
+			rows = append(rows, map[string]any{
+				"serial":       serial,
+				"id":           rec.id,
+				"name":         rec.name,
+				"last_contact": rec.lastContact,
+			})
+		}
+	}
+	return rows, nil
+}
+
+// idLess orders IDs numerically when both parse as integers, otherwise lexically.
+func idLess(a, b string) bool {
+	ai, aerr := strconv.Atoi(a)
+	bi, berr := strconv.Atoi(b)
+	if aerr == nil && berr == nil {
+		return ai < bi
+	}
+	return a < b
+}

--- a/internal/commands/pro_report_test.go
+++ b/internal/commands/pro_report_test.go
@@ -492,6 +492,51 @@ func TestRunReportDuplicateSerials_FetchError(t *testing.T) {
 	}
 }
 
+// Serials that differ only in surrounding whitespace are the same serial and
+// must collide (guards the strings.TrimSpace in the grouping key).
+func TestRunReportDuplicateSerials_WhitespaceCollision(t *testing.T) {
+	client := &overviewMockClient{
+		responses: map[string]overviewMockResponse{
+			"/v3/computers-inventory": {200, `{
+				"totalCount": 2,
+				"results": [
+					{"id":"1","general":{"name":"A"},"hardware":{"serialNumber":"C02X1234"}},
+					{"id":"2","general":{"name":"B"},"hardware":{"serialNumber":"  C02X1234  "}}
+				]
+			}`},
+		},
+	}
+
+	rows, err := runReportDuplicateSerials(context.Background(), client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (whitespace-variant serials must collide)", len(rows))
+	}
+	if rows[0]["serial"] != "C02X1234" || rows[1]["serial"] != "C02X1234" {
+		t.Errorf("serials = %q/%q, want both trimmed to C02X1234", rows[0]["serial"], rows[1]["serial"])
+	}
+}
+
+func TestIDLess(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"2", "10", true},    // numeric: 2 < 10 (not lexical)
+		{"10", "2", false},   // numeric reverse
+		{"abc", "abd", true}, // non-numeric fallback: lexical
+		{"b", "a", false},    // non-numeric fallback reverse
+		{"9", "x", true},     // mixed → lexical ("9" < "x")
+	}
+	for _, c := range cases {
+		if got := idLess(c.a, c.b); got != c.want {
+			t.Errorf("idLess(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // software-installs
 // ---------------------------------------------------------------------------

--- a/internal/commands/pro_report_test.go
+++ b/internal/commands/pro_report_test.go
@@ -416,6 +416,83 @@ func TestRunReportInventorySummary_Empty(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// duplicate-serials
+// ---------------------------------------------------------------------------
+
+func TestRunReportDuplicateSerials_Basic(t *testing.T) {
+	client := &overviewMockClient{
+		responses: map[string]overviewMockResponse{
+			// C02X1234 shared by ids 2 and 10 (logic-board swap); C02Z9999 unique;
+			// two records with blank serials must not be treated as duplicates.
+			"/v3/computers-inventory": {200, `{
+				"totalCount": 5,
+				"results": [
+					{"id":"10","general":{"name":"Mac-new","lastContactTime":"2026-06-01T00:00:00Z"},"hardware":{"serialNumber":"C02X1234"}},
+					{"id":"2","general":{"name":"Mac-old","lastContactTime":"2025-01-01T00:00:00Z"},"hardware":{"serialNumber":"C02X1234"}},
+					{"id":"3","general":{"name":"Mac-unique"},"hardware":{"serialNumber":"C02Z9999"}},
+					{"id":"4","general":{"name":"Pending-A"},"hardware":{"serialNumber":""}},
+					{"id":"5","general":{"name":"Pending-B"},"hardware":{"serialNumber":"  "}}
+				]
+			}`},
+		},
+	}
+
+	rows, err := runReportDuplicateSerials(context.Background(), client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only the two C02X1234 records; blank serials and the unique serial excluded.
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	// Grouped by serial, ordered by numeric ID → id 2 before id 10.
+	if rows[0]["serial"] != "C02X1234" || rows[0]["id"] != "2" {
+		t.Errorf("row0 = %v, want serial C02X1234 id 2", rows[0])
+	}
+	if rows[1]["id"] != "10" {
+		t.Errorf("row1 id = %v, want 10 (numeric order, not lexical)", rows[1]["id"])
+	}
+	if rows[0]["name"] != "Mac-old" || rows[0]["last_contact"] != "2025-01-01T00:00:00Z" {
+		t.Errorf("row0 detail = %v, want name Mac-old / last_contact 2025-01-01", rows[0])
+	}
+}
+
+func TestRunReportDuplicateSerials_NoneWhenAllUnique(t *testing.T) {
+	client := &overviewMockClient{
+		responses: map[string]overviewMockResponse{
+			"/v3/computers-inventory": {200, `{
+				"totalCount": 2,
+				"results": [
+					{"id":"1","general":{"name":"A"},"hardware":{"serialNumber":"S1"}},
+					{"id":"2","general":{"name":"B"},"hardware":{"serialNumber":"S2"}}
+				]
+			}`},
+		},
+	}
+
+	rows, err := runReportDuplicateSerials(context.Background(), client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("got %d rows, want 0", len(rows))
+	}
+}
+
+func TestRunReportDuplicateSerials_FetchError(t *testing.T) {
+	client := &overviewMockClient{
+		responses: map[string]overviewMockResponse{
+			"/v3/computers-inventory": {500, `{}`},
+		},
+	}
+
+	_, err := runReportDuplicateSerials(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // software-installs
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #273.

Investigating #273 confirmed both of the reporter's claims, and surfaced a latent data-loss bug worse than described. This PR fixes the bug and adds two ways to find duplicate serials.

## 1. Fix: `--serial`/`--name` lookups silently targeted the wrong record

Generated `get`/`update`/`patch` resolved `--name`/`--serial`/`--udid` via `resolveNameToID`, which fetched with `page-size=1` and blindly took `results[0]`. When two computer records share a serial (a replaced logic board re-enrolls as a fresh record — exactly the #273 scenario), it silently resolved to whichever record the API returned first:

- `pro computers get --serial <dup>` → returns an arbitrary one of the pair.
- `pro computers patch/update --serial <dup>` → **silently mutates the wrong device**, no error.

(`delete` and `apply` were already safe — they used the collision-detecting `resolveNameToIDForApply`.) `resolveNameToID` also built its RSQL filter from the un-escaped value, unlike the apply path.

**Fix + consolidation** (`generator/parser/generator.go`): both resolvers now share
- `lookupMatchingIDs` — fetches up to 100 candidates so collisions are visible, client-side filters endpoints that ignore RSQL, escapes the value, returns every matching ID;
- `pickMatchingID` — one match resolves; several error under `--no-input`, else prompt.

They now differ only in the no-match branch (error vs. return-for-create), so `get`/`patch`/`update`/`apply`/`delete` can't drift apart on duplicate handling. Regenerated across all resources.

## 2. Feature: surface duplicate serials

Smart groups can't find duplicates (criteria are per-record, not cross-record), so the CLI now can:

- **`pro audit`** — new hygiene check flagging that duplicates exist, with affected-record count (blank serials ignored). The signal.
- **`pro report duplicate-serials`** — lists the offending records (`serial`, `id`, `name`, `last_contact`), grouped by serial and ordered by numeric id so the stale and current records sit adjacent for cleanup. The actionable list #273 asked for. Works with `-o json/csv/yaml`.

## Tests
- `resolve_name_test.go` — collision→error, single→resolve, no-match behaviour for both resolvers, `lookupMatchingIDs` returns all duplicates.
- `pro_audit_test.go` — duplicate found (count, blanks excluded) / all-unique→nil.
- `pro_report_test.go` — grouping + numeric-id order + record detail / all-unique→empty / fetch error.

`make generate`, `go test ./...`, `make lint` (0 issues), and `make verify-generated` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)