### PR TITLE
fix(site): surface Jamf Security Cloud command count

### DIFF
--- a/docs/site/catalog.js
+++ b/docs/site/catalog.js
@@ -66,7 +66,9 @@
     'Classic - Patch Management',
     'Security Configuration',
     'Endpoints',
-    'Access & Identity'
+    'Access & Identity',
+    'Device Risk & Lifecycle',
+    'Shared Signals & Events'
   ];
 
   var JAMF_ICON_SVG = '<svg class="product-icon" viewBox="0 0 43 43" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg>';
@@ -212,6 +214,20 @@
   function animateCount(id, target) {
     var el = document.getElementById(id);
     if (!el) return;
+
+    // Zero-state: a product with no commands in the deployed catalog (e.g. a
+    // namespace merged after the last release the site builds from) renders a
+    // muted "Soon" rather than a stark "0", which reads as broken. Auto-clears
+    // to the real number once that product ships in a release.
+    var card = el.closest('.stat-card');
+    if (target === 0) {
+      if (card) card.classList.add('zero-state');
+      el.textContent = 'Soon';
+      el.classList.add('loaded');
+      return;
+    }
+    if (card) card.classList.remove('zero-state');
+
     var duration = 1200;
     var start = null;
     function step(ts) {

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -173,23 +173,23 @@
     <div class="stat-cards">
       <a href="#commands" class="stat-card" data-product="platform" data-tab="platform" data-tip="Includes Pro commands surfaced through the Platform Gateway — counts overlap with Jamf Pro." aria-label="Jamf Platform — includes Pro commands surfaced through the Platform Gateway, so counts overlap with Jamf Pro.">
         <span class="stat-value" id="stat-platform">&mdash;</span>
-        <span class="stat-label"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf Platform</span>
+        <span class="stat-label"><span class="stat-brand"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf</span><span class="stat-product">Platform</span></span>
       </a>
       <a href="#commands" class="stat-card" data-product="pro" data-tab="pro">
         <span class="stat-value" id="stat-pro">&mdash;</span>
-        <span class="stat-label"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf Pro</span>
+        <span class="stat-label"><span class="stat-brand"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf</span><span class="stat-product">Pro</span></span>
       </a>
       <a href="#commands" class="stat-card" data-product="protect" data-tab="protect">
         <span class="stat-value" id="stat-protect">&mdash;</span>
-        <span class="stat-label"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf Protect</span>
+        <span class="stat-label"><span class="stat-brand"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf</span><span class="stat-product">Protect</span></span>
       </a>
       <a href="#commands" class="stat-card" data-product="school" data-tab="school">
         <span class="stat-value" id="stat-school">&mdash;</span>
-        <span class="stat-label"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf School</span>
+        <span class="stat-label"><span class="stat-brand"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf</span><span class="stat-product">School</span></span>
       </a>
       <a href="#commands" class="stat-card" data-product="security" data-tab="security">
         <span class="stat-value" id="stat-security">&mdash;</span>
-        <span class="stat-label"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf Security Cloud</span>
+        <span class="stat-label"><span class="stat-brand"><svg class="product-icon" viewBox="0 0 43 43" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M33.63 6.96c-5.52 0-8.78 2.33-10.27 7.31l-3.84 11.88c-1.41 3.91-3.68 5.52-7.82 5.52H2.19A2.19 2.19 0 000 33.87v6.06c0 1.16.94 2.1 2.1 2.1h38.57a2.19 2.19 0 002.19-2.19V9.08c0-1.17-.95-2.12-2.11-2.12h-7.12z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M2.35 0A2.35 2.35 0 000 2.35v16.22a2.29 2.29 0 002.29 2.29h8.17c3.74 0 8.88-.77 10.29-7.41l2.23-10.6A2.35 2.35 0 0020.68 0H2.35z" fill="currentColor"/></svg> Jamf</span><span class="stat-product">Security Cloud</span></span>
       </a>
     </div>
 
@@ -321,7 +321,7 @@
 
       <div class="faq-item">
         <h3>What is jamf-cli?</h3>
-        <p>jamf-cli is a unified command-line interface for the Jamf platform. A single binary manages Jamf Platform API Gateway, Jamf Pro, Jamf Protect, Jamf School, and Jamf Security Cloud — over 1,250 commands covering the full API surface, with structured output built for scripting and automation.</p>
+        <p>jamf-cli is a unified command-line interface for the Jamf platform. A single binary manages Jamf Platform API Gateway, Jamf Pro, Jamf Protect, Jamf School, and Jamf Security Cloud — __COMMAND_COUNT__ commands covering the full API surface, with structured output built for scripting and automation.</p>
       </div>
 
       <div class="faq-item">
@@ -361,7 +361,7 @@
         "name": "What is jamf-cli?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "jamf-cli is a unified command-line interface for the Jamf platform. A single binary manages Jamf Platform API Gateway, Jamf Pro, Jamf Protect, Jamf School, and Jamf Security Cloud — over 1,250 commands covering the full API surface, with structured output built for scripting and automation."
+          "text": "jamf-cli is a unified command-line interface for the Jamf platform. A single binary manages Jamf Platform API Gateway, Jamf Pro, Jamf Protect, Jamf School, and Jamf Security Cloud — __COMMAND_COUNT__ commands covering the full API surface, with structured output built for scripting and automation."
         }
       },
       {

--- a/docs/site/style.css
+++ b/docs/site/style.css
@@ -666,10 +666,10 @@ a[target="_blank"]:hover::after {
   background: var(--card-bg);
   border: 1px solid var(--border);
   border-radius: 6px;
-  padding: 1.5rem 2rem;
-  min-width: 150px;
+  padding: 1.15rem 1.5rem;
+  min-width: 140px;
   flex: 1;
-  max-width: 200px;
+  max-width: 180px;
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   transition: transform 0.15s, border-color 0.15s, box-shadow 0.15s;
@@ -728,14 +728,39 @@ a.stat-card:hover {
   line-height: 1.1;
   letter-spacing: -0.02em;
   font-feature-settings: "tnum", "ss01";
+  margin-bottom: 0.4rem;
+}
+
+/* A product not yet in the deployed catalog shows a muted "Soon" instead of a
+   count. Desaturate the whole card and shrink the label so it reads as
+   intentional, not a rendering failure. */
+.stat-card.zero-state {
+  border-color: var(--border);
+  opacity: 0.7;
+}
+.stat-card.zero-state .stat-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0;
 }
 
 .stat-card .stat-label {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-primary);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  white-space: nowrap;
+  letter-spacing: 0.03em;
+  text-align: center;
+  line-height: 1.35;
+}
+
+/* Two-line label: "Jamf" (with icon) on the first line, product name on the
+   second. Keeps every card uniform and lets long names like "Security Cloud"
+   sit on their own line instead of overrunning the card. */
+.stat-card .stat-label .stat-brand,
+.stat-card .stat-label .stat-product {
+  display: block;
 }
 
 .stat-card .stat-label .product-icon {

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -901,9 +901,12 @@ func collectCommands(cmd *cobra.Command, prefix, product, group string) []comman
 			fullPath = prefix + " " + child.Name()
 		}
 
-		// Determine product for this child's subtree.
+		// Determine product for this child's subtree. Only top-level namespaces
+		// set the product: product is empty only at the root, so gating on it
+		// prevents a nested command that happens to be named after a namespace
+		// (e.g. "pro report security") from being re-tagged.
 		childProduct := product
-		if child.Name() == "pro" || child.Name() == "protect" || child.Name() == "school" || child.Name() == "security" || child.Name() == "platform" {
+		if product == "" && (child.Name() == "pro" || child.Name() == "protect" || child.Name() == "school" || child.Name() == "security" || child.Name() == "platform") {
 			childProduct = child.Name()
 		}
 

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -111,6 +111,35 @@ func TestCollectCommands(t *testing.T) {
 	}
 }
 
+// TestCollectCommands_NestedNamespaceNameNotReclassified guards a regression
+// where a nested command named after a top-level namespace (e.g.
+// "pro report security") was mis-tagged with that namespace's product. Only
+// top-level namespaces should set the product.
+func TestCollectCommands_NestedNamespaceNameNotReclassified(t *testing.T) {
+	root := NewRootCmd("test", "abc123", "2024-01-01", "unknown")
+	entries := collectCommands(root, "", "", "")
+
+	byCommand := make(map[string]commandEntry, len(entries))
+	for _, e := range entries {
+		byCommand[e.Command] = e
+	}
+
+	e, ok := byCommand["pro report security"]
+	if !ok {
+		t.Fatal("expected 'pro report security' command in entries")
+	}
+	if e.Product != "pro" {
+		t.Errorf("'pro report security' product = %q, want %q", e.Product, "pro")
+	}
+
+	// Every top-level namespace command should still be tagged with its own product.
+	for _, ns := range []string{"pro", "protect", "school", "security", "platform"} {
+		if got := byCommand[ns].Product; got != ns {
+			t.Errorf("top-level %q product = %q, want %q", ns, got, ns)
+		}
+	}
+}
+
 func TestCommandEntriesToMaps_Full(t *testing.T) {
 	entries := []commandEntry{
 		{


### PR DESCRIPTION
## Problem

The GitHub Pages hero shows **Jamf Security Cloud: 0**, and the headline total (1,599) is 21 short of what `main` actually ships.

<img width="600" alt="Security Cloud showing 0" src="https://github.com/user-attachments/assets/placeholder" />

## Root cause — two independent issues

**1. Latent regression in `commands -o json` (correctness).** The product-detection walk in `collectCommands` matched any command literally *named* a namespace, so `pro report security` was tagged `product: "security"` instead of `pro`. In the released v1.22.0 it's correct; on current `main` it's wrong. On the next release Security Cloud would show 21 (one bogus) and Pro would be undercounted by one.

**2. Stale deployed catalog.** On non-release pushes, `deploy-site.yaml` builds the CLI from the *latest release tag* (`v1.22.0`) "so the deployed catalog reflects the released CLI." The Security Cloud namespace merged **after** v1.22.0, so the deployed binary has no `security` commands at all → the card genuinely shows 0 until v1.23.0 ships. Math checks out exactly: 1,620 (main) − 21 (security) = 1,599 (live). We're **not** changing the release-tracking contract — the "0" is truthful, it just looks broken.

## Changes

- **Regression fix** (`root.go`): gate the namespace check on top-level position (`product == ""`) so a nested command named after a namespace can't be re-tagged. Adds `TestCollectCommands_NestedNamespaceNameNotReclassified`.
- **Graceful zero-state** (`catalog.js` + `style.css`): any product stat card with a 0 count renders a muted **"Soon"** instead of a stark red "0". Reads as intentional, auto-clears to the real number on the next release, and generalizes to any future namespace.
- **Stale prose → dynamic** (`index.html`): replace hardcoded "over 1,250 commands" in the FAQ body + JSON-LD with the `__COMMAND_COUNT__` placeholder the deploy workflow already substitutes (its grep-guard fails the build on any leftover placeholder).
- **Group-order polish** (`catalog.js`): add the real Security Cloud group titles (`Device Risk & Lifecycle`, `Shared Signals & Events`) to `GROUP_ORDER` so the section renders deliberately, not alphabetically.

## Verification

- `make build && make test && make lint` (0 issues) `&& make verify-site` — all green.
- Drove the built site in a browser against a regenerated catalog:
  - Live-data path: Security **20**, Pro **1,349** (regained the mis-tagged command), header total **1,620**, no zero-state.
  - Zero-state path (deployed-v1.22.0 catalog with security stripped): Security card shows **"Soon"**, muted, in both light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)