### PR TITLE
feat(platform): add --name flag to benchmark-reports commands

### DIFF
--- a/generator/platform/emitter.go
+++ b/generator/platform/emitter.go
@@ -65,6 +65,20 @@ var platformTableColumns = map[string][]tableColumn{
 	},
 }
 
+// crossResourceNameLookupPath maps a resource name to a list endpoint owned by
+// a *different* resource, used for --name → ID resolution when the resource has
+// no list op of its own but its single {id} path param refers to a sibling
+// resource's ID.
+//
+// Example: benchmark-reports' ops are GET /benchmarks/{id}/rules etc.; the {id}
+// is a benchmark ID (owned by the separate "benchmarks" tag), so --name resolves
+// against the benchmarks list. The generic platform.ResolveIDByName matches
+// compliance-benchmark titles and reads the "id" field, so no SDK-specific code
+// is needed. Paths carry a literal {tenantId} the template substitutes at runtime.
+var crossResourceNameLookupPath = map[string]string{
+	"benchmark-reports": "/api/compliance-benchmarks/v1/tenant/{tenantId}/benchmarks",
+}
+
 // templateOp wraps *parser.Operation with template-friendly fields.
 type templateOp struct {
 	*parser.Operation
@@ -212,6 +226,12 @@ func buildTemplateResource(r *parser.Resource) templateResource {
 			listPath = restoreTenantSegment(op.Path)
 			break
 		}
+	}
+	// Resources with no list op of their own (e.g. benchmark-reports) resolve
+	// --name against a sibling resource's list endpoint when their {id} refers
+	// to that sibling's ID.
+	if listPath == "" {
+		listPath = crossResourceNameLookupPath[r.Name]
 	}
 
 	ops := make([]templateOp, 0, len(r.Operations))

--- a/internal/commands/platform/generated/benchmark-reports.go
+++ b/internal/commands/platform/generated/benchmark-reports.go
@@ -32,19 +32,33 @@ func NewBenchmarkReportsCmd(cliCtx *registry.CLIContext) *cobra.Command {
 }
 
 func newBenchmarkReportsCompliancePercentageCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var nameFlag string
 	cmd := &cobra.Command{
 		Use:         "compliance-percentage <id>",
 		Short:       "Get compliance percentage for a benchmark report",
 		Long:        "Calculate and return the overall compliance percentage for a specific benchmark report as sum of device compliance scores divided by number of devices",
 		Annotations: map[string]string{"jamf:privileges": "read:pro:compliance-benchmarks"},
-		Args:        cobra.ExactArgs(1),
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := platform.RequirePlatformClient(cliCtx.PlatformSDKClient); err != nil {
 				return err
 			}
+			var resolvedID string
+			if nameFlag != "" {
+				listPath := strings.Replace("/api/compliance-benchmarks/v1/tenant/{tenantId}/benchmarks", "{tenantId}", url.PathEscape(cliCtx.PlatformSDKClient.Transport().TenantID()), 1)
+				id, err := platform.ResolveIDByName(cmd.Context(), cliCtx.PlatformSDKClient, listPath, nameFlag)
+				if err != nil {
+					return err
+				}
+				resolvedID = id
+			} else if len(args) == 1 {
+				resolvedID = args[0]
+			} else {
+				return fmt.Errorf("provide a positional ID or --name")
+			}
 			path := "/api/compliance-benchmarks/v1/tenant/{tenantId}/benchmarks/{id}/compliance-percentage"
 			path = strings.Replace(path, "{tenantId}", url.PathEscape(cliCtx.PlatformSDKClient.Transport().TenantID()), 1)
-			path = strings.Replace(path, "{id}", url.PathEscape(args[0]), 1)
+			path = strings.Replace(path, "{id}", url.PathEscape(resolvedID), 1)
 			q := url.Values{}
 			var body any
 			if encoded := q.Encode(); encoded != "" {
@@ -64,10 +78,12 @@ func newBenchmarkReportsCompliancePercentageCmd(cliCtx *registry.CLIContext) *co
 			return cliCtx.Output.PrintRaw(b)
 		},
 	}
+	cmd.Flags().StringVar(&nameFlag, "name", "", "Resolve target by name instead of ID (uses the resource list endpoint)")
 	return cmd
 }
 
 func newBenchmarkReportsDevicesCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var nameFlag string
 	var ruleId string
 	var deviceSearch string
 	var ruleResult string
@@ -77,14 +93,27 @@ func newBenchmarkReportsDevicesCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short:       "Get devices for a benchmark report rule",
 		Long:        "Provide devices filtered report for a specific benchmark rule",
 		Annotations: map[string]string{"jamf:privileges": "read:pro:compliance-benchmarks"},
-		Args:        cobra.ExactArgs(1),
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := platform.RequirePlatformClient(cliCtx.PlatformSDKClient); err != nil {
 				return err
 			}
+			var resolvedID string
+			if nameFlag != "" {
+				listPath := strings.Replace("/api/compliance-benchmarks/v1/tenant/{tenantId}/benchmarks", "{tenantId}", url.PathEscape(cliCtx.PlatformSDKClient.Transport().TenantID()), 1)
+				id, err := platform.ResolveIDByName(cmd.Context(), cliCtx.PlatformSDKClient, listPath, nameFlag)
+				if err != nil {
+					return err
+				}
+				resolvedID = id
+			} else if len(args) == 1 {
+				resolvedID = args[0]
+			} else {
+				return fmt.Errorf("provide a positional ID or --name")
+			}
 			path := "/api/compliance-benchmarks/v1/tenant/{tenantId}/benchmarks/{id}/devices"
 			path = strings.Replace(path, "{tenantId}", url.PathEscape(cliCtx.PlatformSDKClient.Transport().TenantID()), 1)
-			path = strings.Replace(path, "{id}", url.PathEscape(args[0]), 1)
+			path = strings.Replace(path, "{id}", url.PathEscape(resolvedID), 1)
 			q := url.Values{}
 			if ruleId != "" {
 				q.Set("rule-id", ruleId)
@@ -130,6 +159,7 @@ func newBenchmarkReportsDevicesCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			return cliCtx.Output.PrintRaw(b)
 		},
 	}
+	cmd.Flags().StringVar(&nameFlag, "name", "", "Resolve target by name instead of ID (uses the resource list endpoint)")
 	cmd.Flags().StringVar(&ruleId, "rule-id", "", "Filter by rule-id")
 	_ = cmd.MarkFlagRequired("rule-id")
 	cmd.Flags().StringVar(&deviceSearch, "device-search", "", "Search devices with matching device name or device ID")
@@ -139,6 +169,7 @@ func newBenchmarkReportsDevicesCmd(cliCtx *registry.CLIContext) *cobra.Command {
 }
 
 func newBenchmarkReportsRulesCmd(cliCtx *registry.CLIContext) *cobra.Command {
+	var nameFlag string
 	var ruleSearch string
 	var sort string
 	cmd := &cobra.Command{
@@ -146,14 +177,27 @@ func newBenchmarkReportsRulesCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short:       "Get benchmark rules for a tenant",
 		Long:        "Provide benchmark rules stats for a specific benchmark",
 		Annotations: map[string]string{"jamf:privileges": "read:pro:compliance-benchmarks"},
-		Args:        cobra.ExactArgs(1),
+		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := platform.RequirePlatformClient(cliCtx.PlatformSDKClient); err != nil {
 				return err
 			}
+			var resolvedID string
+			if nameFlag != "" {
+				listPath := strings.Replace("/api/compliance-benchmarks/v1/tenant/{tenantId}/benchmarks", "{tenantId}", url.PathEscape(cliCtx.PlatformSDKClient.Transport().TenantID()), 1)
+				id, err := platform.ResolveIDByName(cmd.Context(), cliCtx.PlatformSDKClient, listPath, nameFlag)
+				if err != nil {
+					return err
+				}
+				resolvedID = id
+			} else if len(args) == 1 {
+				resolvedID = args[0]
+			} else {
+				return fmt.Errorf("provide a positional ID or --name")
+			}
 			path := "/api/compliance-benchmarks/v1/tenant/{tenantId}/benchmarks/{id}/rules"
 			path = strings.Replace(path, "{tenantId}", url.PathEscape(cliCtx.PlatformSDKClient.Transport().TenantID()), 1)
-			path = strings.Replace(path, "{id}", url.PathEscape(args[0]), 1)
+			path = strings.Replace(path, "{id}", url.PathEscape(resolvedID), 1)
 			q := url.Values{}
 			if ruleSearch != "" {
 				q.Set("rule-search", ruleSearch)
@@ -193,6 +237,7 @@ func newBenchmarkReportsRulesCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			return cliCtx.Output.PrintRaw(b)
 		},
 	}
+	cmd.Flags().StringVar(&nameFlag, "name", "", "Resolve target by name instead of ID (uses the resource list endpoint)")
 	cmd.Flags().StringVar(&ruleSearch, "rule-search", "", "string to search in rule title and rule id")
 	cmd.Flags().StringVar(&sort, "sort", "", "Sort order of result (e.g., 'ruleTitle:asc', 'passed:desc', 'failed:desc', 'unknown:desc'). Supports chained sorting like 'ruleId,passed:desc'. Ascending order is default and in such a case doesn't require to be specified, such as 'ruleNumber,ruleTitle'.")
 	return cmd


### PR DESCRIPTION
## Summary

Adds `--name` to all three `pro benchmark-reports` subcommands (`rules`, `devices`, `compliance-percentage`) so users can target a benchmark by title instead of first looking up its ID via `pro compliance-benchmarks`.

```
# before
ID=$(bin/jamf-cli pro compliance-benchmarks list | jq -r '.[]|select(.title=="CIS Level 1 Tahoe Only").id')
bin/jamf-cli pro benchmark-reports rules "$ID"

# after
bin/jamf-cli pro benchmark-reports rules --name "CIS Level 1 Tahoe Only"
```

The positional `<id>` still works; `--name` is an alternative.

## Why it was missing

`benchmark-reports` is its own OpenAPI tag with no `list` op — its ops are `GET /benchmarks/{id}/{rules,devices,compliance-percentage}`, where `{id}` is a *benchmark* ID owned by the separate `benchmarks` tag. The Platform emitter only grants `--name` when a resource has a list op of its own, so this resource never got it.

## Change

Generator-only (generated file is a mechanical `make generate` result):

1. `crossResourceNameLookupPath` map in `generator/platform/emitter.go` — `benchmark-reports` → the benchmarks list endpoint.
2. `buildTemplateResource` falls back to that map when a resource has no own list op.

No SDK-specific code needed: the generated template's existing generic `platform.ResolveIDByName` already matches compliance-benchmark `title` and reads the `id` field (it's already tuned for that endpoint's list shape).

## Testing

- `make generate`, `make build`, full `make test` (pass), `make verify-generated` (in sync).
- Live-tested against a real Platform tenant:
  - `rules`/`compliance-percentage`/`devices` all resolve `--name` correctly
  - `--name` output is byte-identical to the positional-ID output (parity verified)
  - unknown name → `not found: no item with name "..."`
  - no ID and no `--name` → `provide a positional ID or --name`

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)