### PR TITLE
feat(blueprints): denylist model, smart MCX handling, and import-profile scope/converter fixes

### DIFF
--- a/internal/blueprintcomponents/scaffolds.go
+++ b/internal/blueprintcomponents/scaffolds.go
@@ -75,9 +75,11 @@ var rawScaffolds = map[string]string{
 	"com.jamf.ddm.custom-declarations": `{
   "declarations": [
     {
+      "type": "",
+      "channelType": "SYSTEM",
       "kind": "CONFIGURATION",
       "payload": {},
-      "type": ""
+      "payloadKey": 1
     }
   ]
 }`,

--- a/internal/commands/pro_blueprints.go
+++ b/internal/commands/pro_blueprints.go
@@ -1009,10 +1009,24 @@ Examples:
 	cmd.Flags().StringVar(&displayName, "display-name", "", "Display name for the component (defaults to payload type)")
 	cmd.Flags().BoolVar(&stripDefaults, "strip-defaults", false, "Remove keys set to Apple's default values (fetches schemas from GitHub)")
 	_ = cmd.MarkFlagRequired("payload-type")
-	_ = cmd.RegisterFlagCompletionFunc("payload-type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		return profileconvert.SupportedPayloadTypesList(), cobra.ShellCompDirectiveNoFileComp
-	})
 	return cmd
+}
+
+// warnAPIOnlyPayloads inspects a configuration-profile component's config and,
+// if it contains payload types the Jamf Pro UI cannot manage directly, prints
+// an advisory naming them. Those payloads show as read-only "Legacy payload"
+// items in the UI and can only be edited through the blueprints API. Payload
+// types the UI can manage (UIManageablePayloadTypes) produce no warning.
+func warnAPIOnlyPayloads(config json.RawMessage) {
+	apiOnly := profileconvert.APIOnlyPayloadTypes(config)
+	if len(apiOnly) == 0 {
+		return
+	}
+	fmt.Fprintln(os.Stderr, "Note: the following payload(s) can only be managed through the blueprints API — "+
+		"they show as read-only \"Legacy payload\" items in the Jamf Pro UI and cannot be edited there:")
+	for _, pt := range apiOnly {
+		fmt.Fprintf(os.Stderr, "  - %s\n", pt)
+	}
 }
 
 func newBlueprintsImportProfileCmd(cliCtx *registry.CLIContext) *cobra.Command {
@@ -1040,6 +1054,14 @@ exists. Currently supported:
 
 Payloads without a DDM mapping are wrapped in a com.jamf.ddm-configuration-profile
 component. A single profile with mixed payloads produces multiple components.
+Some of these configuration-profile ("legacy payload") components can only be
+managed through the blueprints API — they appear as read-only "Legacy payload"
+items in the Jamf Pro UI and cannot be edited there.
+
+The blueprints API accepts almost every Apple payload type and validates it against
+Apple's published schema. A small set of payload types is disabled by blueprints
+(certificates, VPN, SSO, web clips, fonts, etc.); those are skipped by default with
+a warning. Use --include-unsupported to send them anyway (the API will reject them).
 
 Use --type to specify the profile type: "computer" (default) for macOS configuration
 profiles or "mobile" for mobile device configuration profiles. Profiles can share
@@ -1128,6 +1150,7 @@ Examples:
 				}
 				types := profileconvert.PayloadTypeSummary([]byte(mobileconfig))
 				fmt.Fprintf(os.Stderr, "Processed %d payload(s) (legacy mode — no DDM conversion)\n", len(types))
+				warnAPIOnlyPayloads(config)
 				components = append(components, blueprints.Component{
 					Identifier:    "com.jamf.ddm-configuration-profile",
 					Configuration: config,
@@ -1175,6 +1198,7 @@ Examples:
 				}
 				if ddmResult.ProfileConfig != nil {
 					fmt.Fprintln(os.Stderr, "  remaining payloads wrapped in configuration-profile component")
+					warnAPIOnlyPayloads(ddmResult.ProfileConfig)
 				}
 
 				for _, nc := range ddmResult.NativeComponents {
@@ -1247,7 +1271,7 @@ Examples:
 	cmd.Flags().StringVar(&blueprintName, "blueprint-name", "", "Override the blueprint name (defaults to profile display name)")
 	cmd.Flags().StringVar(&profileType, "type", "computer", "Profile type: computer (macOS) or mobile (iOS/iPadOS/tvOS)")
 	cmd.Flags().BoolVar(&noConvert, "legacy", false, "Wrap all payloads in a single configuration-profile component without DDM conversion")
-	cmd.Flags().BoolVar(&includeUnsupported, "include-unsupported", false, "Include payload types not supported by the platform API (may cause validation errors)")
+	cmd.Flags().BoolVar(&includeUnsupported, "include-unsupported", false, "Send payloads blueprints disables anyway (the API will reject them; by default they are skipped)")
 	cmd.Flags().BoolVar(&stripDefaults, "strip-defaults", false, "Remove keys set to Apple's default values (fetches schemas from GitHub)")
 	_ = cmd.RegisterFlagCompletionFunc("type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"computer", "mobile"}, cobra.ShellCompDirectiveNoFileComp

--- a/internal/commands/pro_blueprints.go
+++ b/internal/commands/pro_blueprints.go
@@ -1036,6 +1036,8 @@ func newBlueprintsImportProfileCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		includeUnsupported bool
 		stripDefaults      bool
 		noConvert          bool
+		computerGroups     []string
+		mobileDeviceGroups []string
 	)
 	cmd := &cobra.Command{
 		Use:   "import-profile <profile-name>",
@@ -1080,12 +1082,19 @@ Scope handling:
   limitations, and exclusions are NOT imported — blueprints only support device
   group scoping. You will be warned about any scope elements that are dropped.
 
+  Because blueprints require at least one device group, a profile whose scope has
+  no groups (e.g. scoped to all computers or to individual devices) cannot be
+  imported as-is: the command errors before calling the API. Use --computer-group
+  or --mobile-device-group to set the scope explicitly. These flags also override
+  the profile's own scope when you want to target different groups.
+
 Examples:
   jamf-cli pro blueprints import-profile "Passcode Policy"
   jamf-cli pro blueprints import-profile "My Restrictions"
   jamf-cli pro blueprints import-profile "Managed Restrictions" --type mobile
   jamf-cli pro blueprints import-profile "FileVault Settings" --blueprint-name "FV Blueprint"
   jamf-cli pro blueprints import-profile "My Restrictions" --strip-defaults
+  jamf-cli pro blueprints import-profile "Software Update" --computer-group "All Managed"
   jamf-cli pro blueprints import-profile "My Restrictions" --include-unsupported`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -1219,15 +1228,33 @@ Examples:
 				return fmt.Errorf("no components produced — all payloads were stripped or unsupported")
 			}
 
-			// Step 4: Extract scope from Classic API XML and resolve to platform UUIDs
-			scopeGroups, scopeWarnings := extractAndResolveScope(ctx, cliCtx.Client, body)
-			for _, w := range scopeWarnings {
-				fmt.Fprintf(os.Stderr, "Warning: %s\n", w)
-			}
-			if len(scopeGroups) > 0 {
-				fmt.Fprintf(os.Stderr, "Resolved %d scope group(s) to platform UUIDs\n", len(scopeGroups))
+			// Step 4: Determine scope. --computer-group/--mobile-device-group override
+			// the profile's own scope; otherwise carry over the profile's target groups.
+			var scopeGroups []string
+			if len(computerGroups) > 0 || len(mobileDeviceGroups) > 0 {
+				scopeGroups, err = resolveAllGroupFlags(ctx, cliCtx.Client, nil, computerGroups, mobileDeviceGroups)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(os.Stderr, "Scope overridden with %d group(s) from flags\n", len(scopeGroups))
 			} else {
-				fmt.Fprintln(os.Stderr, "No scope groups resolved — blueprint will have empty scope")
+				var scopeWarnings []string
+				scopeGroups, scopeWarnings = extractAndResolveScope(ctx, cliCtx.Client, body)
+				for _, w := range scopeWarnings {
+					fmt.Fprintf(os.Stderr, "Warning: %s\n", w)
+				}
+				if len(scopeGroups) > 0 {
+					fmt.Fprintf(os.Stderr, "Resolved %d scope group(s) to platform UUIDs\n", len(scopeGroups))
+				}
+			}
+
+			// Blueprints require a non-empty device-group scope. Fail fast with an
+			// actionable message instead of letting CreateBlueprint 400.
+			if len(scopeGroups) == 0 {
+				return fmt.Errorf("profile %q has no device-group scope that blueprints can use — "+
+					"re-run with --computer-group \"<name>\" (or --mobile-device-group) to set the scope.\n"+
+					"Blueprints only support device-group scoping; all-computers, individual-device, "+
+					"building, and department scopes are not carried over", args[0])
 			}
 
 			// Step 5: Build and create the blueprint
@@ -1273,6 +1300,8 @@ Examples:
 	cmd.Flags().BoolVar(&noConvert, "legacy", false, "Wrap all payloads in a single configuration-profile component without DDM conversion")
 	cmd.Flags().BoolVar(&includeUnsupported, "include-unsupported", false, "Send payloads blueprints disables anyway (the API will reject them; by default they are skipped)")
 	cmd.Flags().BoolVar(&stripDefaults, "strip-defaults", false, "Remove keys set to Apple's default values (fetches schemas from GitHub)")
+	cmd.Flags().StringSliceVar(&computerGroups, "computer-group", nil, "Set the blueprint scope to these computer group name(s), overriding the profile's scope (repeatable)")
+	cmd.Flags().StringSliceVar(&mobileDeviceGroups, "mobile-device-group", nil, "Set the blueprint scope to these mobile device group name(s), overriding the profile's scope (repeatable)")
 	_ = cmd.RegisterFlagCompletionFunc("type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"computer", "mobile"}, cobra.ShellCompDirectiveNoFileComp
 	})

--- a/internal/commands/pro_blueprints.go
+++ b/internal/commands/pro_blueprints.go
@@ -1065,6 +1065,12 @@ Apple's published schema. A small set of payload types is disabled by blueprints
 (certificates, VPN, SSO, web clips, fonts, etc.); those are skipped by default with
 a warning. Use --include-unsupported to send them anyway (the API will reject them).
 
+Application & Custom Settings (MCX) payloads are unwrapped when their inner
+preference domain is a recognized Apple payload. Classifying an unknown domain
+fetches Apple's published schema from GitHub, so import-profile may reach the
+network even without --strip-defaults; it degrades gracefully offline, leaving
+unclassified domains wrapped as opaque Custom Settings (which the API accepts).
+
 Use --type to specify the profile type: "computer" (default) for macOS configuration
 profiles or "mobile" for mobile device configuration profiles. Profiles can share
 names across types, so the flag is required when ambiguous.

--- a/internal/profileconvert/convert.go
+++ b/internal/profileconvert/convert.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"sort"
 	"strings"
 
@@ -20,9 +19,57 @@ a blueprint that contains conflicting keys, unexpected behavior may occur. For e
 if keys within the Restrictions payload conflict, the most restrictive setting will take
 precedence.`
 
-// SupportedPayloadTypes lists legacy payload types supported by Jamf Platform blueprints.
-// Sourced from https://learn.jamf.com/r/en-US/jamf-pro-blueprints-configuration-guide/Blueprints_Release_Notes_Pro
-var SupportedPayloadTypes = map[string]bool{
+// mcxPayloadType is the Apple payload type for the "Application & Custom
+// Settings" payload (Managed Client / MCX). Its managed settings live under a
+// nested PayloadContent dictionary rather than as sibling keys.
+const mcxPayloadType = "com.apple.ManagedClient.preferences"
+
+// DisabledPayloadTypes lists the Apple MDM payload types that Jamf Platform
+// blueprints explicitly refuses. Sending one of these in a
+// com.jamf.ddm-configuration-profile component makes the API reject the whole
+// blueprint with a 400 "Payload disabled: <type>" (independent of the payload's
+// keys). Every other real Apple payload type is accepted and validated against
+// Apple's published schema by the API itself, so this is a denylist rather than
+// an allowlist.
+//
+// Wire-probed against the blueprints API by POSTing every Apple MDM payloadtype
+// (apple/device-management/mdm/profiles) 2026-07-17. This set is
+// instance/version-specific and may drift — the API is the ultimate authority.
+var DisabledPayloadTypes = map[string]bool{
+	"com.apple.ADCertificate.managed":    true, // Active Directory Certificate
+	"com.apple.DirectoryService.managed": true, // Directory Service (AD bind)
+	"com.apple.MCX.FileVault2":           true, // FileVault 2 (legacy MCX)
+	"com.apple.airplay":                  true, // AirPlay
+	"com.apple.airplay.security":         true, // AirPlay Security
+	"com.apple.cellular":                 true, // Cellular
+	"com.apple.dnsSettings.managed":      true, // DNS Settings
+	"com.apple.education":                true, // Education
+	"com.apple.ews.account":              true, // Exchange Web Services account
+	"com.apple.extensiblesso":            true, // Extensible Single Sign-On
+	"com.apple.font":                     true, // Font
+	"com.apple.profileRemovalPassword":   true, // Profile Removal Password
+	"com.apple.proxy.http.global":        true, // Global HTTP Proxy
+	"com.apple.security.pem":             true, // Certificate (PEM)
+	"com.apple.security.pkcs1":           true, // Certificate (PKCS1)
+	"com.apple.security.pkcs12":          true, // Certificate (PKCS12)
+	"com.apple.security.root":            true, // Certificate (root)
+	"com.apple.security.scep":            true, // SCEP
+	"com.apple.vpn.managed":              true, // VPN
+	"com.apple.vpn.managed.appmapping":   true, // Per-App VPN mapping
+	"com.apple.webClip.managed":          true, // Web Clip
+	"com.apple.webcontent-filter":        true, // Web Content Filter
+}
+
+// UIManageablePayloadTypes lists the legacy payload types the Jamf Pro UI can
+// manage directly (the "Legacy payload" picker). The blueprints API accepts
+// many more payload types than these, but any accepted type NOT in this set is
+// delivered as an API-only component: it shows as a read-only "Legacy payload"
+// item in the UI and can only be edited through the blueprints API.
+//
+// Sourced from the Jamf Pro blueprints UI legacy-payload list. Used only to
+// tailor the API-only advisory on import — it is not a filter, so if it drifts
+// the worst case is a slightly inaccurate warning, not a broken import.
+var UIManageablePayloadTypes = map[string]bool{
 	"com.apple.Dictionary":                        true, // Parental Controls: Dictionary
 	"com.apple.DiscRecording":                     true, // Media Management: Disc Burning
 	"com.apple.MCX.Accounts":                      true, // Accounts
@@ -56,15 +103,42 @@ var SupportedPayloadTypes = map[string]bool{
 	"com.apple.screensaver.user":                  true, // Screensaver User
 	"com.apple.security.firewall":                 true, // Firewall
 	"com.apple.security.smartcard":                true, // SmartCard
-	"com.apple.servicemanagement":                 true, // Service Management
+	"com.apple.servicemanagement":                 true, // Service Management - Managed Login Items
 	"com.apple.shareddeviceconfiguration":         true, // Lock Screen Message
 	"com.apple.syspolicy.kernel-extension-policy": true, // System Policy - Kernel Extensions
-	"com.apple.system.logging":                    true, // System Logging
 	"com.apple.systempolicy.control":              true, // System Policy Control
 	"com.apple.systempolicy.managed":              true, // System Policy Managed
 	"com.apple.tvremote":                          true, // TV Remote
 	"com.apple.universalaccess":                   true, // Accessibility
 	"loginwindow":                                 true, // Login Window: Login Items
+}
+
+// APIOnlyPayloadTypes returns, in sorted order, the payload types present in a
+// DDMProfileDto configuration that the Jamf Pro UI cannot manage directly —
+// i.e. accepted by the blueprints API but not in UIManageablePayloadTypes.
+// These render as read-only "Legacy payload" items in the UI. Returns nil when
+// every payload in the config is UI-manageable.
+func APIOnlyPayloadTypes(config json.RawMessage) []string {
+	_, content, ok := parsePayloadContent(config)
+	if !ok {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var apiOnly []string
+	for _, item := range content {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		pt, _ := entry["payloadType"].(string)
+		if pt == "" || UIManageablePayloadTypes[pt] || seen[pt] {
+			continue
+		}
+		seen[pt] = true
+		apiOnly = append(apiOnly, pt)
+	}
+	sort.Strings(apiOnly)
+	return apiOnly
 }
 
 // appleMetadataKeys are keys in a mobileconfig payload dict that represent
@@ -113,10 +187,7 @@ func ConvertMobileconfig(data []byte, filterUnsupported bool) (json.RawMessage, 
 		return nil, nil, fmt.Errorf("mobileconfig has no PayloadContent array")
 	}
 
-	// Unwrap MCX (Custom Settings) payloads before processing
-	payloadContent, mcxWarnings := unwrapMCXPayloads(payloadContent)
-
-	warnings := append([]string(nil), mcxWarnings...)
+	var warnings []string
 	payloads := make([]map[string]any, 0, len(payloadContent))
 	typeCount := make(map[string]int) // tracks per-type index for unique identifiers
 
@@ -131,12 +202,12 @@ func ConvertMobileconfig(data []byte, filterUnsupported bool) (json.RawMessage, 
 			return nil, nil, fmt.Errorf("PayloadContent[%d] has no PayloadType", i)
 		}
 
-		if !SupportedPayloadTypes[payloadType] {
+		if DisabledPayloadTypes[payloadType] {
 			if filterUnsupported {
-				warnings = append(warnings, fmt.Sprintf("removed unsupported payload type %q", payloadType))
+				warnings = append(warnings, fmt.Sprintf("skipped payload type %q — Jamf blueprints does not support it", payloadType))
 				continue
 			}
-			warnings = append(warnings, fmt.Sprintf("payload type %q may not be supported — see https://github.com/apple/device-management/tree/release/mdm/profiles", payloadType))
+			warnings = append(warnings, fmt.Sprintf("payload type %q is disabled by Jamf blueprints — the API will reject the blueprint (remove --include-unsupported to skip it)", payloadType))
 		}
 
 		idx := typeCount[payloadType]
@@ -146,7 +217,7 @@ func ConvertMobileconfig(data []byte, filterUnsupported bool) (json.RawMessage, 
 	}
 
 	if len(payloads) == 0 {
-		return nil, warnings, fmt.Errorf("no supported payloads remain after filtering")
+		return nil, warnings, fmt.Errorf("no payloads remain after skipping types blueprints does not support")
 	}
 
 	config := map[string]any{
@@ -171,8 +242,8 @@ func ConvertPlist(data []byte, payloadType, displayName string) (json.RawMessage
 	}
 
 	var warnings []string
-	if !SupportedPayloadTypes[payloadType] {
-		warnings = append(warnings, fmt.Sprintf("payload type %q may not be supported — see https://github.com/apple/device-management/tree/release/mdm/profiles", payloadType))
+	if DisabledPayloadTypes[payloadType] {
+		warnings = append(warnings, fmt.Sprintf("payload type %q is disabled by Jamf blueprints — the API will reject it", payloadType))
 	}
 
 	// All keys in a raw plist are settings (no Apple metadata to strip).
@@ -226,10 +297,8 @@ func PayloadTypeSummary(data []byte) []string {
 	if !ok {
 		return nil
 	}
-	// Unwrap MCX payloads so the count reflects effective payloads
-	unwrapped, _ := unwrapMCXPayloads(content)
 	var types []string
-	for _, item := range unwrapped {
+	for _, item := range content {
 		if payload, ok := item.(map[string]any); ok {
 			if pt, ok := payload["PayloadType"].(string); ok {
 				types = append(types, pt)
@@ -248,6 +317,21 @@ func buildPayloadEntry(payloadType string, payload map[string]any, index int) ma
 	entry := map[string]any{
 		"payloadType":       payloadType,
 		"payloadIdentifier": generatePayloadIdentifier(payloadType, index),
+	}
+
+	// com.apple.ManagedClient.preferences (the "Application & Custom Settings"
+	// payload, a.k.a. MCX) carries its managed settings under PayloadContent —
+	// which is otherwise an Apple metadata key stripped from every payload.
+	// Preserve it intact so the API receives the full Managed Preferences
+	// structure it expects. The blueprints API rejects the alternative of
+	// unwrapping the inner preference domain into a bare payloadType.
+	if payloadType == mcxPayloadType {
+		if pc, ok := payload["PayloadContent"]; ok {
+			if converted := convertPlistValue(pc); !isEmptyValue(converted) {
+				entry["PayloadContent"] = converted
+			}
+		}
+		return entry
 	}
 
 	for k, v := range payload {
@@ -519,116 +603,11 @@ func ConfigHasPayloads(config json.RawMessage) error {
 	return nil
 }
 
-// unwrapMCXPayloads expands any com.apple.ManagedClient.preferences payloads
-// (Custom Settings / MCX) into synthetic payloads keyed by their inner
-// preference domain. Each domain in the MCX wrapper becomes a standalone
-// payload with PayloadType set to the domain identifier and settings extracted
-// from the Forced / Set-Once mcx_preference_settings dictionaries.
-//
-// Non-MCX payloads pass through unchanged.
-func unwrapMCXPayloads(payloads []any) ([]any, []string) {
-	var result []any
-	var warnings []string
-
-	for _, item := range payloads {
-		payload, ok := item.(map[string]any)
-		if !ok {
-			result = append(result, item)
-			continue
-		}
-
-		payloadType, _ := payload["PayloadType"].(string)
-		if payloadType != "com.apple.ManagedClient.preferences" {
-			result = append(result, item)
-			continue
-		}
-
-		// MCX payload — unwrap inner domains from PayloadContent dict
-		content, ok := payload["PayloadContent"].(map[string]any)
-		if !ok {
-			warnings = append(warnings,
-				"com.apple.ManagedClient.preferences payload has no PayloadContent dictionary — skipping")
-			continue
-		}
-
-		unwrapped := 0
-		domains := make([]string, 0, len(content))
-		for domain := range content {
-			domains = append(domains, domain)
-		}
-		sort.Strings(domains)
-		for _, domain := range domains {
-			domainData := content[domain]
-			domainDict, ok := domainData.(map[string]any)
-			if !ok {
-				continue
-			}
-
-			settings := extractMCXSettings(domainDict)
-			if len(settings) == 0 {
-				continue
-			}
-
-			// Build a synthetic payload that looks like a native payload
-			synthetic := map[string]any{
-				"PayloadType": domain,
-			}
-			// Copy Apple metadata from the MCX wrapper (except PayloadType and PayloadContent)
-			for k, v := range payload {
-				if k == "PayloadType" || k == "PayloadContent" {
-					continue
-				}
-				if appleMetadataKeys[k] {
-					synthetic[k] = v
-				}
-			}
-			maps.Copy(synthetic, settings)
-			result = append(result, synthetic)
-			unwrapped++
-		}
-
-		if unwrapped > 0 {
-			warnings = append(warnings,
-				fmt.Sprintf("unwrapped %d domain(s) from Custom Settings (com.apple.ManagedClient.preferences) payload", unwrapped))
-		} else {
-			warnings = append(warnings,
-				"com.apple.ManagedClient.preferences payload had no extractable settings — skipping")
-		}
-	}
-
-	return result, warnings
-}
-
-// extractMCXSettings extracts preference settings from an MCX domain
-// dictionary. MCX stores settings under Forced and/or Set-Once arrays,
-// each containing dicts with an mcx_preference_settings key.
-func extractMCXSettings(domainDict map[string]any) map[string]any {
-	settings := make(map[string]any)
-	for _, arrayKey := range []string{"Set-Once", "Forced"} {
-		arr, ok := domainDict[arrayKey].([]any)
-		if !ok {
-			continue
-		}
-		for _, entry := range arr {
-			entryDict, ok := entry.(map[string]any)
-			if !ok {
-				continue
-			}
-			prefs, ok := entryDict["mcx_preference_settings"].(map[string]any)
-			if !ok {
-				continue
-			}
-			maps.Copy(settings, prefs)
-		}
-	}
-	return settings
-}
-
-// SupportedPayloadTypesList returns the supported payload types as a sorted slice
-// for shell completion and help text.
-func SupportedPayloadTypesList() []string {
-	types := make([]string, 0, len(SupportedPayloadTypes))
-	for t := range SupportedPayloadTypes {
+// DisabledPayloadTypesList returns the payload types blueprints refuses as a
+// sorted slice, for help text and diagnostics.
+func DisabledPayloadTypesList() []string {
+	types := make([]string, 0, len(DisabledPayloadTypes))
+	for t := range DisabledPayloadTypes {
 		types = append(types, t)
 	}
 	sort.Strings(types)

--- a/internal/profileconvert/convert.go
+++ b/internal/profileconvert/convert.go
@@ -23,47 +23,48 @@ precedence.`
 // SupportedPayloadTypes lists legacy payload types supported by Jamf Platform blueprints.
 // Sourced from https://learn.jamf.com/r/en-US/jamf-pro-blueprints-configuration-guide/Blueprints_Release_Notes_Pro
 var SupportedPayloadTypes = map[string]bool{
-	"com.apple.Dictionary":                       true, // Parental Controls: Dictionary
-	"com.apple.DiscRecording":                    true, // Media Management: Disc Burning
-	"com.apple.MCX.Accounts":                     true, // Accounts
-	"com.apple.MCX.MobileAccounts":               true, // Mobile Accounts
-	"com.apple.MCX.TimeMachine":                  true, // Time Machine
-	"com.apple.MCX.TimeServer":                   true, // Time Server
-	"com.apple.NSExtension":                      true, // NSExtension Management
-	"com.apple.SystemConfiguration":              true, // Network Proxy Configuration
-	"com.apple.TCC.configuration-profile-policy": true, // Privacy Preferences Policy Control
-	"com.apple.airprint":                         true, // AirPrint
-	"com.apple.app.lock":                         true, // App Lock
-	"com.apple.applicationaccess":                true, // Restrictions
-	"com.apple.appstore":                         true, // App Store
-	"com.apple.asam":                             true, // Autonomous Single App Mode
-	"com.apple.cellularprivatenetwork.managed":   true, // Cellular Private Network
-	"com.apple.conferenceroomdisplay":            true, // Conference Room Display
-	"com.apple.desktop":                          true, // Desktop
-	"com.apple.dnsProxy.managed":                 true, // DNS Proxy
-	"com.apple.domains":                          true, // Domains
-	"com.apple.familycontrols.contentfilter":     true, // Parental Controls: Content Filter
-	"com.apple.fileproviderd":                    true, // File Provider
-	"com.apple.finder":                           true, // Finder
-	"com.apple.gamed":                            true, // Parental Controls: Game Center
-	"com.apple.loginitems.managed":               true, // Login Items: Managed Items
-	"com.apple.loginwindow":                      true, // Login Window
-	"com.apple.mcxprinting":                      true, // Printing
-	"com.apple.notificationsettings":             true, // Notifications
-	"com.apple.preference.security":              true, // Security Preferences
-	"com.apple.preference.users":                 true, // User Preferences
-	"com.apple.screensaver":                      true, // Screensaver
-	"com.apple.screensaver.user":                 true, // Screensaver User
-	"com.apple.security.firewall":                true, // Firewall
-	"com.apple.security.smartcard":               true, // SmartCard
-	"com.apple.servicemanagement":                true, // Service Management
-	"com.apple.shareddeviceconfiguration":        true, // Lock Screen Message
-	"com.apple.system.logging":                   true, // System Logging
-	"com.apple.systempolicy.control":             true, // System Policy Control
-	"com.apple.systempolicy.managed":             true, // System Policy Managed
-	"com.apple.tvremote":                         true, // TV Remote
-	"com.apple.universalaccess":                  true, // Accessibility
-	"loginwindow":                                true, // Login Window: Login Items
+	"com.apple.Dictionary":                        true, // Parental Controls: Dictionary
+	"com.apple.DiscRecording":                     true, // Media Management: Disc Burning
+	"com.apple.MCX.Accounts":                      true, // Accounts
+	"com.apple.MCX.MobileAccounts":                true, // Mobile Accounts
+	"com.apple.MCX.TimeMachine":                   true, // Time Machine
+	"com.apple.MCX.TimeServer":                    true, // Time Server
+	"com.apple.NSExtension":                       true, // NSExtension Management
+	"com.apple.SystemConfiguration":               true, // Network Proxy Configuration
+	"com.apple.TCC.configuration-profile-policy":  true, // Privacy Preferences Policy Control
+	"com.apple.airprint":                          true, // AirPrint
+	"com.apple.app.lock":                          true, // App Lock
+	"com.apple.applicationaccess":                 true, // Restrictions
+	"com.apple.appstore":                          true, // App Store
+	"com.apple.asam":                              true, // Autonomous Single App Mode
+	"com.apple.cellularprivatenetwork.managed":    true, // Cellular Private Network
+	"com.apple.conferenceroomdisplay":             true, // Conference Room Display
+	"com.apple.desktop":                           true, // Desktop
+	"com.apple.dnsProxy.managed":                  true, // DNS Proxy
+	"com.apple.domains":                           true, // Domains
+	"com.apple.familycontrols.contentfilter":      true, // Parental Controls: Content Filter
+	"com.apple.fileproviderd":                     true, // File Provider
+	"com.apple.finder":                            true, // Finder
+	"com.apple.gamed":                             true, // Parental Controls: Game Center
+	"com.apple.loginitems.managed":                true, // Login Items: Managed Items
+	"com.apple.loginwindow":                       true, // Login Window
+	"com.apple.mcxprinting":                       true, // Printing
+	"com.apple.notificationsettings":              true, // Notifications
+	"com.apple.preference.security":               true, // Security Preferences
+	"com.apple.preference.users":                  true, // User Preferences
+	"com.apple.screensaver":                       true, // Screensaver
+	"com.apple.screensaver.user":                  true, // Screensaver User
+	"com.apple.security.firewall":                 true, // Firewall
+	"com.apple.security.smartcard":                true, // SmartCard
+	"com.apple.servicemanagement":                 true, // Service Management
+	"com.apple.shareddeviceconfiguration":         true, // Lock Screen Message
+	"com.apple.syspolicy.kernel-extension-policy": true, // System Policy - Kernel Extensions
+	"com.apple.system.logging":                    true, // System Logging
+	"com.apple.systempolicy.control":              true, // System Policy Control
+	"com.apple.systempolicy.managed":              true, // System Policy Managed
+	"com.apple.tvremote":                          true, // TV Remote
+	"com.apple.universalaccess":                   true, // Accessibility
+	"loginwindow":                                 true, // Login Window: Login Items
 }
 
 // appleMetadataKeys are keys in a mobileconfig payload dict that represent

--- a/internal/profileconvert/convert.go
+++ b/internal/profileconvert/convert.go
@@ -602,14 +602,3 @@ func ConfigHasPayloads(config json.RawMessage) error {
 	}
 	return nil
 }
-
-// DisabledPayloadTypesList returns the payload types blueprints refuses as a
-// sorted slice, for help text and diagnostics.
-func DisabledPayloadTypesList() []string {
-	types := make([]string, 0, len(DisabledPayloadTypes))
-	for t := range DisabledPayloadTypes {
-		types = append(types, t)
-	}
-	sort.Strings(types)
-	return types
-}

--- a/internal/profileconvert/convert_test.go
+++ b/internal/profileconvert/convert_test.go
@@ -241,21 +241,19 @@ func TestConvertMobileconfig_MultiPayload(t *testing.T) {
 	}
 }
 
-func TestConvertMobileconfig_UnsupportedPayloadType(t *testing.T) {
-	config, warnings, err := ConvertMobileconfig([]byte(testUnsupportedPayloadMobileconfig), false)
+func TestConvertMobileconfig_UnknownPayloadPassesThrough(t *testing.T) {
+	// A payload type that is NOT on the denylist is passed through to the API
+	// (which schema-validates it) with no warning — even with filtering enabled.
+	config, warnings, err := ConvertMobileconfig([]byte(testUnsupportedPayloadMobileconfig), true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should warn but still convert
-	if len(warnings) != 1 {
-		t.Fatalf("expected 1 warning, got %d", len(warnings))
-	}
-	if warnings[0] == "" {
-		t.Error("warning should not be empty")
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for a non-disabled type, got %v", warnings)
 	}
 
-	// Output is still valid
+	// Output is still valid and includes the payload.
 	var result map[string]any
 	if err := json.Unmarshal(config, &result); err != nil {
 		t.Fatalf("invalid JSON output: %v", err)
@@ -271,8 +269,8 @@ func TestConvertMobileconfig_UnsupportedPayloadType(t *testing.T) {
 	}
 }
 
-func TestConvertMobileconfig_FilterUnsupported(t *testing.T) {
-	// Multi-payload profile where one payload is unsupported
+func TestConvertMobileconfig_FilterDisabled(t *testing.T) {
+	// Multi-payload profile where one payload is a type blueprints disables.
 	data := `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
@@ -286,9 +284,9 @@ func TestConvertMobileconfig_FilterUnsupported(t *testing.T) {
 		</dict>
 		<dict>
 			<key>PayloadType</key>
-			<string>com.example.fake.payload</string>
-			<key>SSID_STR</key>
-			<string>CorpWifi</string>
+			<string>com.apple.vpn.managed</string>
+			<key>UserDefinedName</key>
+			<string>Corp VPN</string>
 		</dict>
 	</array>
 	<key>PayloadDisplayName</key>
@@ -304,15 +302,15 @@ func TestConvertMobileconfig_FilterUnsupported(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should warn about removed payload
+	// Should warn about the skipped disabled payload.
 	if len(warnings) != 1 {
 		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
 	}
-	if !strings.Contains(warnings[0], "removed unsupported") {
-		t.Errorf("expected 'removed unsupported' warning, got %q", warnings[0])
+	if !strings.Contains(warnings[0], "does not support") {
+		t.Errorf("expected 'does not support' warning, got %q", warnings[0])
 	}
 
-	// Only supported payload should remain
+	// Only the non-disabled payload should remain.
 	var result map[string]any
 	if err := json.Unmarshal(config, &result); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
@@ -327,9 +325,31 @@ func TestConvertMobileconfig_FilterUnsupported(t *testing.T) {
 }
 
 func TestConvertMobileconfig_FilterAllRemoved(t *testing.T) {
-	_, _, err := ConvertMobileconfig([]byte(testUnsupportedPayloadMobileconfig), true)
+	// A profile containing only a disabled payload type, with filtering on,
+	// removes everything and errors.
+	data := `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.vpn.managed</string>
+			<key>UserDefinedName</key>
+			<string>Corp VPN</string>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>VPN Only</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>AAAAAAAA-0000-0000-0000-000000000000</string>
+</dict>
+</plist>`
+	_, _, err := ConvertMobileconfig([]byte(data), true)
 	if err == nil {
-		t.Error("expected error when all payloads filtered out")
+		t.Error("expected error when all payloads are disabled and filtered out")
 	}
 }
 
@@ -417,13 +437,28 @@ func TestConvertPlist_DefaultDisplayName(t *testing.T) {
 	}
 }
 
-func TestConvertPlist_UnsupportedType(t *testing.T) {
-	_, warnings, err := ConvertPlist([]byte(testPlist), "com.example.fake.payload", "")
+func TestConvertPlist_DisabledType(t *testing.T) {
+	// A disabled type warns that the API will reject it.
+	_, warnings, err := ConvertPlist([]byte(testPlist), "com.apple.vpn.managed", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(warnings) != 1 {
-		t.Errorf("expected 1 warning for unsupported type, got %d", len(warnings))
+		t.Fatalf("expected 1 warning for disabled type, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "disabled") {
+		t.Errorf("expected 'disabled' warning, got %q", warnings[0])
+	}
+}
+
+func TestConvertPlist_UnknownTypeNoWarning(t *testing.T) {
+	// A non-disabled type produces no warning — the API validates it.
+	_, warnings, err := ConvertPlist([]byte(testPlist), "com.example.fake.payload", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for a non-disabled type, got %v", warnings)
 	}
 }
 
@@ -515,10 +550,10 @@ func TestPayloadTypeSummary(t *testing.T) {
 	}
 }
 
-func TestSupportedPayloadTypesList(t *testing.T) {
-	types := SupportedPayloadTypesList()
-	if len(types) != len(SupportedPayloadTypes) {
-		t.Errorf("got %d types, want %d", len(types), len(SupportedPayloadTypes))
+func TestDisabledPayloadTypesList(t *testing.T) {
+	types := DisabledPayloadTypesList()
+	if len(types) != len(DisabledPayloadTypes) {
+		t.Errorf("got %d types, want %d", len(types), len(DisabledPayloadTypes))
 	}
 	// Should be sorted
 	for i := 1; i < len(types); i++ {
@@ -671,15 +706,12 @@ func TestConvertMobileconfig_MCXPayload(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should have an unwrap warning
-	hasUnwrap := false
+	// MCX (Custom Settings) is kept intact as com.apple.ManagedClient.preferences,
+	// NOT unwrapped — the blueprints API rejects the unwrapped bare domain.
 	for _, w := range warnings {
 		if strings.Contains(w, "unwrapped") {
-			hasUnwrap = true
+			t.Errorf("did not expect an unwrap warning, got %q", w)
 		}
-	}
-	if !hasUnwrap {
-		t.Error("expected unwrap warning")
 	}
 
 	var result map[string]any
@@ -689,23 +721,37 @@ func TestConvertMobileconfig_MCXPayload(t *testing.T) {
 
 	content, ok := result["payloadContent"].([]any)
 	if !ok || len(content) != 1 {
-		t.Fatalf("expected 1 payload after MCX unwrap, got %v", result["payloadContent"])
+		t.Fatalf("expected 1 payload, got %v", result["payloadContent"])
 	}
 
 	payload := content[0].(map[string]any)
-	if payload["payloadType"] != "com.apple.applicationaccess" {
-		t.Errorf("payloadType = %v, want com.apple.applicationaccess", payload["payloadType"])
+	if payload["payloadType"] != "com.apple.ManagedClient.preferences" {
+		t.Errorf("payloadType = %v, want com.apple.ManagedClient.preferences", payload["payloadType"])
 	}
-	if payload["allowCamera"] != false {
-		t.Errorf("allowCamera = %v, want false", payload["allowCamera"])
+
+	// The inner managed-preferences structure must be preserved under PayloadContent.
+	pc, ok := payload["PayloadContent"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected PayloadContent preserved, got %T", payload["PayloadContent"])
 	}
-	if payload["allowAirDrop"] != false {
-		t.Errorf("allowAirDrop = %v, want false", payload["allowAirDrop"])
+	domain, ok := pc["com.apple.applicationaccess"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected com.apple.applicationaccess domain in PayloadContent, got %v", pc)
+	}
+	forced, ok := domain["Forced"].([]any)
+	if !ok || len(forced) != 1 {
+		t.Fatalf("expected Forced array with 1 entry, got %v", domain["Forced"])
+	}
+	settings := forced[0].(map[string]any)["mcx_preference_settings"].(map[string]any)
+	if settings["allowCamera"] != false || settings["allowAirDrop"] != false {
+		t.Errorf("expected allowCamera/allowAirDrop false, got %v", settings)
 	}
 }
 
-func TestConvertMobileconfig_MCXFilterUnsupported(t *testing.T) {
-	// MCX wrapping an unsupported domain — should be filtered
+func TestConvertMobileconfig_MCXCustomDomainKept(t *testing.T) {
+	// MCX wrapping a third-party preference domain. Previously this was unwrapped
+	// to a bare payloadType and filtered out; now it is kept intact as
+	// com.apple.ManagedClient.preferences and accepted even with filtering on.
 	data := `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
@@ -735,16 +781,27 @@ func TestConvertMobileconfig_MCXFilterUnsupported(t *testing.T) {
 		</dict>
 	</array>
 	<key>PayloadDisplayName</key>
-	<string>MCX Unsupported</string>
+	<string>MCX Custom Domain</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>
 	<string>AAAAAAAA-0000-0000-0000-000000000000</string>
 </dict>
 </plist>`
-	_, _, err := ConvertMobileconfig([]byte(data), true)
-	if err == nil {
-		t.Error("expected error when MCX unwraps to unsupported domain and filtering enabled")
+	config, _, err := ConvertMobileconfig([]byte(data), true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(config, &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	content := result["payloadContent"].([]any)
+	if len(content) != 1 {
+		t.Fatalf("expected 1 payload (MCX kept), got %d", len(content))
+	}
+	if pt := content[0].(map[string]any)["payloadType"]; pt != "com.apple.ManagedClient.preferences" {
+		t.Errorf("payloadType = %v, want com.apple.ManagedClient.preferences", pt)
 	}
 }
 
@@ -803,14 +860,10 @@ func TestConvertMobileconfig_MCXMultiDomain(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	hasUnwrap := false
 	for _, w := range warnings {
-		if strings.Contains(w, "unwrapped 2 domain") {
-			hasUnwrap = true
+		if strings.Contains(w, "unwrapped") {
+			t.Errorf("did not expect an unwrap warning, got %q", w)
 		}
-	}
-	if !hasUnwrap {
-		t.Errorf("expected '2 domain' unwrap warning, got %v", warnings)
 	}
 
 	var result map[string]any
@@ -818,8 +871,18 @@ func TestConvertMobileconfig_MCXMultiDomain(t *testing.T) {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 	content := result["payloadContent"].([]any)
-	if len(content) != 2 {
-		t.Fatalf("expected 2 payloads after MCX unwrap, got %d", len(content))
+	if len(content) != 1 {
+		t.Fatalf("expected 1 MCX payload (kept intact, both domains inside), got %d", len(content))
+	}
+	pc, ok := content[0].(map[string]any)["PayloadContent"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected PayloadContent preserved, got %v", content[0])
+	}
+	if _, ok := pc["com.apple.applicationaccess"]; !ok {
+		t.Errorf("missing com.apple.applicationaccess domain in PayloadContent: %v", pc)
+	}
+	if _, ok := pc["com.apple.screensaver"]; !ok {
+		t.Errorf("missing com.apple.screensaver domain in PayloadContent: %v", pc)
 	}
 }
 
@@ -886,99 +949,17 @@ func TestConvertMobileconfig_MCXMixedWithRegular(t *testing.T) {
 		t.Errorf("payload[0] type = %v, want com.apple.screensaver", p0["payloadType"])
 	}
 
-	// Second is the unwrapped applicationaccess
+	// Second is the MCX payload, kept intact (not unwrapped).
 	p1 := content[1].(map[string]any)
-	if p1["payloadType"] != "com.apple.applicationaccess" {
-		t.Errorf("payload[1] type = %v, want com.apple.applicationaccess", p1["payloadType"])
+	if p1["payloadType"] != "com.apple.ManagedClient.preferences" {
+		t.Errorf("payload[1] type = %v, want com.apple.ManagedClient.preferences", p1["payloadType"])
 	}
-	if p1["allowCamera"] != false {
-		t.Errorf("allowCamera = %v, want false", p1["allowCamera"])
+	pc, ok := p1["PayloadContent"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected PayloadContent preserved on MCX payload, got %v", p1)
 	}
-}
-
-func TestUnwrapMCXPayloads_SetOnce(t *testing.T) {
-	payload := map[string]any{
-		"PayloadType": "com.apple.ManagedClient.preferences",
-		"PayloadContent": map[string]any{
-			"com.apple.finder": map[string]any{
-				"Set-Once": []any{
-					map[string]any{
-						"mcx_preference_settings": map[string]any{
-							"ShowHardDrivesOnDesktop": true,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	result, warnings := unwrapMCXPayloads([]any{payload})
-	if len(result) != 1 {
-		t.Fatalf("expected 1 unwrapped payload, got %d", len(result))
-	}
-
-	synthetic := result[0].(map[string]any)
-	if synthetic["PayloadType"] != "com.apple.finder" {
-		t.Errorf("PayloadType = %v, want com.apple.finder", synthetic["PayloadType"])
-	}
-	if synthetic["ShowHardDrivesOnDesktop"] != true {
-		t.Errorf("ShowHardDrivesOnDesktop = %v, want true", synthetic["ShowHardDrivesOnDesktop"])
-	}
-
-	if len(warnings) == 0 || !strings.Contains(warnings[0], "unwrapped") {
-		t.Errorf("expected unwrap warning, got %v", warnings)
-	}
-}
-
-func TestUnwrapMCXPayloads_NoContent(t *testing.T) {
-	payload := map[string]any{
-		"PayloadType": "com.apple.ManagedClient.preferences",
-		// No PayloadContent
-	}
-
-	result, warnings := unwrapMCXPayloads([]any{payload})
-	if len(result) != 0 {
-		t.Errorf("expected 0 results for MCX with no content, got %d", len(result))
-	}
-	if len(warnings) != 1 || !strings.Contains(warnings[0], "no PayloadContent") {
-		t.Errorf("expected 'no PayloadContent' warning, got %v", warnings)
-	}
-}
-
-func TestUnwrapMCXPayloads_EmptySettings(t *testing.T) {
-	payload := map[string]any{
-		"PayloadType": "com.apple.ManagedClient.preferences",
-		"PayloadContent": map[string]any{
-			"com.apple.finder": map[string]any{
-				// No Forced or Set-Once
-			},
-		},
-	}
-
-	result, warnings := unwrapMCXPayloads([]any{payload})
-	if len(result) != 0 {
-		t.Errorf("expected 0 results for MCX with empty settings, got %d", len(result))
-	}
-	if len(warnings) != 1 || !strings.Contains(warnings[0], "no extractable settings") {
-		t.Errorf("expected 'no extractable settings' warning, got %v", warnings)
-	}
-}
-
-func TestUnwrapMCXPayloads_NonMCXPassthrough(t *testing.T) {
-	payload := map[string]any{
-		"PayloadType": "com.apple.screensaver",
-		"idleTime":    600,
-	}
-
-	result, warnings := unwrapMCXPayloads([]any{payload})
-	if len(result) != 1 {
-		t.Fatalf("expected 1 passthrough payload, got %d", len(result))
-	}
-	if len(warnings) != 0 {
-		t.Errorf("expected no warnings for non-MCX payload, got %v", warnings)
-	}
-	if result[0].(map[string]any)["PayloadType"] != "com.apple.screensaver" {
-		t.Error("non-MCX payload should pass through unchanged")
+	if _, ok := pc["com.apple.applicationaccess"]; !ok {
+		t.Errorf("missing com.apple.applicationaccess domain in PayloadContent: %v", pc)
 	}
 }
 

--- a/internal/profileconvert/convert_test.go
+++ b/internal/profileconvert/convert_test.go
@@ -550,19 +550,6 @@ func TestPayloadTypeSummary(t *testing.T) {
 	}
 }
 
-func TestDisabledPayloadTypesList(t *testing.T) {
-	types := DisabledPayloadTypesList()
-	if len(types) != len(DisabledPayloadTypes) {
-		t.Errorf("got %d types, want %d", len(types), len(DisabledPayloadTypes))
-	}
-	// Should be sorted
-	for i := 1; i < len(types); i++ {
-		if types[i] < types[i-1] {
-			t.Errorf("not sorted: %s before %s", types[i-1], types[i])
-		}
-	}
-}
-
 func TestConvertMobileconfig_StripsEmptyValues(t *testing.T) {
 	data := `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">

--- a/internal/profileconvert/ddm_converter.go
+++ b/internal/profileconvert/ddm_converter.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"sort"
 	"strings"
 
 	"howett.net/plist"
@@ -101,11 +102,22 @@ func ConvertToDDMComponents(data []byte, filterUnsupported bool, fetcher *Schema
 		return nil, fmt.Errorf("mobileconfig has no PayloadContent array")
 	}
 
-	// Unwrap MCX (Custom Settings) payloads before processing
-	payloadContent, mcxWarnings := unwrapMCXPayloads(payloadContent)
-
 	result := &DDMConversionResult{DisplayName: displayName}
-	result.Warnings = append(result.Warnings, mcxWarnings...)
+
+	// Expand MCX (Custom Settings) payloads before processing. Inner domains that
+	// are real Apple payloads (have a converter, or Apple publishes a schema for
+	// them) are unwrapped to standalone payloads so converters can run and the API
+	// can validate them; third-party/unknown domains stay wrapped in a residual
+	// ManagedClient.preferences payload, which the API accepts as opaque custom
+	// settings but rejects as an unwrapped bare type. classifier reuses the
+	// strip-defaults fetcher when present, else a lightweight one that only hits
+	// the network for MCX inner domains (like --strip-defaults does for schemas).
+	classifier := fetcher
+	if classifier == nil {
+		classifier = NewSchemaFetcher(nil)
+	}
+	payloadContent = splitMCXPayloads(payloadContent, classifier, result)
+
 	var profilePayloads []map[string]any
 	seenComponents := make(map[string]bool)
 	typeCount := make(map[string]int) // tracks per-type index for unique identifiers
@@ -124,14 +136,14 @@ func ConvertToDDMComponents(data []byte, filterUnsupported bool, fetcher *Schema
 		matched := findConverters(payloadType)
 		if len(matched) == 0 {
 			// No DDM converter — standard profile wrapping path
-			if !SupportedPayloadTypes[payloadType] {
+			if DisabledPayloadTypes[payloadType] {
 				if filterUnsupported {
 					result.Warnings = append(result.Warnings,
-						fmt.Sprintf("removed unsupported payload type %q", payloadType))
+						fmt.Sprintf("skipped payload type %q — Jamf blueprints does not support it", payloadType))
 					continue
 				}
 				result.Warnings = append(result.Warnings,
-					fmt.Sprintf("payload type %q may not be supported — see https://github.com/apple/device-management/tree/release/mdm/profiles", payloadType))
+					fmt.Sprintf("payload type %q is disabled by Jamf blueprints — the API will reject the blueprint (remove --include-unsupported to skip it)", payloadType))
 			}
 			entry := buildPayloadEntry(payloadType, payload, typeCount[payloadType])
 			// Skip payloads with no settings (only payloadType + payloadIdentifier)
@@ -199,23 +211,12 @@ func ConvertToDDMComponents(data []byte, filterUnsupported bool, fetcher *Schema
 			remaining = leftover
 		}
 
-		// Remaining keys go into the configuration-profile wrapper —
-		// but only if the payload type is supported for wrapping.
+		// Remaining keys go into the configuration-profile wrapper, unless the
+		// payload type is one blueprints refuses (then drop it when filtering).
 		if len(remaining) > 0 {
-			if !SupportedPayloadTypes[payloadType] {
-				if filterUnsupported {
-					result.Warnings = append(result.Warnings,
-						fmt.Sprintf("removed %d unconverted key(s) from unsupported payload type %q", len(remaining), payloadType))
-				} else {
-					idx := typeCount[payloadType]
-					typeCount[payloadType]++
-					entry := map[string]any{
-						"payloadType":       payloadType,
-						"payloadIdentifier": generatePayloadIdentifier(payloadType, idx),
-					}
-					maps.Copy(entry, remaining)
-					profilePayloads = append(profilePayloads, entry)
-				}
+			if DisabledPayloadTypes[payloadType] && filterUnsupported {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("removed %d unconverted key(s) from payload type %q — Jamf blueprints does not support it", len(remaining), payloadType))
 			} else {
 				idx := typeCount[payloadType]
 				typeCount[payloadType]++
@@ -336,6 +337,125 @@ func ensureFullSoftwareUpdateSchema(result *DDMConversionResult) {
 		return
 	}
 	result.NativeComponents[idx].Configuration = merged
+}
+
+// splitMCXPayloads expands com.apple.ManagedClient.preferences (Custom Settings)
+// payloads. Each inner preference domain that is a real Apple payload — one with
+// a DDM converter, or one for which Apple publishes a payload schema — is emitted
+// as a standalone payload so converters can run and the blueprints API can
+// validate it. Domains that are not recognized Apple payloads (third-party
+// preference domains) stay wrapped in a residual ManagedClient.preferences
+// payload, which the API accepts as opaque custom settings but rejects as an
+// unwrapped bare type. Non-MCX payloads pass through unchanged.
+func splitMCXPayloads(payloads []any, classifier *SchemaFetcher, result *DDMConversionResult) []any {
+	out := make([]any, 0, len(payloads))
+	for _, item := range payloads {
+		p, ok := item.(map[string]any)
+		if !ok {
+			out = append(out, item)
+			continue
+		}
+		if pt, _ := p["PayloadType"].(string); pt != mcxPayloadType {
+			out = append(out, item)
+			continue
+		}
+		content, ok := p["PayloadContent"].(map[string]any)
+		if !ok {
+			out = append(out, item) // malformed MCX — leave for buildPayloadEntry
+			continue
+		}
+
+		domains := make([]string, 0, len(content))
+		for d := range content {
+			domains = append(domains, d)
+		}
+		sort.Strings(domains)
+
+		residual := make(map[string]any)
+		var unwrapped []string
+		for _, domain := range domains {
+			dd, ok := content[domain].(map[string]any)
+			if !ok {
+				residual[domain] = content[domain]
+				continue
+			}
+			settings := extractMCXSettings(dd)
+			if len(settings) == 0 || !isRealApplePayload(domain, classifier) {
+				residual[domain] = content[domain]
+				continue
+			}
+			bare := map[string]any{"PayloadType": domain}
+			copyMCXMetadata(p, bare)
+			maps.Copy(bare, settings)
+			out = append(out, bare)
+			unwrapped = append(unwrapped, domain)
+		}
+
+		if len(residual) > 0 {
+			resMCX := map[string]any{"PayloadType": mcxPayloadType, "PayloadContent": residual}
+			copyMCXMetadata(p, resMCX)
+			out = append(out, resMCX)
+		}
+		if len(unwrapped) > 0 {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("unwrapped %d Apple domain(s) from Custom Settings for DDM conversion: %s",
+					len(unwrapped), strings.Join(unwrapped, ", ")))
+		}
+	}
+	return out
+}
+
+// isRealApplePayload reports whether a preference domain is a real Apple payload
+// type — one with a DDM converter, or one for which Apple publishes a payload
+// schema (fetched live, like --strip-defaults). Network/lookup failures fall back
+// to false so unknown domains stay wrapped in MCX (which the API accepts).
+func isRealApplePayload(domain string, classifier *SchemaFetcher) bool {
+	if len(findConverters(domain)) > 0 {
+		return true
+	}
+	if classifier == nil {
+		return false
+	}
+	defaults, _ := classifier.FetchDefaults(domain)
+	return defaults != nil
+}
+
+// copyMCXMetadata copies Apple metadata keys (except PayloadType and
+// PayloadContent) from an MCX wrapper onto a payload derived from it.
+func copyMCXMetadata(src, dst map[string]any) {
+	for k, v := range src {
+		if k == "PayloadType" || k == "PayloadContent" {
+			continue
+		}
+		if appleMetadataKeys[k] {
+			dst[k] = v
+		}
+	}
+}
+
+// extractMCXSettings extracts preference settings from an MCX domain dictionary.
+// MCX stores settings under Forced and/or Set-Once arrays, each a list of dicts
+// with an mcx_preference_settings dictionary.
+func extractMCXSettings(domainDict map[string]any) map[string]any {
+	settings := make(map[string]any)
+	for _, arrayKey := range []string{"Set-Once", "Forced"} {
+		arr, ok := domainDict[arrayKey].([]any)
+		if !ok {
+			continue
+		}
+		for _, entry := range arr {
+			ed, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			prefs, ok := ed["mcx_preference_settings"].(map[string]any)
+			if !ok {
+				continue
+			}
+			maps.Copy(settings, prefs)
+		}
+	}
+	return settings
 }
 
 // findComponent returns the component with the given identifier and its index,

--- a/internal/profileconvert/ddm_converter.go
+++ b/internal/profileconvert/ddm_converter.go
@@ -217,14 +217,8 @@ func ConvertToDDMComponents(data []byte, filterUnsupported bool, fetcher *Schema
 			if DisabledPayloadTypes[payloadType] && filterUnsupported {
 				result.Warnings = append(result.Warnings,
 					fmt.Sprintf("removed %d unconverted key(s) from payload type %q — Jamf blueprints does not support it", len(remaining), payloadType))
-			} else {
-				idx := typeCount[payloadType]
+			} else if entry := buildLeftoverEntry(payloadType, remaining, typeCount[payloadType]); entry != nil {
 				typeCount[payloadType]++
-				entry := map[string]any{
-					"payloadType":       payloadType,
-					"payloadIdentifier": generatePayloadIdentifier(payloadType, idx),
-				}
-				maps.Copy(entry, remaining)
 				profilePayloads = append(profilePayloads, entry)
 			}
 		}
@@ -337,6 +331,56 @@ func ensureFullSoftwareUpdateSchema(result *DDMConversionResult) {
 		return
 	}
 	result.NativeComponents[idx].Configuration = merged
+}
+
+// mcxWrapLeftoverTypes are payload types the blueprints API refuses as bare
+// configuration-profile payloads but accepts wrapped in Custom Settings (MCX).
+// A converter's unconverted leftover keys for these types are therefore
+// delivered via a com.apple.ManagedClient.preferences payload (which is also
+// their correct legacy delivery — they are preference domains, not standalone
+// MDM payloads). Wire-verified: bare com.apple.SoftwareUpdate → 400, the same
+// keys wrapped in MCX → accepted.
+var mcxWrapLeftoverTypes = map[string]bool{
+	"com.apple.SoftwareUpdate": true,
+}
+
+// buildLeftoverEntry constructs a configuration-profile payload entry from the
+// keys a converter did not consume. Empty values (empty strings/arrays the DDM
+// API rejects) are dropped. Types in mcxWrapLeftoverTypes are wrapped in a
+// com.apple.ManagedClient.preferences (Custom Settings) payload; all others are
+// emitted as a bare payload of their own type. Returns nil if nothing remains
+// after dropping empties.
+func buildLeftoverEntry(payloadType string, remaining map[string]any, index int) map[string]any {
+	clean := make(map[string]any, len(remaining))
+	for k, v := range remaining {
+		cv := convertPlistValue(v)
+		if isEmptyValue(cv) {
+			continue
+		}
+		clean[k] = cv
+	}
+	if len(clean) == 0 {
+		return nil
+	}
+	if mcxWrapLeftoverTypes[payloadType] {
+		return map[string]any{
+			"payloadType":       mcxPayloadType,
+			"payloadIdentifier": generatePayloadIdentifier(payloadType, index),
+			"PayloadContent": map[string]any{
+				payloadType: map[string]any{
+					"Forced": []any{
+						map[string]any{"mcx_preference_settings": clean},
+					},
+				},
+			},
+		}
+	}
+	entry := map[string]any{
+		"payloadType":       payloadType,
+		"payloadIdentifier": generatePayloadIdentifier(payloadType, index),
+	}
+	maps.Copy(entry, clean)
+	return entry
 }
 
 // splitMCXPayloads expands com.apple.ManagedClient.preferences (Custom Settings)

--- a/internal/profileconvert/ddm_converter_test.go
+++ b/internal/profileconvert/ddm_converter_test.go
@@ -316,10 +316,16 @@ func TestConvertSoftwareUpdate_Deferrals(t *testing.T) {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 
-	// Full component structure should be present
-	for _, section := range []string{"AllowStandardUserOSUpdates", "AutomaticActions", "Deferrals", "Notifications", "RapidSecurityResponse", "RecommendedCadence"} {
-		if _, ok := parsed[section]; !ok {
-			t.Errorf("expected top-level section %q in output", section)
+	// The converter emits ONLY the Deferrals section — sibling sections are
+	// intentionally absent so they don't clobber another converter's Included:true
+	// during merge. ensureFullSoftwareUpdateSchema backfills them at the orchestrator
+	// level (see TestConvertToDDMComponents_SoftwareUpdatePlusDeferralNoClobber).
+	if _, ok := parsed["Deferrals"]; !ok {
+		t.Error("expected Deferrals section in output")
+	}
+	for _, section := range []string{"AutomaticActions", "Notifications", "RapidSecurityResponse"} {
+		if _, ok := parsed[section]; ok {
+			t.Errorf("did not expect sibling section %q in standalone deferral output (would clobber on merge)", section)
 		}
 	}
 
@@ -350,12 +356,6 @@ func TestConvertSoftwareUpdate_Deferrals(t *testing.T) {
 	}
 	if system["Value"] != float64(1) {
 		t.Errorf("expected SystemPeriodInDays.Value=1 (base default), got %v", system["Value"])
-	}
-
-	// Non-converted top-level sections should have Included=false (not managed)
-	notifications := parsed["Notifications"].(map[string]any)
-	if notifications["Included"] != false {
-		t.Error("expected Notifications.Included=false (not converted)")
 	}
 }
 
@@ -1385,6 +1385,119 @@ func TestConvertToDDMComponents_MCXAppleDomainNoConverterUnwrapped(t *testing.T)
 	}
 	if p["tilesize"] != float64(48) {
 		t.Errorf("expected tilesize 48 carried over, got %v", p["tilesize"])
+	}
+}
+
+func TestConvertToDDMComponents_SoftwareUpdateLeftoverMCXWrapped(t *testing.T) {
+	// A com.apple.SoftwareUpdate payload with mappable + unmappable keys.
+	// AutomaticDownload converts to native software-update-settings; the
+	// unmappable AutomaticCheckEnabled is delivered via MCX (Custom Settings)
+	// rather than a bare com.apple.SoftwareUpdate payload (which the API refuses).
+	// CatalogURL is an empty string and must be dropped.
+	mc := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.SoftwareUpdate</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>AutomaticDownload</key>
+			<true/>
+			<key>AutomaticCheckEnabled</key>
+			<true/>
+			<key>CatalogURL</key>
+			<string></string>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>SU</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>`
+
+	result, err := ConvertToDDMComponents([]byte(mc), true, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Native software-update-settings from the mappable key.
+	if _, idx := findComponent(result.NativeComponents, "com.jamf.ddm.software-update-settings"); idx < 0 {
+		t.Fatal("expected native software-update-settings component")
+	}
+
+	// Leftover delivered via MCX, not a bare com.apple.SoftwareUpdate payload.
+	if result.ProfileConfig == nil {
+		t.Fatal("expected ProfileConfig with the MCX-wrapped leftover")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(result.ProfileConfig, &cfg); err != nil {
+		t.Fatalf("invalid ProfileConfig JSON: %v", err)
+	}
+	p := cfg["payloadContent"].([]any)[0].(map[string]any)
+	if p["payloadType"] != "com.apple.ManagedClient.preferences" {
+		t.Fatalf("expected MCX-wrapped leftover, got payloadType %v", p["payloadType"])
+	}
+	pc := p["PayloadContent"].(map[string]any)["com.apple.SoftwareUpdate"].(map[string]any)
+	settings := pc["Forced"].([]any)[0].(map[string]any)["mcx_preference_settings"].(map[string]any)
+	if settings["AutomaticCheckEnabled"] != true {
+		t.Errorf("expected AutomaticCheckEnabled preserved in MCX, got %v", settings["AutomaticCheckEnabled"])
+	}
+	if _, present := settings["CatalogURL"]; present {
+		t.Error("empty-string CatalogURL should have been dropped")
+	}
+}
+
+func TestConvertToDDMComponents_SoftwareUpdatePlusDeferralNoClobber(t *testing.T) {
+	// A profile with BOTH a com.apple.SoftwareUpdate payload (AutomaticActions)
+	// and applicationaccess deferral keys, both targeting software-update-settings.
+	// The two converters must merge without clobbering each other: the deferral
+	// converter must not flip the SoftwareUpdate-mapped AutomaticActions section
+	// back to Included:false.
+	mc := `<?xml version="1.0"?><plist version="1.0"><dict>
+<key>PayloadContent</key><array>
+<dict><key>PayloadType</key><string>com.apple.SoftwareUpdate</string>
+<key>AutomaticDownload</key><true/><key>CriticalUpdateInstall</key><true/></dict>
+<dict><key>PayloadType</key><string>com.apple.applicationaccess</string>
+<key>forceDelayedSoftwareUpdates</key><true/>
+<key>enforcedSoftwareUpdateMinorOSDeferredInstallDelay</key><integer>5</integer></dict>
+</array>
+<key>PayloadDisplayName</key><string>SU+Deferral</string>
+<key>PayloadType</key><string>Configuration</string></dict></plist>`
+
+	result, err := ConvertToDDMComponents([]byte(mc), true, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	comp, idx := findComponent(result.NativeComponents, "com.jamf.ddm.software-update-settings")
+	if idx < 0 {
+		t.Fatal("expected software-update-settings component")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(comp.Configuration, &cfg); err != nil {
+		t.Fatalf("invalid component JSON: %v", err)
+	}
+	included := func(section, key string) any {
+		sec, _ := cfg[section].(map[string]any)
+		sub, _ := sec[key].(map[string]any)
+		return sub["Included"]
+	}
+	// SoftwareUpdate-mapped section must survive the deferral merge.
+	if included("AutomaticActions", "Download") != true {
+		t.Errorf("AutomaticActions.Download.Included = %v, want true (clobbered by deferral merge)", included("AutomaticActions", "Download"))
+	}
+	if included("AutomaticActions", "InstallSecurityUpdate") != true {
+		t.Errorf("AutomaticActions.InstallSecurityUpdate.Included = %v, want true", included("AutomaticActions", "InstallSecurityUpdate"))
+	}
+	// Deferral section must also be present.
+	if included("Deferrals", "MinorPeriodInDays") != true {
+		t.Errorf("Deferrals.MinorPeriodInDays.Included = %v, want true", included("Deferrals", "MinorPeriodInDays"))
 	}
 }
 

--- a/internal/profileconvert/ddm_converter_test.go
+++ b/internal/profileconvert/ddm_converter_test.go
@@ -1205,8 +1205,8 @@ func TestConvertToDDMComponents_NoConverters(t *testing.T) {
 	}
 }
 
-func TestConvertToDDMComponents_FilterUnsupported(t *testing.T) {
-	// Profile with only an unsupported payload type and no DDM converter
+func TestConvertToDDMComponents_FilterDisabled(t *testing.T) {
+	// Profile with only a disabled payload type and no DDM converter.
 	mobileconfig := `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -1215,21 +1215,21 @@ func TestConvertToDDMComponents_FilterUnsupported(t *testing.T) {
 	<array>
 		<dict>
 			<key>PayloadType</key>
-			<string>com.example.custom.unsupported</string>
+			<string>com.apple.vpn.managed</string>
 			<key>PayloadIdentifier</key>
-			<string>com.example.custom</string>
+			<string>com.example.vpn</string>
 			<key>PayloadUUID</key>
 			<string>UUID-1</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
-			<key>foo</key>
-			<string>bar</string>
+			<key>UserDefinedName</key>
+			<string>Corp VPN</string>
 		</dict>
 	</array>
 	<key>PayloadDisplayName</key>
-	<string>Unsupported Profile</string>
+	<string>Disabled Profile</string>
 	<key>PayloadIdentifier</key>
-	<string>com.example.unsupported</string>
+	<string>com.example.disabled</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadVersion</key>
@@ -1247,10 +1247,10 @@ func TestConvertToDDMComponents_FilterUnsupported(t *testing.T) {
 	}
 }
 
-func TestConvertToDDMComponents_MCXWrappedApplicationaccess(t *testing.T) {
-	// MCX wrapping com.apple.applicationaccess should unwrap and hit the
-	// safari / software-update / RSR converters just like a native payload.
-	mobileconfig := `<?xml version="1.0" encoding="UTF-8"?>
+// mcxProfile builds a Custom Settings (MCX) mobileconfig wrapping one inner
+// preference domain with the given forced settings block (raw XML).
+func mcxProfile(domain, forcedSettingsXML string) string {
+	return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -1259,26 +1259,17 @@ func TestConvertToDDMComponents_MCXWrappedApplicationaccess(t *testing.T) {
 		<dict>
 			<key>PayloadType</key>
 			<string>com.apple.ManagedClient.preferences</string>
-			<key>PayloadIdentifier</key>
-			<string>com.example.mcx</string>
-			<key>PayloadUUID</key>
-			<string>UUID-MCX</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
 			<key>PayloadContent</key>
 			<dict>
-				<key>com.apple.applicationaccess</key>
+				<key>` + domain + `</key>
 				<dict>
 					<key>Forced</key>
 					<array>
 						<dict>
 							<key>mcx_preference_settings</key>
-							<dict>
-								<key>safariAllowPopups</key>
-								<false/>
-								<key>allowCamera</key>
-								<false/>
-							</dict>
+							<dict>` + forcedSettingsXML + `</dict>
 						</dict>
 					</array>
 				</dict>
@@ -1286,22 +1277,28 @@ func TestConvertToDDMComponents_MCXWrappedApplicationaccess(t *testing.T) {
 		</dict>
 	</array>
 	<key>PayloadDisplayName</key>
-	<string>CIS Restrictions MCX</string>
-	<key>PayloadIdentifier</key>
-	<string>com.example.cis</string>
+	<string>MCX Test</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
 </dict>
 </plist>`
+}
 
-	result, err := ConvertToDDMComponents([]byte(mobileconfig), true, nil)
+func TestConvertToDDMComponents_MCXAppleDomainConverted(t *testing.T) {
+	// MCX wrapping a real Apple domain that has a converter (applicationaccess)
+	// is unwrapped so the converter runs. safariAllowPopups -> safari-settings;
+	// allowCamera has no converter, so it lands in the config-profile wrapper as
+	// a bare applicationaccess payload (NOT ManagedClient.preferences).
+	mc := mcxProfile("com.apple.applicationaccess",
+		`<key>safariAllowPopups</key><false/><key>allowCamera</key><false/>`)
+
+	result, err := ConvertToDDMComponents([]byte(mc), true, nil) // nil fetcher: converter short-circuits, no network
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// safariAllowAutoFill should trigger the safari converter
 	hasSafari := false
 	for _, c := range result.NativeComponents {
 		if c.Identifier == "com.jamf.ddm.safari-settings" {
@@ -1309,82 +1306,85 @@ func TestConvertToDDMComponents_MCXWrappedApplicationaccess(t *testing.T) {
 		}
 	}
 	if !hasSafari {
-		t.Error("expected safari-settings native component from MCX-wrapped applicationaccess")
+		t.Error("expected safari-settings native component from unwrapped MCX applicationaccess")
 	}
 
-	// allowCamera is not handled by any DDM converter, so it should end up
-	// in the configuration-profile wrapper
 	if result.ProfileConfig == nil {
-		t.Error("expected ProfileConfig for remaining applicationaccess keys")
+		t.Fatal("expected ProfileConfig for the unconverted applicationaccess key")
 	}
-
-	// Should have MCX unwrap warning
-	hasUnwrap := false
-	for _, w := range result.Warnings {
-		if strings.Contains(w, "unwrapped") {
-			hasUnwrap = true
-		}
+	var cfg map[string]any
+	if err := json.Unmarshal(result.ProfileConfig, &cfg); err != nil {
+		t.Fatalf("invalid ProfileConfig JSON: %v", err)
 	}
-	if !hasUnwrap {
-		t.Error("expected MCX unwrap warning")
+	p := cfg["payloadContent"].([]any)[0].(map[string]any)
+	if p["payloadType"] != "com.apple.applicationaccess" {
+		t.Errorf("expected bare com.apple.applicationaccess in wrapper, got %v", p["payloadType"])
 	}
 }
 
-func TestConvertToDDMComponents_MCXWrappedPasscode(t *testing.T) {
-	// MCX wrapping com.apple.mobiledevice.passwordpolicy should fully convert
-	mobileconfig := `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PayloadContent</key>
-	<array>
-		<dict>
-			<key>PayloadType</key>
-			<string>com.apple.ManagedClient.preferences</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
-			<key>PayloadContent</key>
-			<dict>
-				<key>com.apple.mobiledevice.passwordpolicy</key>
-				<dict>
-					<key>Forced</key>
-					<array>
-						<dict>
-							<key>mcx_preference_settings</key>
-							<dict>
-								<key>minLength</key>
-								<integer>8</integer>
-								<key>requireAlphanumeric</key>
-								<true/>
-							</dict>
-						</dict>
-					</array>
-				</dict>
-			</dict>
-		</dict>
-	</array>
-	<key>PayloadDisplayName</key>
-	<string>MCX Passcode</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
-</dict>
-</plist>`
+func TestConvertToDDMComponents_MCXThirdPartyKept(t *testing.T) {
+	// MCX wrapping a third-party domain (no converter, no Apple schema) stays
+	// wrapped in ManagedClient.preferences — the API accepts it as opaque custom
+	// settings but rejects it as an unwrapped bare type.
+	mc := mcxProfile("uk.co.datajar.Management",
+		`<key>jssURL</key><string>https://x.example/</string>`)
 
-	result, err := ConvertToDDMComponents([]byte(mobileconfig), true, nil)
+	// Mock fetcher: classify the third-party domain as unknown (404 -> nil).
+	fetcher := NewSchemaFetcher(nil)
+	fetcher.mu.Lock()
+	fetcher.cache["uk.co.datajar.Management"] = &schemaResult{defaults: nil}
+	fetcher.mu.Unlock()
+
+	result, err := ConvertToDDMComponents([]byte(mc), true, fetcher)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	hasPasscode := false
-	for _, c := range result.NativeComponents {
-		if c.Identifier == "com.jamf.ddm.passcode-settings" {
-			hasPasscode = true
-		}
+	if result.ProfileConfig == nil {
+		t.Fatal("expected ProfileConfig containing the kept MCX payload")
 	}
-	if !hasPasscode {
-		t.Error("expected passcode-settings native component from MCX-wrapped passwordpolicy")
+	var cfg map[string]any
+	if err := json.Unmarshal(result.ProfileConfig, &cfg); err != nil {
+		t.Fatalf("invalid ProfileConfig JSON: %v", err)
+	}
+	p := cfg["payloadContent"].([]any)[0].(map[string]any)
+	if p["payloadType"] != "com.apple.ManagedClient.preferences" {
+		t.Errorf("expected third-party domain kept in MCX, got payloadType %v", p["payloadType"])
+	}
+	pc, ok := p["PayloadContent"].(map[string]any)
+	if !ok || pc["uk.co.datajar.Management"] == nil {
+		t.Errorf("expected datajar domain preserved inside MCX PayloadContent, got %v", p["PayloadContent"])
+	}
+}
+
+func TestConvertToDDMComponents_MCXAppleDomainNoConverterUnwrapped(t *testing.T) {
+	// MCX wrapping a real Apple domain with no converter (e.g. com.apple.dock).
+	// Apple publishes a schema for it, so it is unwrapped to a bare payload and
+	// lands in the config-profile wrapper as com.apple.dock (not MCX).
+	mc := mcxProfile("com.apple.dock", `<key>tilesize</key><integer>48</integer>`)
+
+	// Mock fetcher: classify com.apple.dock as a known Apple payload (schema present).
+	fetcher := NewSchemaFetcher(nil)
+	fetcher.mu.Lock()
+	fetcher.cache["com.apple.dock"] = &schemaResult{defaults: &SchemaDefaults{}}
+	fetcher.mu.Unlock()
+
+	result, err := ConvertToDDMComponents([]byte(mc), true, fetcher)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ProfileConfig == nil {
+		t.Fatal("expected ProfileConfig containing the unwrapped dock payload")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(result.ProfileConfig, &cfg); err != nil {
+		t.Fatalf("invalid ProfileConfig JSON: %v", err)
+	}
+	p := cfg["payloadContent"].([]any)[0].(map[string]any)
+	if p["payloadType"] != "com.apple.dock" {
+		t.Errorf("expected unwrapped bare com.apple.dock, got %v", p["payloadType"])
+	}
+	if p["tilesize"] != float64(48) {
+		t.Errorf("expected tilesize 48 carried over, got %v", p["tilesize"])
 	}
 }
 

--- a/internal/profileconvert/ddm_softwareupdate.go
+++ b/internal/profileconvert/ddm_softwareupdate.go
@@ -104,18 +104,22 @@ func convertSoftwareUpdate(settings map[string]any) (json.RawMessage, map[string
 		return nil, remaining, warnings, nil
 	}
 
-	// Build the full component schema. The Jamf UI expects every section
-	// to be present — missing sections render as blank. Sections we did
-	// not convert use Included: false so the UI shows them as unmanaged.
-	config, err := softwareUpdateBaseConfig()
+	// Emit ONLY the Deferrals section (kept complete, from the scaffold, with the
+	// values we set marked Included:true and the rest Included:false). Emitting the
+	// whole scaffold here — every section present with Included:false — would
+	// clobber sections another converter set to Included:true (e.g. AutomaticActions
+	// from com.apple.SoftwareUpdate) when the two configs are deep-merged into one
+	// component. ensureFullSoftwareUpdateSchema backfills the remaining top-level
+	// sections after all converters run.
+	base, err := softwareUpdateBaseConfig()
 	if err != nil {
 		return nil, settings, warnings, fmt.Errorf("loading software-update scaffold: %w", err)
 	}
-	baseDeferrals, ok := config["Deferrals"].(map[string]any)
+	baseDeferrals, ok := base["Deferrals"].(map[string]any)
 	if !ok {
 		return nil, settings, warnings, fmt.Errorf("software-update scaffold missing Deferrals section")
 	}
-	config["Deferrals"] = mergeDeferrals(baseDeferrals, deferrals)
+	config := map[string]any{"Deferrals": mergeDeferrals(baseDeferrals, deferrals)}
 
 	raw, err := marshalConfig(config)
 	if err != nil {

--- a/internal/profileconvert/ddm_softwareupdate_profile.go
+++ b/internal/profileconvert/ddm_softwareupdate_profile.go
@@ -46,10 +46,10 @@ func convertSoftwareUpdateProfile(settings map[string]any) (json.RawMessage, map
 	var warnings []string
 	converted := 0
 
-	// Build only the sections we modify — the orchestrator backfills missing
-	// scaffold sections after all converters run (see ensureFullSoftwareUpdateSchema).
-	// This allows clean merging when the deferral converter already produced
-	// a full scaffold for Deferrals.
+	// Build only the sections we modify. Every converter targeting
+	// software-update-settings emits just its own disjoint sections, so they
+	// deep-merge without clobbering each other; ensureFullSoftwareUpdateSchema
+	// backfills the remaining scaffold sections after all converters run.
 	config := make(map[string]any)
 
 	for key, value := range settings {


### PR DESCRIPTION
## Summary

Overhauls `pro blueprints import-profile` and the underlying `internal/profileconvert` layer so far more real-world configuration profiles import successfully, based on wire-probing what the Platform blueprints API actually accepts.

The blueprints API accepts **almost every** Apple payload type and schema-validates each itself; it hard-disables only a fixed set and refuses a few preference-domain types as bare payloads. The CLI previously used a narrow allowlist that filtered out payloads the API would happily accept.

## Changes

**Denylist model (was allowlist)**
- Replaced the 41-entry `SupportedPayloadTypes` allowlist with `DisabledPayloadTypes` — the 22 payload types the API returns `Payload disabled` for (wire-probed across all 118 Apple MDM payload types). Everything else flows through to the API's own schema validation, so payloads like `com.apple.dock`, `com.apple.wifi.managed`, and Custom Settings now import instead of being stripped.
- Reinstated the former list as `UIManageablePayloadTypes` (its true meaning) and used it to emit a precise advisory naming the payloads the Jamf Pro UI renders read-only ("Legacy payload" / managed via API only).

**Smart MCX (Custom Settings) handling**
- `splitMCXPayloads` unwraps inner preference domains that are real Apple payloads — those with a converter, or for which Apple publishes a schema (checked live via `SchemaFetcher`, same mechanism as `--strip-defaults`, degrading gracefully to "unknown" on 404/offline) — so converters run and the API validates them. Third-party/unknown domains stay wrapped in `com.apple.ManagedClient.preferences` (accepted as opaque; rejected if unwrapped). `--legacy` keeps MCX fully intact.

**Scope override + empty-scope guard**
- Added `--computer-group`/`--mobile-device-group` to `import-profile` to set (and override) the blueprint scope.
- A profile whose scope resolves to no device groups (all-computers / individual / building / department) now **fails fast with an actionable error** instead of a 400 from `CreateBlueprint`.

**SoftwareUpdate converter fixes**
- Converter leftover keys for preference-domain types the API refuses as bare payloads (`com.apple.SoftwareUpdate`) are now delivered via a Custom Settings (MCX) payload; empty-string/array leftovers the API rejects are dropped.
- Fixed a pre-existing merge-clobber: the software-update deferral converter emitted a full scaffold (every section `Included:false`), overwriting sections another converter (e.g. `AutomaticActions` from `com.apple.SoftwareUpdate`) had set to `Included:true` during the deep-merge. It now emits only the `Deferrals` section; `ensureFullSoftwareUpdateSchema` backfills the rest.

**Misc**
- Fixed the stale `custom-declarations` scaffold (added required `channelType`, `payloadKey`).

## Testing

- `make test` (all packages) and `make lint` green.
- New/updated unit tests for the denylist, smart MCX split, leftover MCX-wrap, and the merge-clobber regression.
- Live-tested against a Jamf tenant: imported all 382 computer + mobile profiles, then validated the SoftwareUpdate converter output, scope override, and empty-scope guard in the Jamf Pro UI. All test blueprints cleaned up.

## Known follow-ups (out of scope)

- Bare non-MCX preference-domain payloads (e.g. `com.apple.SubmitDiagInfo`) still fail — would need a general "wrap bare-rejected pref-domains in MCX" pass.
- Empty-scope profiles still require a manual `--computer-group`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)