### PR TITLE
feat(device): show dateCompleted in MDM + policy history

### DIFF
--- a/internal/commands/pro_device.go
+++ b/internal/commands/pro_device.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -249,16 +250,19 @@ func fetchMDMHistory(ctx context.Context, client registry.HTTPClient, management
 			continue
 		}
 		cmdType := strVal(cmd, "commandType")
-		status := strVal(cmd, "status")
+		// The v2 API field is "commandState" (e.g. ACKNOWLEDGED, PENDING, ERROR),
+		// not "status" — reading the wrong key left this column blank.
+		state := strVal(cmd, "commandState")
+		completed := formatCompletedDate(strVal(cmd, "dateCompleted"))
 
 		var color string
-		if strings.EqualFold(status, "Error") || strings.EqualFold(status, "Failed") {
+		if strings.EqualFold(state, "Error") || strings.EqualFold(state, "Failed") {
 			color = "red"
 		}
 
 		items = append(items, overviewItem{
 			Resource:  cmdType,
-			Value:     status,
+			Value:     historyValue(state, completed),
 			ColorHint: color,
 		})
 	}
@@ -315,6 +319,7 @@ func fetchPolicyHistory(ctx context.Context, client registry.HTTPClient, deviceI
 		}
 		name := strVal(entry, "policy_name")
 		status := strVal(entry, "status")
+		completed := formatCompletedDate(strVal(entry, "date_completed_utc"))
 
 		var color string
 		if strings.EqualFold(status, "Failed") {
@@ -323,7 +328,7 @@ func fetchPolicyHistory(ctx context.Context, client registry.HTTPClient, deviceI
 
 		items = append(items, overviewItem{
 			Resource:  name,
-			Value:     status,
+			Value:     historyValue(status, completed),
 			ColorHint: color,
 		})
 	}
@@ -331,6 +336,48 @@ func fetchPolicyHistory(ctx context.Context, client registry.HTTPClient, deviceI
 	return &overviewSection{
 		Name:  "Policy History (Last 10)",
 		Items: items,
+	}
+}
+
+// formatCompletedDate normalizes an API completion timestamp to a compact
+// "2006-01-02 15:04" form. It returns "" when the value is empty or the
+// epoch-zero sentinel APIs use for "not completed" (e.g. 1970-01-01T00:00:00Z
+// for a pending MDM command). Unparseable values are returned unchanged so no
+// data is silently dropped.
+func formatCompletedDate(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	// MDM v2 dates are RFC3339 with "Z"; Classic date_completed_utc uses a
+	// numeric "-0700" offset without a colon.
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02T15:04:05.000-0700",
+		"2006-01-02T15:04:05-0700",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, raw); err == nil {
+			if t.Year() <= 1970 {
+				return ""
+			}
+			return t.Format("2006-01-02 15:04")
+		}
+	}
+	return raw
+}
+
+// historyValue joins a history entry's status/state with its completion date
+// for display in a single right-aligned value column, omitting either side
+// when empty.
+func historyValue(status, completed string) string {
+	switch {
+	case completed == "":
+		return status
+	case status == "":
+		return completed
+	default:
+		return status + "  " + completed
 	}
 }
 

--- a/internal/commands/pro_device_test.go
+++ b/internal/commands/pro_device_test.go
@@ -36,6 +36,7 @@ const fullDeviceDetailJSON = `{
 	"id": "42",
 	"general": {
 		"name": "MacBook-Lab1",
+		"managementId": "2435abf1-f8f0-4633-b133-891be9b974fd",
 		"lastIpAddress": "10.0.1.42",
 		"platform": "Mac",
 		"managed": true,
@@ -73,22 +74,25 @@ const fullDeviceDetailJSON = `{
 	}
 }`
 
+// mdmCommandsJSON mirrors the real /v2/mdm/commands shape: the status field is
+// "commandState" (not "status") and completion is "dateCompleted". A pending
+// command carries the epoch-zero sentinel, which must render without a date.
 const mdmCommandsJSON = `{
 	"totalCount": 2,
 	"results": [
 		{
 			"uuid": "cmd-001",
 			"commandType": "ProfileList",
-			"status": "Acknowledged",
+			"commandState": "ACKNOWLEDGED",
 			"dateSent": "2026-03-30T10:00:00Z",
-			"completedDateTime": "2026-03-30T10:01:00Z"
+			"dateCompleted": "2026-03-30T10:01:00Z"
 		},
 		{
 			"uuid": "cmd-002",
 			"commandType": "EraseDevice",
-			"status": "Error",
+			"commandState": "PENDING",
 			"dateSent": "2026-03-29T08:00:00Z",
-			"completedDateTime": "2026-03-29T08:05:00Z"
+			"dateCompleted": "1970-01-01T00:00:00Z"
 		}
 	]
 }`
@@ -100,12 +104,14 @@ const policyHistoryXML = `<?xml version="1.0" encoding="UTF-8"?>
 			<policy_id>10</policy_id>
 			<policy_name>Install Chrome</policy_name>
 			<date_completed_epoch>1711800000000</date_completed_epoch>
+			<date_completed_utc>2026-03-30T12:00:00.000+0000</date_completed_utc>
 			<status>Completed</status>
 		</policy_log>
 		<policy_log>
 			<policy_id>11</policy_id>
 			<policy_name>Update Flash</policy_name>
 			<date_completed_epoch>1711790000000</date_completed_epoch>
+			<date_completed_utc>2026-03-30T09:13:20.000+0000</date_completed_utc>
 			<status>Failed</status>
 		</policy_log>
 	</policy_logs>
@@ -164,6 +170,82 @@ func TestRunDeviceDeepDive_Basic(t *testing.T) {
 	for _, want := range []string{"Identity", "Hardware & OS", "Security", "User & Location"} {
 		if !sectionNames[want] {
 			t.Errorf("missing section %q", want)
+		}
+	}
+
+	// MDM history: completed command shows state + date; pending (epoch-zero)
+	// shows state only. Regression guard for the commandState/dateCompleted fix.
+	mdm := findSection(t, sections, "MDM Command History (Last 10)")
+	assertItem(t, mdm, "ProfileList", "ACKNOWLEDGED  2026-03-30 10:01")
+	assertItem(t, mdm, "EraseDevice", "PENDING")
+
+	// Policy history: status + completion date from date_completed_utc.
+	pol := findSection(t, sections, "Policy History (Last 10)")
+	assertItem(t, pol, "Install Chrome", "Completed  2026-03-30 12:00")
+	assertItem(t, pol, "Update Flash", "Failed  2026-03-30 09:13")
+}
+
+// findSection returns the named section or fails the test.
+func findSection(t *testing.T, sections []overviewSection, name string) overviewSection {
+	t.Helper()
+	for _, s := range sections {
+		if s.Name == name {
+			return s
+		}
+	}
+	t.Fatalf("missing section %q", name)
+	return overviewSection{}
+}
+
+// assertItem asserts the section contains an item with the given resource label
+// and value.
+func assertItem(t *testing.T, s overviewSection, resource, value string) {
+	t.Helper()
+	for _, item := range s.Items {
+		if item.Resource == resource {
+			if item.Value != value {
+				t.Errorf("section %q item %q value = %q, want %q", s.Name, resource, item.Value, value)
+			}
+			return
+		}
+	}
+	t.Errorf("section %q missing item %q", s.Name, resource)
+}
+
+func TestFormatCompletedDate(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"mdm epoch zero sentinel", "1970-01-01T00:00:00Z", ""},
+		{"mdm rfc3339 millis", "2024-06-03T07:53:42.489Z", "2024-06-03 07:53"},
+		{"mdm rfc3339 no fraction", "2026-03-30T10:01:00Z", "2026-03-30 10:01"},
+		{"classic utc offset", "2024-06-21T10:05:45.000+0000", "2024-06-21 10:05"},
+		{"unparseable returned raw", "2024/06/21 at 10:05 AM", "2024/06/21 at 10:05 AM"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatCompletedDate(tt.in); got != tt.want {
+				t.Errorf("formatCompletedDate(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHistoryValue(t *testing.T) {
+	tests := []struct {
+		status, completed, want string
+	}{
+		{"ACKNOWLEDGED", "2024-06-03 07:53", "ACKNOWLEDGED  2024-06-03 07:53"},
+		{"PENDING", "", "PENDING"},
+		{"", "2024-06-03 07:53", "2024-06-03 07:53"},
+		{"", "", ""},
+	}
+	for _, tt := range tests {
+		if got := historyValue(tt.status, tt.completed); got != tt.want {
+			t.Errorf("historyValue(%q, %q) = %q, want %q", tt.status, tt.completed, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
Closes #274.

The `pro device` view lists MDM Command History and Policy History (last 10 each) with the command type / policy name and its status, but not **when** it completed. This adds the completion date to both sections, as requested.

## Changes

**MDM Command History**
- Now surfaces `dateCompleted` next to each command's state.
- **Also fixes a latent bug:** the section read the field `status`, but `/v2/mdm/commands` returns `commandState` (`ACKNOWLEDGED`, `PENDING`, `ERROR`, …). The status column was therefore **blank for every device**. Now reads `commandState`.
- Pending commands report the epoch-zero sentinel (`1970-01-01T00:00:00Z`); those render with no date.

**Policy History**
- Surfaces `date_completed_utc` next to each policy's status.

**Helpers**
- `formatCompletedDate` — normalizes MDM RFC3339 timestamps and Classic `date_completed_utc` (`…+0000`) to a compact `2006-01-02 15:04`; blanks the epoch-zero sentinel; returns unparseable input unchanged so nothing is silently dropped.
- `historyValue` — folds status/state + date into the single right-aligned value column (no renderer/struct changes; flows through `-o json`/`csv`/etc.).

## Live output (test instance, device id 5)

```
MDM Command History (Last 10)
  CLEAR_ACTIVATION_LOCK_BYPASS_CODE         ACKNOWLEDGED  2024-06-03 07:53
  INSTALL_PROFILE                                                  PENDING

Policy History (Last 10)
  Update Inventory                             Completed  2024-06-21 10:05
  Submit inventory to datajar.mobi             Completed  2024-06-03 16:16
```

## Tests
- Corrected stale fixtures that used non-existent API fields (`status`/`completedDateTime`) — they only passed because they matched the old buggy read. Fixtures now mirror the real API shape (verified against a live instance), including an epoch-zero pending command and `date_completed_utc`.
- Added assertions on both history sections and table-driven unit tests for the two helpers.
- `make lint` → 0 issues; `go test ./...` → green.

No overlap with #275 (that PR touches the generator, generated files, and `pro_report*`/`pro_audit`; this is scoped to `pro_device.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)