### PR TITLE
fix(blueprints): wrap payload types outside the API's registry instead of failing the import (#307)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,9 @@ Runtime-gated: commands are always registered but `RunE` starts with `requirePla
 
 Name resolution via `internal/platform/Resolver` (blueprints by name, benchmarks by title, baselines by title, device groups by name). Devices use SDK filter methods directly (UUID vs serial auto-detected by hyphen presence).
 
-CRUD pattern matches Protect: `apply` (upsert, blueprint uses merge-patch; benchmark is create-only — SDK has no update), `get <name>`, `delete <name>`, `export <name>`. `apply --scaffold` prints create request template (auth skipped for scaffold).
+CRUD pattern: `apply` (upsert, blueprint uses merge-patch; benchmark is create-only — SDK has no update), `get`, `delete`, `export`. `apply --scaffold` prints create request template (auth skipped for scaffold).
+
+**Identifier convention differs from Protect.** Protect takes a positional `<name>`; Platform takes a positional **`<id>`** plus a `--name` flag (`delete <uuid>` or `delete --name "My Blueprint"` — passing a name positionally is sent as an ID and 404s). This holds for both the generated commands (template: `generator/platform/template.go`, gated on `SupportsNameLookup`) and the hand-written ones (`resolveBlueprintID` in `pro_blueprints.go`), which reject `<id>` and `--name` together. Exception: `blueprints clone <source-name> <new-name>` takes names positionally.
 
 Naming: `platform-` prefix where overlap with existing Pro resources (`platform-devices`, `platform-device-groups`); no prefix for unique resources (`blueprints`, `compliance-benchmarks`, `ddm-reports`).
 

--- a/docs/solutions/logic-errors/blueprints-payload-type-registry-2026-07-28.md
+++ b/docs/solutions/logic-errors/blueprints-payload-type-registry-2026-07-28.md
@@ -1,0 +1,134 @@
+---
+title: "import-profile failed with an opaque 400: the blueprints configuration-profile component takes a fixed payload-type registry, not any Apple payload"
+date: 2026-07-28
+category: logic-errors
+module: internal/profileconvert
+problem_type: bug
+severity: high
+applies_when:
+  - "Working on import-profile, ConvertMobileconfig, ConvertPlist, or the MCX (Custom Settings) split"
+  - "A blueprint create/update returns VALIDATION_FAILURE on steps[N].components[M].configuration"
+  - "Deciding whether a legacy Apple payload can be sent as a standalone com.jamf.ddm-configuration-profile payload"
+tags:
+  - blueprints
+  - platform-api
+  - profileconvert
+  - import-profile
+  - mcx
+  - custom-settings
+  - payload-types
+  - wire-probed
+---
+
+# The blueprints configuration-profile component has a payload-type registry
+
+## Symptom
+
+`pro blueprints import-profile` failed for many real Jamf Pro profiles with a
+400 naming only the whole component:
+
+```json
+{"httpStatus":400,"errors":[{"code":"VALIDATION_FAILURE",
+  "field":"steps[0].components[2].configuration",
+  "description":"Failed to validate configuration."}]}
+```
+
+No payload, key, or reason. A stock Jamf Pro "Restrictions" profile (14 payloads)
+and a stock "Login Window" profile both failed outright — nothing was created.
+
+## Root cause
+
+The code (and `specs/platform/blueprints-api.json`, and therefore the command
+help) assumed the API "accepts **any** Apple MDM payload and validates it against
+Apple's published schema", with only `com.apple.font` and
+`com.apple.webClip.managed` excluded. That is wrong in both directions.
+
+Wire-probed against a live tenant (one bare `{payloadType, payloadIdentifier}`
+payload per POST, 136 payload types — every type Apple publishes in
+`apple/device-management/mdm/profiles` plus Jamf's `com.apple.MCX.<Name>` family
+and Jamf's own spellings). Four distinct outcomes:
+
+| Outcome | Count | API response |
+|---|---|---|
+| Accepted standalone | 74 | 201 |
+| Accepted, needs its required keys | (of the 74) | names the missing field, e.g. `payloadContent[0].moduleName: must not be empty` |
+| Explicitly blocked | 22 | `payloadType: Payload disabled: <type>` |
+| Not in the registry | 40 | `configuration: Failed to validate configuration.` |
+
+Two findings that drive the design:
+
+1. **The opaque message means "unknown payload type".** It is byte-for-byte what
+   an invented type (`com.zzz.invented`) returns. Keys are barely checked by
+   comparison — `com.apple.finder` accepts a made-up key, a string where the
+   schema wants a boolean, and no keys at all. So a failing import is almost
+   always carrying a payload *type* outside the registry, not a bad key. (A
+   wrong-typed value on a strict type can also produce it, so probe types bare to
+   classify them.)
+2. **Well-documented Apple payloads are in the unknown bucket** —
+   `com.apple.MCX`, `com.apple.Safari`, `com.apple.SoftwareUpdate`,
+   `com.apple.Terminal`, `com.apple.TimeMachine`, `com.apple.systemuiserver`,
+   `com.apple.ShareKitHelper`, `com.apple.coremediaio.support`,
+   `com.apple.mail.managed`, `.GlobalPreferences`, `com.apple.mcxloginscripts`, …
+   Apple having a schema says nothing about the registry.
+
+That second point is exactly what `splitMCXPayloads` keyed on: it unwrapped an MCX
+inner domain to a standalone payload when Apple published a schema for it
+(`isRealApplePayload`, a live GitHub fetch). For `com.apple.Safari` and friends
+that turned an importable profile into a rejected one.
+
+Two smaller causes in the same failure:
+
+- **Jamf Pro writes a non-canonical spelling.** Its User Preferences payload is
+  `com.apple.preferences.users`, which is Apple's *filename*; Apple's declared
+  `payloadtype` — and the only spelling the registry knows — is
+  `com.apple.preference.users` (singular). One character, whole-profile failure.
+- `DisabledPayloadTypes` (22 entries) already matched the probed "Payload
+  disabled" set exactly, so only the unknown-type bucket was unhandled.
+
+## Fix
+
+`internal/profileconvert/convert.go`:
+
+- `SupportedPayloadTypes` — the probed 74-type registry.
+- `canonicalPayloadTypes` / `CanonicalPayloadType` — Jamf → Apple spelling rewrite.
+- `wrapAsManagedPreferences` — package a domain's settings as
+  `com.apple.ManagedClient.preferences` (`Forced` → `mcx_preference_settings`).
+
+A type outside the registry is **wrapped, not dropped**: probing confirmed the MCX
+wrapper is accepted for every domain tried, including third-party ones
+(`com.microsoft.Word`), and it is also the correct legacy delivery for these
+domains — they are managed preferences, not standalone MDM payloads. Applied in
+`ConvertMobileconfig`, `ConvertPlist`, and `ConvertToDDMComponents`, plus
+`buildLeftoverEntry` (which generalises the old one-entry
+`mcxWrapLeftoverTypes = {com.apple.SoftwareUpdate}` special case).
+
+`splitMCXPayloads` now unwraps only when a converter will consume the domain or
+`SupportedPayloadTypes` has it (`unwrappableDomain`). That also removes the live
+GitHub fetch from the default import path — classification is deterministic and
+offline.
+
+Result on the two failing profiles: Restrictions 400 → created (4 payloads wrapped,
+1 spelling rewritten, settings preserved), Login Window 400 → created (3 wrapped).
+
+## Gotchas
+
+- **The API reference is wrong here.** `specs/platform/blueprints-api.json`
+  still documents "any Apple MDM payload" and names only two exclusions. Don't
+  re-derive behaviour from it; it is vendored, so fix the CLI's own docs instead.
+- **`PayloadContent` keeps Apple's capitalisation** inside a wrapped payload. The
+  API accepts `payloadContent` too and stores whichever it is given verbatim, so
+  the capitalised Apple spelling is the one to emit.
+- **Missing a supported type is benign, the reverse is not.** An unknown-to-us
+  type that the API actually supports gets MCX-wrapped — still delivered, just as
+  managed preferences. So prefer omission over guessing a type into the list.
+- **Re-deriving the registry:** probe each candidate type *bare*. Bare removes
+  key-validity as a confounder, and a supported-but-needs-keys type identifies
+  itself by naming the missing field instead of returning the opaque message.
+  Batching many types per POST and bisecting failures does not work reliably —
+  duplicate blueprint names across batches fail for an unrelated reason and get
+  mis-attributed to a payload type.
+- `com.apple.MCX.Accounts`, `.EnergySaver`, `.MobileAccounts`, `.TimeMachine`,
+  `.TimeServer` are supported even though Apple declares all of those files as
+  payloadtype `com.apple.MCX` (which is *not* supported). Jamf's per-panel split
+  is what the registry keys on. `com.apple.MCX.FileVault2` is disabled, and
+  `.Dock`, `.Printing`, `.WiFi`, `.Mobility` are unknown.

--- a/internal/commands/pro_blueprints.go
+++ b/internal/commands/pro_blueprints.go
@@ -1060,16 +1060,18 @@ Some of these configuration-profile ("legacy payload") components can only be
 managed through the blueprints API — they appear as read-only "Legacy payload"
 items in the Jamf Pro UI and cannot be edited there.
 
-The blueprints API accepts almost every Apple payload type and validates it against
-Apple's published schema. A small set of payload types is disabled by blueprints
-(certificates, VPN, SSO, web clips, fonts, etc.); those are skipped by default with
-a warning. Use --include-unsupported to send them anyway (the API will reject them).
+The configuration-profile component takes a fixed set of payload types as standalone
+payloads — not every Apple payload, despite what the API reference says. Types outside
+that set (com.apple.MCX, com.apple.Safari, com.apple.SoftwareUpdate, com.apple.Terminal,
+com.apple.systemuiserver, third-party preference domains, ...) are delivered as
+Application & Custom Settings (MCX) instead, which the API accepts for any domain and
+which is their correct legacy delivery. A separate set is disabled outright by
+blueprints (certificates, VPN, SSO, web clips, fonts, etc.); those are skipped with a
+warning. Use --include-unsupported to send the disabled ones anyway (the API rejects them).
 
-Application & Custom Settings (MCX) payloads are unwrapped when their inner
-preference domain is a recognized Apple payload. Classifying an unknown domain
-fetches Apple's published schema from GitHub, so import-profile may reach the
-network even without --strip-defaults; it degrades gracefully offline, leaving
-unclassified domains wrapped as opaque Custom Settings (which the API accepts).
+Application & Custom Settings (MCX) payloads are unwrapped only when their inner
+preference domain is one the API accepts standalone, or one a DDM converter can
+consume. Everything else stays wrapped as opaque Custom Settings.
 
 Use --type to specify the profile type: "computer" (default) for macOS configuration
 profiles or "mobile" for mobile device configuration profiles. Profiles can share

--- a/internal/profileconvert/convert.go
+++ b/internal/profileconvert/convert.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
@@ -58,6 +59,150 @@ var DisabledPayloadTypes = map[string]bool{
 	"com.apple.vpn.managed.appmapping":   true, // Per-App VPN mapping
 	"com.apple.webClip.managed":          true, // Web Clip
 	"com.apple.webcontent-filter":        true, // Web Content Filter
+}
+
+// SupportedPayloadTypes lists the payload types the blueprints
+// com.jamf.ddm-configuration-profile component accepts as standalone payloads.
+//
+// The component matches payloadType against a fixed registry — it does NOT
+// validate arbitrary Apple payloads. Wire-probed by POSTing a blueprint carrying
+// one bare payload ({payloadType, payloadIdentifier}) per type: a type outside
+// this set is rejected with the opaque error
+//
+//	steps[0].components[0].configuration: Failed to validate configuration.
+//
+// which is byte-for-byte what an invented payload type produces. Keys are barely
+// validated by comparison — a made-up key, or a string where the schema wants a
+// boolean, is accepted for most types — so an import that fails validation is
+// almost always carrying a payload type from outside this set.
+//
+// A type outside this set is still deliverable: wrapped in a
+// com.apple.ManagedClient.preferences (Custom Settings/MCX) payload, the API
+// accepts any preference domain, including third-party ones. See
+// wrapAsManagedPreferences — that is the recovery path, not a filter.
+//
+// To re-derive after an API change, probe each candidate type bare and treat
+// "Failed to validate configuration." as unsupported. Types the API knows but
+// deliberately blocks report "Payload disabled: <type>" instead and belong in
+// DisabledPayloadTypes.
+var SupportedPayloadTypes = map[string]bool{
+	"com.apple.AssetCache.managed":                true,
+	"com.apple.Dictionary":                        true,
+	"com.apple.DiscRecording":                     true,
+	"com.apple.MCX.Accounts":                      true,
+	"com.apple.MCX.EnergySaver":                   true,
+	"com.apple.MCX.MobileAccounts":                true,
+	"com.apple.MCX.TimeMachine":                   true,
+	"com.apple.MCX.TimeServer":                    true,
+	"com.apple.ManagedClient.preferences":         true,
+	"com.apple.NSExtension":                       true,
+	"com.apple.SetupAssistant.managed":            true,
+	"com.apple.SystemConfiguration":               true,
+	"com.apple.TCC.configuration-profile-policy":  true,
+	"com.apple.airprint":                          true,
+	"com.apple.app.lock":                          true,
+	"com.apple.applicationaccess":                 true,
+	"com.apple.applicationaccess.new":             true,
+	"com.apple.appstore":                          true,
+	"com.apple.asam":                              true,
+	"com.apple.associated-domains":                true,
+	"com.apple.cellularprivatenetwork.managed":    true,
+	"com.apple.conferenceroomdisplay":             true,
+	"com.apple.desktop":                           true,
+	"com.apple.dnsProxy.managed":                  true,
+	"com.apple.dock":                              true,
+	"com.apple.domains":                           true,
+	"com.apple.familycontrols.contentfilter":      true,
+	"com.apple.familycontrols.timelimits.v2":      true,
+	"com.apple.fileproviderd":                     true,
+	"com.apple.finder":                            true,
+	"com.apple.firstactiveethernet.managed":       true,
+	"com.apple.firstethernet.managed":             true,
+	"com.apple.gamed":                             true,
+	"com.apple.globalethernet.managed":            true,
+	"com.apple.homescreenlayout":                  true,
+	"com.apple.loginitems.managed":                true,
+	"com.apple.loginwindow":                       true,
+	"com.apple.lom":                               true,
+	"com.apple.mcxMenuExtras":                     true,
+	"com.apple.mcxprinting":                       true,
+	"com.apple.networkusagerules":                 true,
+	"com.apple.notificationsettings":              true,
+	"com.apple.preference.security":               true,
+	"com.apple.preference.users":                  true,
+	"com.apple.relay.managed":                     true,
+	"com.apple.screensaver":                       true,
+	"com.apple.screensaver.user":                  true,
+	"com.apple.secondactiveethernet.managed":      true,
+	"com.apple.secondethernet.managed":            true,
+	"com.apple.security.FDERecoveryKeyEscrow":     true,
+	"com.apple.security.acme":                     true,
+	"com.apple.security.certificatepreference":    true,
+	"com.apple.security.certificaterevocation":    true,
+	"com.apple.security.certificatetransparency":  true,
+	"com.apple.security.firewall":                 true,
+	"com.apple.security.identitypreference":       true,
+	"com.apple.security.smartcard":                true,
+	"com.apple.servicemanagement":                 true,
+	"com.apple.shareddeviceconfiguration":         true,
+	"com.apple.syspolicy.kernel-extension-policy": true,
+	"com.apple.system-extension-policy":           true,
+	"com.apple.systemmigration":                   true,
+	"com.apple.systempolicy.control":              true,
+	"com.apple.systempolicy.managed":              true,
+	"com.apple.systempolicy.rule":                 true,
+	"com.apple.thirdactiveethernet.managed":       true,
+	"com.apple.thirdethernet.managed":             true,
+	"com.apple.tvremote":                          true,
+	"com.apple.universalaccess":                   true,
+	"com.apple.vpn.managed.applayer":              true,
+	"com.apple.wifi.managed":                      true,
+	"com.apple.xsan":                              true,
+	"com.apple.xsan.preferences":                  true,
+	"loginwindow":                                 true,
+}
+
+// canonicalPayloadTypes maps payload type spellings Jamf Pro writes into Classic
+// configuration profiles onto the spelling the blueprints registry keys on.
+//
+// Jamf Pro's User Preferences payload is written as com.apple.preferences.users,
+// which is the *filename* Apple publishes that payload's schema under; Apple's
+// declared payloadtype — and the only spelling the API accepts — is
+// com.apple.preference.users (singular).
+var canonicalPayloadTypes = map[string]string{
+	"com.apple.preferences.users": "com.apple.preference.users",
+}
+
+// CanonicalPayloadType returns the payload type spelling the blueprints API
+// expects, rewriting the Jamf Pro variants in canonicalPayloadTypes. Types with
+// no known variant are returned unchanged.
+func CanonicalPayloadType(payloadType string) string {
+	if canonical, ok := canonicalPayloadTypes[payloadType]; ok {
+		return canonical
+	}
+	return payloadType
+}
+
+// wrapAsManagedPreferences packages a preference domain's settings as a
+// com.apple.ManagedClient.preferences (Custom Settings/MCX) payload, the form the
+// blueprints API accepts for any domain — including the payload types outside
+// SupportedPayloadTypes and third-party domains it has never heard of. This is
+// also the correct legacy delivery for such domains: they are managed preferences
+// rather than standalone MDM payloads.
+//
+// PayloadContent keeps Apple's capitalisation because the API stores it verbatim.
+func wrapAsManagedPreferences(payloadType string, settings map[string]any, index int) map[string]any {
+	return map[string]any{
+		"payloadType":       mcxPayloadType,
+		"payloadIdentifier": generatePayloadIdentifier(payloadType, index),
+		"PayloadContent": map[string]any{
+			payloadType: map[string]any{
+				"Forced": []any{
+					map[string]any{"mcx_preference_settings": settings},
+				},
+			},
+		},
+	}
 }
 
 // UIManageablePayloadTypes lists the legacy payload types the Jamf Pro UI can
@@ -201,6 +346,10 @@ func ConvertMobileconfig(data []byte, filterUnsupported bool) (json.RawMessage, 
 		if payloadType == "" {
 			return nil, nil, fmt.Errorf("PayloadContent[%d] has no PayloadType", i)
 		}
+		if canonical := CanonicalPayloadType(payloadType); canonical != payloadType {
+			warnings = append(warnings, fmt.Sprintf("rewrote payload type %q to %q — the blueprints API only accepts Apple's canonical spelling", payloadType, canonical))
+			payloadType = canonical
+		}
 
 		if DisabledPayloadTypes[payloadType] {
 			if filterUnsupported {
@@ -213,6 +362,19 @@ func ConvertMobileconfig(data []byte, filterUnsupported bool) (json.RawMessage, 
 		idx := typeCount[payloadType]
 		typeCount[payloadType]++
 		entry := buildPayloadEntry(payloadType, payload, idx)
+		// Payload types outside the component's registry are rejected as standalone
+		// payloads but accepted as Custom Settings, which is also their correct
+		// legacy delivery. Wrap rather than lose the settings.
+		if !SupportedPayloadTypes[payloadType] && !DisabledPayloadTypes[payloadType] {
+			settings := settingsFromEntry(entry)
+			if len(settings) == 0 {
+				warnings = append(warnings, fmt.Sprintf("removed empty payload %q — no settings after metadata stripping", payloadType))
+				typeCount[payloadType]--
+				continue
+			}
+			warnings = append(warnings, fmt.Sprintf("payload type %q is not a standalone blueprints payload — delivering it as Custom Settings (MCX)", payloadType))
+			entry = wrapAsManagedPreferences(payloadType, settings, idx)
+		}
 		payloads = append(payloads, entry)
 	}
 
@@ -242,22 +404,38 @@ func ConvertPlist(data []byte, payloadType, displayName string) (json.RawMessage
 	}
 
 	var warnings []string
+	if canonical := CanonicalPayloadType(payloadType); canonical != payloadType {
+		warnings = append(warnings, fmt.Sprintf("rewrote payload type %q to %q — the blueprints API only accepts Apple's canonical spelling", payloadType, canonical))
+		payloadType = canonical
+	}
 	if DisabledPayloadTypes[payloadType] {
 		warnings = append(warnings, fmt.Sprintf("payload type %q is disabled by Jamf blueprints — the API will reject it", payloadType))
 	}
 
 	// All keys in a raw plist are settings (no Apple metadata to strip).
 	// Empty values are removed since the DDM API rejects them.
-	entry := map[string]any{
-		"payloadType":       payloadType,
-		"payloadIdentifier": generatePayloadIdentifier(payloadType, 0),
-	}
+	clean := make(map[string]any, len(settings))
 	for k, v := range settings {
 		converted := convertPlistValue(v)
 		if isEmptyValue(converted) {
 			continue
 		}
-		entry[k] = converted
+		clean[k] = converted
+	}
+
+	// A domain the component's registry doesn't know — which is every third-party
+	// domain, the common case for a raw plist — is only deliverable wrapped as
+	// Custom Settings.
+	var entry map[string]any
+	if !SupportedPayloadTypes[payloadType] && !DisabledPayloadTypes[payloadType] {
+		warnings = append(warnings, fmt.Sprintf("payload type %q is not a standalone blueprints payload — delivering it as Custom Settings (MCX)", payloadType))
+		entry = wrapAsManagedPreferences(payloadType, clean, 0)
+	} else {
+		entry = map[string]any{
+			"payloadType":       payloadType,
+			"payloadIdentifier": generatePayloadIdentifier(payloadType, 0),
+		}
+		maps.Copy(entry, clean)
 	}
 
 	if displayName == "" {
@@ -313,6 +491,20 @@ func PayloadTypeSummary(data []byte) []string {
 // empty values (empty strings and empty arrays) are removed since the DDM API
 // rejects them, and the payloadIdentifier is generated deterministically.
 // The index disambiguates multiple payloads of the same type.
+// settingsFromEntry returns the setting keys of a built payload entry, dropping
+// the structural keys. Used when an already-built entry has to be re-packaged as
+// a Custom Settings payload.
+func settingsFromEntry(entry map[string]any) map[string]any {
+	settings := make(map[string]any, len(entry))
+	for k, v := range entry {
+		if k == "payloadType" || k == "payloadIdentifier" {
+			continue
+		}
+		settings[k] = v
+	}
+	return settings
+}
+
 func buildPayloadEntry(payloadType string, payload map[string]any, index int) map[string]any {
 	entry := map[string]any{
 		"payloadType":       payloadType,

--- a/internal/profileconvert/convert_test.go
+++ b/internal/profileconvert/convert_test.go
@@ -241,19 +241,19 @@ func TestConvertMobileconfig_MultiPayload(t *testing.T) {
 	}
 }
 
-func TestConvertMobileconfig_UnknownPayloadPassesThrough(t *testing.T) {
-	// A payload type that is NOT on the denylist is passed through to the API
-	// (which schema-validates it) with no warning — even with filtering enabled.
+func TestConvertMobileconfig_UnknownPayloadWrappedAsMCX(t *testing.T) {
+	// A payload type outside SupportedPayloadTypes is rejected by the API as a
+	// standalone payload, so it is delivered wrapped in Custom Settings (MCX)
+	// instead of being dropped or sent bare.
 	config, warnings, err := ConvertMobileconfig([]byte(testUnsupportedPayloadMobileconfig), true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(warnings) != 0 {
-		t.Errorf("expected no warnings for a non-disabled type, got %v", warnings)
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "Custom Settings") {
+		t.Errorf("expected one Custom Settings warning, got %v", warnings)
 	}
 
-	// Output is still valid and includes the payload.
 	var result map[string]any
 	if err := json.Unmarshal(config, &result); err != nil {
 		t.Fatalf("invalid JSON output: %v", err)
@@ -261,11 +261,23 @@ func TestConvertMobileconfig_UnknownPayloadPassesThrough(t *testing.T) {
 
 	content := result["payloadContent"].([]any)
 	payload := content[0].(map[string]any)
-	if payload["payloadType"] != "com.example.fake.payload" {
-		t.Errorf("payloadType = %v, want com.example.fake.payload", payload["payloadType"])
+	if payload["payloadType"] != mcxPayloadType {
+		t.Fatalf("payloadType = %v, want %s", payload["payloadType"], mcxPayloadType)
 	}
-	if payload["SSID_STR"] != "CorpWifi" {
-		t.Errorf("SSID_STR = %v, want CorpWifi", payload["SSID_STR"])
+
+	// The settings survive, nested under the original domain.
+	domains, ok := payload["PayloadContent"].(map[string]any)
+	if !ok {
+		t.Fatalf("wrapped payload has no PayloadContent dict: %v", payload)
+	}
+	domain, ok := domains["com.example.fake.payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("wrapped payload missing the original domain: %v", domains)
+	}
+	forced := domain["Forced"].([]any)
+	settings := forced[0].(map[string]any)["mcx_preference_settings"].(map[string]any)
+	if settings["SSID_STR"] != "CorpWifi" {
+		t.Errorf("SSID_STR = %v, want CorpWifi", settings["SSID_STR"])
 	}
 }
 
@@ -451,14 +463,78 @@ func TestConvertPlist_DisabledType(t *testing.T) {
 	}
 }
 
-func TestConvertPlist_UnknownTypeNoWarning(t *testing.T) {
-	// A non-disabled type produces no warning — the API validates it.
-	_, warnings, err := ConvertPlist([]byte(testPlist), "com.example.fake.payload", "")
+func TestConvertPlist_UnknownTypeWrappedAsMCX(t *testing.T) {
+	// A raw plist for a domain the blueprints registry doesn't know — the common
+	// case for third-party settings — is delivered as Custom Settings (MCX).
+	config, warnings, err := ConvertPlist([]byte(testPlist), "com.example.fake.payload", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "Custom Settings") {
+		t.Fatalf("expected one Custom Settings warning, got %v", warnings)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(config, &result); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+	payload := result["payloadContent"].([]any)[0].(map[string]any)
+	if payload["payloadType"] != mcxPayloadType {
+		t.Errorf("payloadType = %v, want %s", payload["payloadType"], mcxPayloadType)
+	}
+	if _, ok := payload["PayloadContent"].(map[string]any)["com.example.fake.payload"]; !ok {
+		t.Errorf("wrapped payload missing the original domain: %v", payload["PayloadContent"])
+	}
+}
+
+func TestConvertPlist_SupportedTypeStaysBare(t *testing.T) {
+	// A type the API accepts standalone must NOT be wrapped.
+	config, warnings, err := ConvertPlist([]byte(testPlist), "com.apple.dock", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(warnings) != 0 {
-		t.Errorf("expected no warnings for a non-disabled type, got %v", warnings)
+		t.Errorf("expected no warnings for a supported type, got %v", warnings)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(config, &result); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+	payload := result["payloadContent"].([]any)[0].(map[string]any)
+	if payload["payloadType"] != "com.apple.dock" {
+		t.Errorf("payloadType = %v, want com.apple.dock", payload["payloadType"])
+	}
+}
+
+func TestCanonicalPayloadType_JamfSpelling(t *testing.T) {
+	// Jamf Pro writes Apple's *filename* spelling for the User Preferences
+	// payload; the API only accepts Apple's declared payloadtype.
+	if got := CanonicalPayloadType("com.apple.preferences.users"); got != "com.apple.preference.users" {
+		t.Errorf("CanonicalPayloadType = %q, want com.apple.preference.users", got)
+	}
+	if got := CanonicalPayloadType("com.apple.dock"); got != "com.apple.dock" {
+		t.Errorf("CanonicalPayloadType rewrote a type it should not have: %q", got)
+	}
+	if !SupportedPayloadTypes[CanonicalPayloadType("com.apple.preferences.users")] {
+		t.Error("canonical User Preferences type should be in SupportedPayloadTypes")
+	}
+}
+
+func TestSupportedPayloadTypes_CoversUIManageableList(t *testing.T) {
+	// Every payload type the Jamf Pro UI can manage must be one the API accepts
+	// standalone, otherwise import would wrap something the UI could have shown.
+	for pt := range UIManageablePayloadTypes {
+		if !SupportedPayloadTypes[pt] {
+			t.Errorf("UI-manageable type %q missing from SupportedPayloadTypes", pt)
+		}
+	}
+}
+
+func TestSupportedPayloadTypes_DisjointFromDisabled(t *testing.T) {
+	for pt := range DisabledPayloadTypes {
+		if SupportedPayloadTypes[pt] {
+			t.Errorf("type %q is in both SupportedPayloadTypes and DisabledPayloadTypes", pt)
+		}
 	}
 }
 

--- a/internal/profileconvert/ddm_converter.go
+++ b/internal/profileconvert/ddm_converter.go
@@ -104,19 +104,12 @@ func ConvertToDDMComponents(data []byte, filterUnsupported bool, fetcher *Schema
 
 	result := &DDMConversionResult{DisplayName: displayName}
 
-	// Expand MCX (Custom Settings) payloads before processing. Inner domains that
-	// are real Apple payloads (have a converter, or Apple publishes a schema for
-	// them) are unwrapped to standalone payloads so converters can run and the API
-	// can validate them; third-party/unknown domains stay wrapped in a residual
+	// Expand MCX (Custom Settings) payloads before processing. Inner domains the
+	// blueprints API accepts standalone (or that a converter will consume) are
+	// unwrapped so converters can run; everything else stays wrapped in a residual
 	// ManagedClient.preferences payload, which the API accepts as opaque custom
-	// settings but rejects as an unwrapped bare type. classifier reuses the
-	// strip-defaults fetcher when present, else a lightweight one that only hits
-	// the network for MCX inner domains (like --strip-defaults does for schemas).
-	classifier := fetcher
-	if classifier == nil {
-		classifier = NewSchemaFetcher(nil)
-	}
-	payloadContent = splitMCXPayloads(payloadContent, classifier, result)
+	// settings but rejects as an unwrapped bare type.
+	payloadContent = splitMCXPayloads(payloadContent, result)
 
 	var profilePayloads []map[string]any
 	seenComponents := make(map[string]bool)
@@ -131,6 +124,11 @@ func ConvertToDDMComponents(data []byte, filterUnsupported bool, fetcher *Schema
 		payloadType, _ := payload["PayloadType"].(string)
 		if payloadType == "" {
 			return nil, fmt.Errorf("PayloadContent[%d] has no PayloadType", i)
+		}
+		if canonical := CanonicalPayloadType(payloadType); canonical != payloadType {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("rewrote payload type %q to %q — the blueprints API only accepts Apple's canonical spelling", payloadType, canonical))
+			payloadType = canonical
 		}
 
 		matched := findConverters(payloadType)
@@ -151,6 +149,15 @@ func ConvertToDDMComponents(data []byte, filterUnsupported bool, fetcher *Schema
 				result.Warnings = append(result.Warnings,
 					fmt.Sprintf("removed empty payload %q — no settings after metadata stripping", payloadType))
 				continue
+			}
+			// Types outside the configuration-profile component's registry are
+			// rejected as standalone payloads (opaque "Failed to validate
+			// configuration.") but accepted as Custom Settings, which is also their
+			// correct legacy delivery. Wrap rather than fail the whole import.
+			if !SupportedPayloadTypes[payloadType] && !DisabledPayloadTypes[payloadType] {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("payload type %q is not a standalone blueprints payload — delivering it as Custom Settings (MCX)", payloadType))
+				entry = wrapAsManagedPreferences(payloadType, settingsFromEntry(entry), typeCount[payloadType])
 			}
 			typeCount[payloadType]++
 			profilePayloads = append(profilePayloads, entry)
@@ -333,23 +340,14 @@ func ensureFullSoftwareUpdateSchema(result *DDMConversionResult) {
 	result.NativeComponents[idx].Configuration = merged
 }
 
-// mcxWrapLeftoverTypes are payload types the blueprints API refuses as bare
-// configuration-profile payloads but accepts wrapped in Custom Settings (MCX).
-// A converter's unconverted leftover keys for these types are therefore
-// delivered via a com.apple.ManagedClient.preferences payload (which is also
-// their correct legacy delivery — they are preference domains, not standalone
-// MDM payloads). Wire-verified: bare com.apple.SoftwareUpdate → 400, the same
-// keys wrapped in MCX → accepted.
-var mcxWrapLeftoverTypes = map[string]bool{
-	"com.apple.SoftwareUpdate": true,
-}
-
 // buildLeftoverEntry constructs a configuration-profile payload entry from the
 // keys a converter did not consume. Empty values (empty strings/arrays the DDM
-// API rejects) are dropped. Types in mcxWrapLeftoverTypes are wrapped in a
-// com.apple.ManagedClient.preferences (Custom Settings) payload; all others are
-// emitted as a bare payload of their own type. Returns nil if nothing remains
-// after dropping empties.
+// API rejects) are dropped. Types outside SupportedPayloadTypes are wrapped in a
+// com.apple.ManagedClient.preferences (Custom Settings) payload — the API refuses
+// them as bare payloads, and Custom Settings is also their correct legacy
+// delivery since they are preference domains rather than standalone MDM payloads.
+// All others are emitted as a bare payload of their own type. Returns nil if
+// nothing remains after dropping empties.
 func buildLeftoverEntry(payloadType string, remaining map[string]any, index int) map[string]any {
 	clean := make(map[string]any, len(remaining))
 	for k, v := range remaining {
@@ -362,18 +360,8 @@ func buildLeftoverEntry(payloadType string, remaining map[string]any, index int)
 	if len(clean) == 0 {
 		return nil
 	}
-	if mcxWrapLeftoverTypes[payloadType] {
-		return map[string]any{
-			"payloadType":       mcxPayloadType,
-			"payloadIdentifier": generatePayloadIdentifier(payloadType, index),
-			"PayloadContent": map[string]any{
-				payloadType: map[string]any{
-					"Forced": []any{
-						map[string]any{"mcx_preference_settings": clean},
-					},
-				},
-			},
-		}
+	if !SupportedPayloadTypes[payloadType] {
+		return wrapAsManagedPreferences(payloadType, clean, index)
 	}
 	entry := map[string]any{
 		"payloadType":       payloadType,
@@ -384,14 +372,13 @@ func buildLeftoverEntry(payloadType string, remaining map[string]any, index int)
 }
 
 // splitMCXPayloads expands com.apple.ManagedClient.preferences (Custom Settings)
-// payloads. Each inner preference domain that is a real Apple payload — one with
-// a DDM converter, or one for which Apple publishes a payload schema — is emitted
-// as a standalone payload so converters can run and the blueprints API can
-// validate it. Domains that are not recognized Apple payloads (third-party
-// preference domains) stay wrapped in a residual ManagedClient.preferences
-// payload, which the API accepts as opaque custom settings but rejects as an
-// unwrapped bare type. Non-MCX payloads pass through unchanged.
-func splitMCXPayloads(payloads []any, classifier *SchemaFetcher, result *DDMConversionResult) []any {
+// payloads. An inner preference domain is emitted as a standalone payload only if
+// the blueprints API will actually take it that way — it has a DDM converter, or
+// it is in SupportedPayloadTypes. Every other domain stays wrapped in a residual
+// ManagedClient.preferences payload, which the API accepts as opaque custom
+// settings but rejects as an unwrapped bare type. Non-MCX payloads pass through
+// unchanged.
+func splitMCXPayloads(payloads []any, result *DDMConversionResult) []any {
 	out := make([]any, 0, len(payloads))
 	for _, item := range payloads {
 		p, ok := item.(map[string]any)
@@ -424,7 +411,7 @@ func splitMCXPayloads(payloads []any, classifier *SchemaFetcher, result *DDMConv
 				continue
 			}
 			settings := extractMCXSettings(dd)
-			if len(settings) == 0 || !isRealApplePayload(domain, classifier) {
+			if len(settings) == 0 || !unwrappableDomain(domain) {
 				residual[domain] = content[domain]
 				continue
 			}
@@ -449,19 +436,17 @@ func splitMCXPayloads(payloads []any, classifier *SchemaFetcher, result *DDMConv
 	return out
 }
 
-// isRealApplePayload reports whether a preference domain is a real Apple payload
-// type — one with a DDM converter, or one for which Apple publishes a payload
-// schema (fetched live, like --strip-defaults). Network/lookup failures fall back
-// to false so unknown domains stay wrapped in MCX (which the API accepts).
-func isRealApplePayload(domain string, classifier *SchemaFetcher) bool {
-	if len(findConverters(domain)) > 0 {
-		return true
-	}
-	if classifier == nil {
-		return false
-	}
-	defaults, _ := classifier.FetchDefaults(domain)
-	return defaults != nil
+// unwrappableDomain reports whether an MCX inner preference domain can be lifted
+// out to a standalone payload: either a converter will consume it, or the
+// blueprints API accepts it as a standalone payloadType.
+//
+// Apple publishing a schema for a domain is NOT sufficient — the API takes a fixed
+// registry of payload types, and several well-documented Apple payloads
+// (com.apple.Safari, com.apple.SoftwareUpdate, com.apple.systemuiserver, …) are
+// rejected outside a Custom Settings wrapper. Unwrapping on "Apple has a schema"
+// is what made those imports fail with an opaque validation error.
+func unwrappableDomain(domain string) bool {
+	return len(findConverters(domain)) > 0 || SupportedPayloadTypes[CanonicalPayloadType(domain)]
 }
 
 // copyMCXMetadata copies Apple metadata keys (except PayloadType and

--- a/internal/profileconvert/ddm_converter_test.go
+++ b/internal/profileconvert/ddm_converter_test.go
@@ -1712,3 +1712,157 @@ func TestConvertCookiePolicy_NonNumeric(t *testing.T) {
 		t.Errorf("convertCookiePolicy(\"invalid\") = %v, want Always", got)
 	}
 }
+
+func TestConvertToDDMComponents_MCXAppleDomainAPIRejectsStaysWrapped(t *testing.T) {
+	// Apple publishes a schema for com.apple.Safari, but the blueprints registry
+	// has no such payload type — unwrapping it produced the opaque
+	// "Failed to validate configuration." 400. It must stay wrapped in MCX.
+	mc := mcxProfile("com.apple.Safari", `<key>AutoFillPasswords</key><false/>`)
+
+	result, err := ConvertToDDMComponents([]byte(mc), true, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ProfileConfig == nil {
+		t.Fatal("expected ProfileConfig containing the kept MCX payload")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(result.ProfileConfig, &cfg); err != nil {
+		t.Fatalf("invalid ProfileConfig JSON: %v", err)
+	}
+	p := cfg["payloadContent"].([]any)[0].(map[string]any)
+	if p["payloadType"] != mcxPayloadType {
+		t.Fatalf("com.apple.Safari should stay MCX-wrapped, got payloadType %v", p["payloadType"])
+	}
+	if _, ok := p["PayloadContent"].(map[string]any)["com.apple.Safari"]; !ok {
+		t.Errorf("expected com.apple.Safari preserved inside MCX, got %v", p["PayloadContent"])
+	}
+}
+
+func TestConvertToDDMComponents_DirectUnsupportedPayloadWrapped(t *testing.T) {
+	// The Jamf Pro Restrictions UI emits preference-domain payloads directly
+	// (com.apple.ShareKitHelper, com.apple.systemuiserver, com.apple.MCX, …). The
+	// blueprints registry refuses all of them standalone, which failed the whole
+	// import; each is delivered as Custom Settings instead. com.apple.finder is a
+	// supported type in the same profile and must stay bare.
+	mc := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.ShareKitHelper</string>
+			<key>SHKAllowedShareServices</key>
+			<array><string>com.apple.share.AirDrop</string></array>
+		</dict>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.MCX</string>
+			<key>safariAllowAutoFill</key>
+			<true/>
+		</dict>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.finder</string>
+			<key>ProhibitBurn</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>Restrictions</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>`
+
+	result, err := ConvertToDDMComponents([]byte(mc), true, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ProfileConfig == nil {
+		t.Fatal("expected ProfileConfig")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(result.ProfileConfig, &cfg); err != nil {
+		t.Fatalf("invalid ProfileConfig JSON: %v", err)
+	}
+
+	byType := map[string][]map[string]any{}
+	for _, item := range cfg["payloadContent"].([]any) {
+		p := item.(map[string]any)
+		pt, _ := p["payloadType"].(string)
+		byType[pt] = append(byType[pt], p)
+	}
+
+	if len(byType["com.apple.finder"]) != 1 {
+		t.Errorf("supported com.apple.finder should stay bare, got %v", byType)
+	}
+	if len(byType[mcxPayloadType]) != 2 {
+		t.Fatalf("expected the two unsupported payloads wrapped as MCX, got %v", byType)
+	}
+	wrapped := map[string]bool{}
+	for _, p := range byType[mcxPayloadType] {
+		for domain := range p["PayloadContent"].(map[string]any) {
+			wrapped[domain] = true
+		}
+	}
+	for _, want := range []string{"com.apple.ShareKitHelper", "com.apple.MCX"} {
+		if !wrapped[want] {
+			t.Errorf("expected %s delivered as Custom Settings, got domains %v", want, wrapped)
+		}
+	}
+}
+
+func TestConvertToDDMComponents_JamfUserPreferencesSpellingRewritten(t *testing.T) {
+	// Jamf Pro writes com.apple.preferences.users; only Apple's declared
+	// payloadtype (com.apple.preference.users) is accepted, and once rewritten it
+	// is a supported standalone payload, so it must not be MCX-wrapped.
+	mc := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.preferences.users</string>
+			<key>DisableUsingiCloudPassword</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>User Prefs</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>`
+
+	result, err := ConvertToDDMComponents([]byte(mc), true, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(result.ProfileConfig, &cfg); err != nil {
+		t.Fatalf("invalid ProfileConfig JSON: %v", err)
+	}
+	p := cfg["payloadContent"].([]any)[0].(map[string]any)
+	if p["payloadType"] != "com.apple.preference.users" {
+		t.Errorf("payloadType = %v, want com.apple.preference.users", p["payloadType"])
+	}
+
+	var rewrote bool
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "canonical spelling") {
+			rewrote = true
+		}
+	}
+	if !rewrote {
+		t.Errorf("expected a warning naming the rewrite, got %v", result.Warnings)
+	}
+}


### PR DESCRIPTION
Fixes #307.

## Problem

`pro blueprints import-profile` failed on many stock Jamf Pro profiles with a 400 that named only the component, and created nothing:

```
steps[0].components[2].configuration: Failed to validate configuration.
```

## Root cause

The code assumed the blueprints API "accepts any Apple MDM payload and validates it against Apple's published schema", excluding only `com.apple.font` and `com.apple.webClip.managed`. That is what Jamf's own spec says — verified byte-identical in the v952 spec bundle — and it is wrong in both directions.

The `com.jamf.ddm-configuration-profile` component matches `payloadType` against a **fixed registry**. The opaque error is byte-for-byte what an invented payload type (`com.zzz.invented`) returns, i.e. it means *unknown type*. Keys are barely checked by comparison: `com.apple.finder` accepts a made-up key, a string where the schema wants a boolean, and no keys at all.

Wire-probed 136 payload types bare — every type Apple publishes in `apple/device-management/mdm/profiles`, plus Jamf's `com.apple.MCX.<Name>` family and Jamf's own spellings:

| Outcome | Count | API response |
|---|---|---|
| Accepted standalone | 74 | 201 |
| Explicitly blocked | 22 | `payloadType: Payload disabled: <type>` |
| Unknown to the registry | 40 | `configuration: Failed to validate configuration.` |

The 22 blocked types matched the existing `DisabledPayloadTypes` map exactly. The 40 unknown ones had no handling at all — and Apple publishing a schema says nothing about the registry: `com.apple.MCX`, `com.apple.Safari`, `com.apple.SoftwareUpdate`, `com.apple.Terminal`, `com.apple.systemuiserver`, `com.apple.ShareKitHelper`, `com.apple.coremediaio.support`, `com.apple.mail.managed`, `.GlobalPreferences` are all in it.

## Changes

- **`SupportedPayloadTypes`** — the probed 74-type registry.
- **`wrapAsManagedPreferences`** — an out-of-registry domain is delivered as `com.apple.ManagedClient.preferences` (`Forced` → `mcx_preference_settings`). Accepted for every domain probed including third-party (`com.microsoft.Word`), and it is these domains' correct legacy delivery: they are managed preferences, not standalone MDM payloads. **Wrapped, not dropped** — no settings are lost.
- **`CanonicalPayloadType`** — rewrites `com.apple.preferences.users` (Apple's *filename*, which Jamf Pro writes) to the payloadtype the registry knows, `com.apple.preference.users`. One character, whole-profile failure.
- **`splitMCXPayloads`** unwraps an MCX inner domain only when a converter consumes it or the registry accepts it (`unwrappableDomain`), replacing the "Apple publishes a schema" predicate that was actively turning importable profiles into rejected ones. Also removes the live GitHub fetch from the default import path — classification is now deterministic and offline.
- **`buildLeftoverEntry`** generalises the one-entry `mcxWrapLeftoverTypes` special case (`com.apple.SoftwareUpdate`, found by an earlier probe) to the whole registry check.
- Command help no longer repeats the spec's "accepts almost every Apple payload" claim.

## Verification

End-to-end against a live tenant with the built binary:

- **Restrictions** (14 payloads): 400 → created. 4 payloads wrapped, 1 spelling rewritten. `com.apple.dashboard`, previously *dropped* for a missing required key, is now preserved.
- **Login Window** (6 payloads): 400 → created. `com.apple.MCX`, `.GlobalPreferences`, `com.apple.mcxloginscripts` wrapped; settings confirmed on the wire nested under their domains.

New tests cover: an MCX-wrapped `com.apple.Safari` staying wrapped (the predicate regression), direct unsupported payloads wrapped while a supported sibling stays bare, the spelling rewrite, and two invariants — `UIManageablePayloadTypes ⊆ SupportedPayloadTypes`, and `SupportedPayloadTypes` disjoint from `DisabledPayloadTypes`.

`make test`, `make lint`, `make verify-generated` all clean.

## Notes for review

- **Missing a supported type is benign; guessing one in is not.** An unknown-to-us type the API does support gets MCX-wrapped — still delivered, just as managed preferences. The failure mode this PR removes can't return from an omission.
- Docs commit records the re-derivation method: probe **bare** (removes key validity as a confounder; a supported-but-needs-keys type identifies itself by naming the missing field). Batching types per POST and bisecting does **not** work — duplicate blueprint names fail for an unrelated reason and get mis-attributed to a payload type.
- Two upstream items are out of scope here: Jamf's spec documents 2 disabled types rather than 22 and never mentions the registry, and the unknown-type 400 should name the offending `payloadContent[N].payloadType` the way the disabled-type 400 already does.
- The SDK needs no change — `jamfplatform-go-sdk` never inspects payload contents; acceptance is purely server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)