### PR TITLE
feat(cli): notify once a day when a newer jamf-cli release is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Config file: `~/.config/jamf-cli/config.yaml`
 ```yaml
 default-profile: prod
 default-output: table
+update-check: true # set false to silence the daily "newer jamf-cli available" hint
 
 profiles:
   prod:

--- a/cmd/jamf-cli/main.go
+++ b/cmd/jamf-cli/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/Jamf-Concepts/jamf-cli/internal/commands"
 	"github.com/Jamf-Concepts/jamf-cli/internal/exitcode"
@@ -40,8 +41,26 @@ func injectEnvArgs(args []string, env string) []string {
 	return result
 }
 
+// resolveVersion falls back to the module version the Go toolchain stamps into
+// the binary. Release builds get their version from -ldflags (see the
+// Makefile), but `go install github.com/Jamf-Concepts/jamf-cli/cmd/jamf-cli@latest`
+// gets none and would report the "dev" default — which makes bug reports
+// untraceable and suppresses the newer-release advisory, since that only runs
+// on an exact release version.
+func resolveVersion(ldflagsVersion string, readBuildInfo func() (*debug.BuildInfo, bool)) string {
+	if ldflagsVersion != "" && ldflagsVersion != "dev" {
+		return ldflagsVersion
+	}
+	info, ok := readBuildInfo()
+	if !ok || info == nil || info.Main.Version == "" || info.Main.Version == "(devel)" {
+		return ldflagsVersion
+	}
+	return info.Main.Version
+}
+
 func main() {
 	os.Args = injectEnvArgs(os.Args, os.Getenv("JAMF_CLI_ARGS"))
+	version = resolveVersion(version, debug.ReadBuildInfo)
 
 	cmd := commands.NewRootCmd(version, commit, date, specProVersion)
 	executedCmd, err := cmd.ExecuteC()

--- a/cmd/jamf-cli/main_test.go
+++ b/cmd/jamf-cli/main_test.go
@@ -3,9 +3,79 @@
 package main
 
 import (
+	"runtime/debug"
 	"slices"
 	"testing"
 )
+
+func TestResolveVersion(t *testing.T) {
+	buildInfo := func(v string) func() (*debug.BuildInfo, bool) {
+		return func() (*debug.BuildInfo, bool) {
+			info := &debug.BuildInfo{}
+			info.Main.Version = v
+			return info, true
+		}
+	}
+	noBuildInfo := func() (*debug.BuildInfo, bool) { return nil, false }
+
+	tests := []struct {
+		name           string
+		ldflagsVersion string
+		readBuildInfo  func() (*debug.BuildInfo, bool)
+		want           string
+	}{
+		{
+			name:           "ldflags version wins",
+			ldflagsVersion: "v1.25.2",
+			readBuildInfo:  buildInfo("v1.0.0"),
+			want:           "v1.25.2",
+		},
+		{
+			name:           "go install falls back to the module version",
+			ldflagsVersion: "dev",
+			readBuildInfo:  buildInfo("v1.26.0"),
+			want:           "v1.26.0",
+		},
+		{
+			name:           "local go build stays dev",
+			ldflagsVersion: "dev",
+			readBuildInfo:  buildInfo("(devel)"),
+			want:           "dev",
+		},
+		{
+			name:           "empty module version stays dev",
+			ldflagsVersion: "dev",
+			readBuildInfo:  buildInfo(""),
+			want:           "dev",
+		},
+		{
+			name:           "missing build info stays dev",
+			ldflagsVersion: "dev",
+			readBuildInfo:  noBuildInfo,
+			want:           "dev",
+		},
+		{
+			name:           "empty ldflags version also falls back",
+			ldflagsVersion: "",
+			readBuildInfo:  buildInfo("v1.26.0"),
+			want:           "v1.26.0",
+		},
+		{
+			name:           "git describe version is left alone",
+			ldflagsVersion: "v1.25.2-3-gabc1234-dirty",
+			readBuildInfo:  buildInfo("v1.26.0"),
+			want:           "v1.25.2-3-gabc1234-dirty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveVersion(tt.ldflagsVersion, tt.readBuildInfo); got != tt.want {
+				t.Errorf("resolveVersion(%q) = %q, want %q", tt.ldflagsVersion, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestInjectEnvArgs(t *testing.T) {
 	tests := []struct {

--- a/docs/solutions/design-patterns/release-update-notifier-2026-07-29.md
+++ b/docs/solutions/design-patterns/release-update-notifier-2026-07-29.md
@@ -1,0 +1,99 @@
+---
+title: "Release update notifier: module proxy over GitHub API, notify-only, gate-first"
+date: 2026-07-29
+category: design-patterns
+module: internal/commands
+problem_type: design_pattern
+severity: low
+applies_when:
+  - "Adding any background network probe that runs on ordinary command invocations"
+  - "Deciding where a CLI should read its own latest published version from"
+  - "Adding a self-update or upgrade command"
+  - "Adding advisory stderr output that must not pollute machine-readable stdout"
+tags:
+  - update-notifier
+  - version
+  - go-module-proxy
+  - rate-limits
+  - cobra
+  - mcp
+  - ci
+---
+
+# Release update notifier
+
+## Context
+
+jamf-cli ships weekly-ish and installs through four channels (Homebrew tap,
+`.pkg`, release tarball, `go install`). None of them tells a user their CLI is
+stale, so admins hit "that command doesn't exist" on endpoints a newer build
+already generates. `checkTenantVersion` (root.go) already warned about the
+*mirror* case — tenant older than the baked-in spec — so the notifier follows
+its conventions rather than inventing new ones.
+
+Three decisions are worth remembering.
+
+## 1. Read the latest version from the Go module proxy, not the GitHub API
+
+`api.github.com/repos/.../releases/latest` is capped at **60 requests per hour
+per IP, unauthenticated** — a budget every client behind one corporate NAT
+shares. For a tool used by admin teams inside a single egress IP, that fails
+silently and unpredictably.
+
+`https://proxy.golang.org/github.com/!jamf-!concepts/jamf-cli/@latest` returns
+`{"Version":"v1.25.2","Time":"..."}` — CDN-backed, no credentials, no per-IP
+budget, and already the canonical source for `go install`. Module paths escape
+capitals as `!lowercase`; use `module.EscapePath`, don't hand-write it.
+
+Fallback is `github.com/<repo>/releases/latest`, whose 302 carries the tag. It
+is a plain web request rather than an API call, so it isn't rate-limited
+either. **Do not add the GitHub API as a source.**
+
+Version comparison uses `golang.org/x/mod/semver` — already in the module
+graph, no third-party dependency. `compareProVersions` in root.go is *not*
+reusable here: it truncates to three ints and ignores prerelease ordering.
+
+## 2. Notify, never self-update
+
+A Homebrew-managed or `.pkg`-deployed binary lives in a path the invoking user
+often cannot write, and swapping a notarized binary out from under Homebrew's
+manifest breaks `brew doctor`. So the notice is install-source aware
+(`detectInstallKind`) and prints the command that actually works for *that*
+install: `brew upgrade jamf-cli`, `go install ...@latest`, or the releases URL.
+Detection is path-based on purpose — shelling out to `brew --prefix` would cost
+more than the whole check.
+
+Homebrew installs get a 24h grace period after a release: the tap is bumped
+after the GitHub release, so an immediate nag points at a version
+`brew upgrade` cannot resolve yet.
+
+## 3. Put every suppression rule in one gate, and print in PostRun
+
+`updateCheckGate` holds the policy as data (version shape, opt-outs, quiet,
+no-hints, TTY on *both* stdout and stderr, CI markers, skipped commands) so it
+is testable without a terminal, a network, or a command tree. Vetoes worth
+keeping in mind:
+
+- **`mcp` must be skipped** — it speaks JSON-RPC over stdio.
+- **Both stdout and stderr must be TTYs.** Piped stdout means a script is
+  consuming output; a redirected stderr means someone is capturing logs.
+- **Non-release versions never notify** — `dev`, a `git describe` suffix, a
+  `-dirty` tree, and prereleases have no defined upgrade. This is also why
+  `main.resolveVersion` falls back to `debug.ReadBuildInfo`: without it every
+  `go install` build reports `dev` and silently opts out.
+
+The notice prints in `PersistentPostRunE` (success path only), never in
+PreRun: it can then neither interleave with nor delay the command's own output,
+and a user dealing with an error doesn't also get told about a release.
+
+The probe runs in a goroutine with a 2s context, at most once per 24h (1h after
+a failure — the failure is cached deliberately, so an offline machine stops
+paying the timeout on every command). Cache is `.update-cache.json` beside the
+config file, 0600, temp-file-then-rename, mirroring `writeVersionCache`.
+
+## Guidance
+
+Adding another background probe to ordinary invocations? Copy this shape:
+gate as data → cached with a TTL → background with a hard deadline → advisory
+on stderr in PostRun → three opt-outs (flag, env, config key) → every failure
+silent.

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.54.0
+	golang.org/x/mod v0.37.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cma
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
 golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -98,6 +98,7 @@ func newConfigShowCmd(cliCtx *registry.CLIContext) *cobra.Command {
 				"config-file":     config.ConfigPath(),
 				"default-profile": cfg.DefaultProfile,
 				"default-output":  cfg.DefaultOutput,
+				"update-check":    cfg.UpdateCheck == nil || *cfg.UpdateCheck,
 				"profiles":        profiles,
 			}
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -58,6 +58,7 @@ var (
 	tenantID            string
 	cliVersion          string // set by NewRootCmd for use by power commands
 	noVersionCheck      bool   // skip tenant version compatibility probe
+	noUpdateCheck       bool   // skip the newer-jamf-cli-release advisory
 )
 
 // cliClient wraps our client to implement registry.HTTPClient
@@ -562,7 +563,13 @@ Set JAMF_CLI_ARGS to prepend default flags to every invocation:
   export JAMF_CLI_ARGS='--profile "My CI Profile"'
 
 Set JAMF_CLI_NO_HINTS=1 to suppress advisory hints while keeping the
-spinner and progress output (narrower than --quiet).`,
+spinner and progress output (narrower than --quiet).
+
+Once a day, an interactive release build checks whether a newer jamf-cli
+exists and prints a one-line hint to stderr. Silence it with
+--no-update-check, JAMF_CLI_NO_UPDATE_CHECK=1, or "update-check: false"
+in the config file. It never runs in CI, when output is piped, or under
+--quiet / --no-hints.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -623,6 +630,14 @@ spinner and progress output (narrower than --quiet).`,
 			formatter.SetNoHints(noHints)
 			formatter.SetExplicitNoColor(explicitNoColor)
 			cliCtx.Output = &cliOutput{formatter}
+
+			// Release advisory — probes at most once per 24 h, in the
+			// background, and prints in PersistentPostRunE so it can neither
+			// delay nor interleave with the command's own output. Started
+			// before the auth-skip returns below so it covers auth-free
+			// commands too. Every suppression rule lives in the gate; see
+			// startUpdateCheck.
+			pendingUpdateCheck = startUpdateCheck(cmd, cfg, version, noUpdateCheck)
 
 			// Group parent commands (made runnable only to reject unknown
 			// subcommands) never call an API; skip auth so `pro buildings`
@@ -744,6 +759,9 @@ spinner and progress output (narrower than --quiet).`,
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			// Only on the success path: a user staring at an error does not
+			// need to hear about a release too.
+			pendingUpdateCheck.notify(os.Stderr)
 			if outFileHandle != nil {
 				return outFileHandle.Close()
 			}
@@ -792,6 +810,7 @@ spinner and progress output (narrower than --quiet).`,
 	cmd.PersistentFlags().StringVar(&tokenFile, "token-file", "", "path to file containing API token")
 	cmd.PersistentFlags().StringVar(&tenantID, "tenant-id", "", "Jamf Pro tenant ID for platform gateway auth (or JAMF_TENANT_ID env)")
 	cmd.PersistentFlags().BoolVar(&noVersionCheck, "no-version-check", false, "skip tenant version compatibility check (also: JAMF_NO_VERSION_CHECK env)")
+	cmd.PersistentFlags().BoolVar(&noUpdateCheck, "no-update-check", false, "skip the daily check for a newer jamf-cli release (also: JAMF_CLI_NO_UPDATE_CHECK env, or update-check: false in config)")
 
 	// Version command (extracted to version.go so it can pull in provenance).
 	cmd.AddCommand(newVersionCmd(cliCtx, version, commit, date, specProVersion))

--- a/internal/commands/update_check.go
+++ b/internal/commands/update_check.go
@@ -1,0 +1,530 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/config"
+	"github.com/Jamf-Concepts/jamf-cli/internal/output"
+)
+
+const (
+	updateModulePath = "github.com/Jamf-Concepts/jamf-cli"
+	updateRepoSlug   = "Jamf-Concepts/jamf-cli"
+
+	// updateCacheTTL bounds how often a release probe leaves the machine.
+	// A failed probe cools down for less time so a transient outage doesn't
+	// mute the notice for a whole day.
+	updateCacheTTL   = 24 * time.Hour
+	updateFailureTTL = time.Hour
+
+	// updateProbeTimeout caps what the check can cost. It is paid at most
+	// once per updateCacheTTL, and only on a command that already succeeded.
+	updateProbeTimeout = 2 * time.Second
+
+	// updateBrewGrace suppresses the notice for Homebrew installs while a
+	// release is still fresh: the tap is bumped after the GitHub release, so
+	// telling a brew user to upgrade immediately points at a version
+	// `brew upgrade` cannot resolve yet.
+	updateBrewGrace = 24 * time.Hour
+)
+
+// Endpoints are variables, not constants, so tests can point them at an
+// httptest server.
+var (
+	updateProxyBaseURL  = "https://proxy.golang.org"
+	updateGitHubBaseURL = "https://github.com"
+)
+
+// updateState is the on-disk record of the last release probe. An empty
+// LatestVersion records a *failed* probe, which is what keeps repeated
+// invocations on a blocked network from each paying updateProbeTimeout.
+type updateState struct {
+	CheckedAt     time.Time `json:"checked_at"`
+	LatestVersion string    `json:"latest_version,omitempty"`
+	ReleasedAt    time.Time `json:"released_at,omitempty"`
+	ReleaseURL    string    `json:"release_url,omitempty"`
+}
+
+// fresh reports whether the cached answer is recent enough to reuse. A
+// CheckedAt in the future (clock skew, a cache copied between machines) counts
+// as fresh rather than triggering a probe on every invocation.
+func (s updateState) fresh(now time.Time) bool {
+	if s.CheckedAt.IsZero() {
+		return false
+	}
+	ttl := updateCacheTTL
+	if s.LatestVersion == "" {
+		ttl = updateFailureTTL
+	}
+	return now.Sub(s.CheckedAt) < ttl
+}
+
+// updateCachePath is a sibling of the config file, matching the tenant
+// version cache (see versionCachePath).
+func updateCachePath() string {
+	return filepath.Join(filepath.Dir(config.ConfigPath()), ".update-cache.json")
+}
+
+func readUpdateCache() updateState {
+	data, err := os.ReadFile(updateCachePath())
+	if err != nil {
+		return updateState{}
+	}
+	var s updateState
+	if json.Unmarshal(data, &s) != nil {
+		return updateState{}
+	}
+	return s
+}
+
+// writeUpdateCache persists the probe result with mode 0600. The write is
+// atomic (temp file then rename) so parallel invocations never read a partial
+// file. Failures are ignored — the cache is best-effort.
+func writeUpdateCache(s updateState) {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return
+	}
+	p := updateCachePath()
+	if os.MkdirAll(filepath.Dir(p), 0o700) != nil {
+		return
+	}
+	tmp := p + ".tmp"
+	if os.WriteFile(tmp, data, 0o600) == nil {
+		_ = os.Rename(tmp, p)
+	}
+}
+
+// normalizeVersion tolerates a version string built without the tag's "v"
+// prefix (VERSION=1.25.2 make build). Everything else is returned unchanged so
+// invalid input stays invalid.
+func normalizeVersion(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || v[0] < '0' || v[0] > '9' {
+		return v
+	}
+	return "v" + v
+}
+
+// isReleaseVersion reports whether v names an exact published release.
+// "dev", a `git describe` suffix (v1.25.2-3-gabc1234), a -dirty working tree,
+// and prerelease tags are all builds whose "upgrade" is undefined, so they
+// never notify.
+func isReleaseVersion(v string) bool {
+	v = normalizeVersion(v)
+	return semver.IsValid(v) && semver.Prerelease(v) == "" && semver.Build(v) == ""
+}
+
+// newerAvailable reports whether latest supersedes current. Both sides must be
+// exact releases: nobody should be nudged from a stable build onto an rc, and a
+// non-release current version has no defined upgrade.
+func newerAvailable(current, latest string) bool {
+	if !isReleaseVersion(current) || !isReleaseVersion(latest) {
+		return false
+	}
+	return semver.Compare(semver.Canonical(normalizeVersion(latest)), semver.Canonical(normalizeVersion(current))) > 0
+}
+
+// releaseTagURL builds the human-facing release page URL for a tag.
+func releaseTagURL(tag string) string {
+	return fmt.Sprintf("%s/%s/releases/tag/%s", strings.TrimSuffix(updateGitHubBaseURL, "/"), updateRepoSlug, tag)
+}
+
+// fetchLatestRelease resolves the newest published jamf-cli release.
+//
+// The Go module proxy is the primary source: CDN-backed, no credentials, and —
+// unlike api.github.com's 60-requests-per-hour unauthenticated cap, which every
+// client behind one corporate NAT shares — no per-IP budget an admin team can
+// exhaust. When the proxy can't answer (GOPROXY blocked by policy, module not
+// yet indexed), fall back to the github.com/<repo>/releases/latest redirect,
+// which is a plain web request rather than an API call.
+//
+// Neither request carries tenant, profile, or credential data: the module path
+// and the current version (in User-Agent) are all that leave the machine.
+func fetchLatestRelease(ctx context.Context, hc *http.Client, userAgent string) (updateState, error) {
+	s, err := fetchLatestFromProxy(ctx, hc, userAgent)
+	if err == nil {
+		return s, nil
+	}
+	s2, err2 := fetchLatestFromGitHub(ctx, hc, userAgent)
+	if err2 != nil {
+		// Report the primary failure — the fallback's error is usually the
+		// same underlying network problem.
+		return updateState{}, err
+	}
+	return s2, nil
+}
+
+// fetchLatestFromProxy queries the module proxy's @latest endpoint.
+func fetchLatestFromProxy(ctx context.Context, hc *http.Client, userAgent string) (updateState, error) {
+	escaped, err := module.EscapePath(updateModulePath)
+	if err != nil {
+		return updateState{}, err
+	}
+	url := fmt.Sprintf("%s/%s/@latest", strings.TrimSuffix(updateProxyBaseURL, "/"), escaped)
+	body, err := updateGet(ctx, hc, url, userAgent, http.StatusOK)
+	if err != nil {
+		return updateState{}, err
+	}
+
+	var payload struct {
+		Version string    `json:"Version"`
+		Time    time.Time `json:"Time"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return updateState{}, fmt.Errorf("parsing module proxy response: %w", err)
+	}
+	if !semver.IsValid(payload.Version) {
+		return updateState{}, fmt.Errorf("module proxy returned invalid version %q", payload.Version)
+	}
+	return updateState{
+		LatestVersion: payload.Version,
+		ReleasedAt:    payload.Time,
+		ReleaseURL:    releaseTagURL(payload.Version),
+	}, nil
+}
+
+// fetchLatestFromGitHub reads the tag out of the /releases/latest redirect.
+// Redirects are deliberately not followed: the 302's Location is the answer,
+// and stopping there avoids downloading the release page HTML.
+func fetchLatestFromGitHub(ctx context.Context, hc *http.Client, userAgent string) (updateState, error) {
+	url := fmt.Sprintf("%s/%s/releases/latest", strings.TrimSuffix(updateGitHubBaseURL, "/"), updateRepoSlug)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return updateState{}, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	noRedirect := &http.Client{
+		Timeout:   hc.Timeout,
+		Transport: hc.Transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		return updateState{}, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	// The tag is in Location on a redirect; if something upstream already
+	// followed it, the final URL carries the same tag.
+	target := resp.Header.Get("Location")
+	if target == "" && resp.StatusCode == http.StatusOK && resp.Request != nil {
+		target = resp.Request.URL.Path
+	}
+	if target == "" {
+		return updateState{}, fmt.Errorf("unexpected HTTP %d from %s", resp.StatusCode, url)
+	}
+
+	tag := path.Base(strings.TrimSuffix(target, "/"))
+	if !semver.IsValid(tag) {
+		return updateState{}, fmt.Errorf("could not read a release tag from %q", target)
+	}
+	return updateState{LatestVersion: tag, ReleaseURL: releaseTagURL(tag)}, nil
+}
+
+// updateGet performs a GET and returns the body, capped so a misrouted
+// response (a captive portal, a proxy error page) can't be read unbounded.
+func updateGet(ctx context.Context, hc *http.Client, url, userAgent string, wantStatus int) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != wantStatus {
+		return nil, fmt.Errorf("unexpected HTTP %d from %s", resp.StatusCode, url)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+}
+
+// installKind classifies how this binary got onto the machine, which decides
+// what the upgrade instruction should say. Detection is path-based on purpose:
+// shelling out to `brew --prefix` would cost more than the whole check.
+type installKind int
+
+const (
+	installUnknown installKind = iota
+	installHomebrew
+	installGoInstall
+)
+
+// detectInstallKind inspects the resolved executable path. execPath should
+// already have symlinks evaluated, which is what turns a Homebrew shim in
+// <prefix>/bin into its .../Cellar/... target.
+func detectInstallKind(execPath string) installKind {
+	if execPath == "" {
+		return installUnknown
+	}
+	p := filepath.ToSlash(execPath)
+	if strings.Contains(p, "/Cellar/") || strings.Contains(p, "/homebrew/") || strings.Contains(p, "/.linuxbrew/") {
+		return installHomebrew
+	}
+	if prefix := os.Getenv("HOMEBREW_PREFIX"); prefix != "" && strings.HasPrefix(p, filepath.ToSlash(prefix)+"/") {
+		return installHomebrew
+	}
+	dir := path.Dir(p)
+	if gobin := os.Getenv("GOBIN"); gobin != "" && dir == filepath.ToSlash(gobin) {
+		return installGoInstall
+	}
+	for _, gopath := range filepath.SplitList(os.Getenv("GOPATH")) {
+		if gopath != "" && dir == filepath.ToSlash(filepath.Join(gopath, "bin")) {
+			return installGoInstall
+		}
+	}
+	if strings.HasSuffix(dir, "/go/bin") {
+		return installGoInstall
+	}
+	return installUnknown
+}
+
+// upgradeHint returns the command (or destination) that actually upgrades this
+// particular install.
+func upgradeHint(kind installKind) string {
+	switch kind {
+	case installHomebrew:
+		return "brew upgrade jamf-cli"
+	case installGoInstall:
+		return "go install " + updateModulePath + "/cmd/jamf-cli@latest"
+	default:
+		return fmt.Sprintf("%s/%s/releases/latest", strings.TrimSuffix(updateGitHubBaseURL, "/"), updateRepoSlug)
+	}
+}
+
+// formatUpdateNotice renders the advisory, or "" when there is nothing to say.
+func formatUpdateNotice(current string, latest updateState, kind installKind, now time.Time) string {
+	if latest.LatestVersion == "" || !newerAvailable(current, latest.LatestVersion) {
+		return ""
+	}
+	if kind == installHomebrew && !latest.ReleasedAt.IsZero() && now.Sub(latest.ReleasedAt) < updateBrewGrace {
+		return ""
+	}
+	url := latest.ReleaseURL
+	if url == "" {
+		url = releaseTagURL(latest.LatestVersion)
+	}
+	return fmt.Sprintf("hint: new jamf-cli release: %s → %s (%s)\n      %s\n",
+		normalizeVersion(current), normalizeVersion(latest.LatestVersion), upgradeHint(kind), url)
+}
+
+// updateCheckGate collects every condition that decides whether an invocation
+// may probe for a new release. Kept as data so the policy is testable without
+// a terminal, a network, or a real command tree.
+type updateCheckGate struct {
+	Version   string // version this binary reports
+	Disabled  bool   // --no-update-check, env, or config update-check: false
+	Quiet     bool   // --quiet
+	NoHints   bool   // --no-hints; the notice is an advisory hint
+	StdoutTTY bool
+	StderrTTY bool
+	CI        bool
+	SkipCmd   bool // command whose output must stay machine-clean
+}
+
+// allowed reports whether the check may run. Every condition is a veto: the
+// notice exists for a human at a terminal running a release build, and nobody
+// else.
+func (g updateCheckGate) allowed() bool {
+	switch {
+	case g.Disabled, g.Quiet, g.NoHints, g.CI, g.SkipCmd:
+		return false
+	case !g.StdoutTTY || !g.StderrTTY:
+		return false
+	default:
+		return isReleaseVersion(g.Version)
+	}
+}
+
+// updateCheckCIEnv lists the environment variables that mark an automated run.
+// Matches the set gh CLI treats as CI, plus the vendor-neutral spellings.
+var updateCheckCIEnv = []string{
+	"CI",
+	"CONTINUOUS_INTEGRATION",
+	"BUILD_NUMBER",
+	"RUN_ID",
+	"GITHUB_ACTIONS",
+	"GITLAB_CI",
+	"TF_BUILD",
+}
+
+// isCIEnvironment reports whether any CI marker is set to a non-empty value.
+// Presence is what matters — CI systems set these to "true", "1", or a build
+// number interchangeably.
+func isCIEnvironment() bool {
+	for _, name := range updateCheckCIEnv {
+		if os.Getenv(name) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// updateCheckSkipCommands are commands whose output is consumed by a machine
+// (or that exist to answer a question about this binary), so an advisory line
+// on stderr would be noise at best. `mcp` is mandatory: it speaks JSON-RPC.
+var updateCheckSkipCommands = map[string]bool{
+	"mcp":                           true,
+	"completion":                    true,
+	"agent-context":                 true,
+	"version":                       true,
+	"help":                          true,
+	cobra.ShellCompRequestCmd:       true,
+	cobra.ShellCompNoDescRequestCmd: true,
+}
+
+// isUpdateCheckSkippedCommand walks the command chain, so `pro ... mcp`-style
+// nesting is caught the same way chainSkip does it for auth.
+func isUpdateCheckSkippedCommand(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if updateCheckSkipCommands[c.Name()] {
+			return true
+		}
+	}
+	return false
+}
+
+// updateCheckDisabled resolves the three opt-outs: the --no-update-check flag,
+// JAMF_CLI_NO_UPDATE_CHECK (value-parsed, so =0 leaves the check on, matching
+// JAMF_CLI_NO_HINTS), and `update-check: false` in the config file for an
+// admin who wants it off across a deployed fleet.
+func updateCheckDisabled(flag bool, cfg *config.Config) bool {
+	if flag {
+		return true
+	}
+	if b, err := strconv.ParseBool(os.Getenv("JAMF_CLI_NO_UPDATE_CHECK")); err == nil && b {
+		return true
+	}
+	return cfg != nil && cfg.UpdateCheck != nil && !*cfg.UpdateCheck
+}
+
+// pendingUpdateCheck carries the probe launched in PersistentPreRunE through to
+// PersistentPostRunE. Package-level to match root.go's global-state
+// convention; a nil value is safe to notify().
+var pendingUpdateCheck *updateChecker
+
+// updateChecker carries the in-flight probe (if one was needed) from
+// PersistentPreRunE to PersistentPostRunE.
+type updateChecker struct {
+	current  string
+	kind     installKind
+	cached   updateState
+	result   chan updateState
+	cancel   context.CancelFunc
+	deadline time.Duration
+}
+
+// startUpdateCheck evaluates the gate and, when the cached answer is stale,
+// launches the probe in the background so the command itself never waits on
+// the network. Returns nil when this invocation must stay silent.
+func startUpdateCheck(cmd *cobra.Command, cfg *config.Config, version string, flagDisabled bool) *updateChecker {
+	gate := updateCheckGate{
+		Version:   version,
+		Disabled:  updateCheckDisabled(flagDisabled, cfg),
+		Quiet:     quiet,
+		NoHints:   noHints,
+		StdoutTTY: output.IsTerminal(os.Stdout.Fd()),
+		StderrTTY: output.IsTerminal(os.Stderr.Fd()),
+		CI:        isCIEnvironment(),
+		SkipCmd:   isUpdateCheckSkippedCommand(cmd),
+	}
+	if !gate.allowed() {
+		return nil
+	}
+	return newUpdateChecker(version, time.Now())
+}
+
+// newUpdateChecker reads the cache and, only when the cached answer is stale,
+// launches the probe. Split from startUpdateCheck so the probe/cache behaviour
+// is testable without a terminal.
+func newUpdateChecker(version string, now time.Time) *updateChecker {
+	c := &updateChecker{
+		current:  version,
+		kind:     detectInstallKind(resolvedExecutablePath()),
+		cached:   readUpdateCache(),
+		deadline: updateProbeTimeout,
+	}
+	if c.cached.fresh(now) {
+		return c
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), updateProbeTimeout)
+	c.cancel = cancel
+	c.result = make(chan updateState, 1)
+	go func() {
+		state, err := fetchLatestRelease(ctx, &http.Client{Timeout: updateProbeTimeout}, "jamf-cli/"+version)
+		if err != nil {
+			// Record the failure so an offline machine cools down instead of
+			// paying the timeout on every command.
+			state = updateState{}
+		}
+		state.CheckedAt = time.Now()
+		writeUpdateCache(state)
+		c.result <- state
+	}()
+	return c
+}
+
+// notify writes the advisory to w, if there is one. Called after the command's
+// own output so a probe can never interleave with, or delay, real results.
+func (c *updateChecker) notify(w io.Writer) {
+	if c == nil {
+		return
+	}
+	state := c.cached
+	if c.result != nil {
+		if c.cancel != nil {
+			defer c.cancel()
+		}
+		select {
+		case state = <-c.result:
+		case <-time.After(c.deadline):
+			// Probe outlived its budget; say nothing and try again next run.
+			return
+		}
+	}
+	if notice := formatUpdateNotice(c.current, state, c.kind, time.Now()); notice != "" {
+		_, _ = fmt.Fprint(w, notice)
+	}
+}
+
+// resolvedExecutablePath returns this binary's path with symlinks resolved,
+// or "" when it can't be determined. Symlink resolution is what turns a
+// Homebrew shim into its Cellar target.
+func resolvedExecutablePath() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		return resolved
+	}
+	return exe
+}

--- a/internal/commands/update_check_test.go
+++ b/internal/commands/update_check_test.go
@@ -1,0 +1,848 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/config"
+)
+
+// clearUpdateEnv neutralises every environment variable the update check
+// consults so a developer's shell (or a CI runner) can't flip a result.
+func clearUpdateEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range updateCheckCIEnv {
+		t.Setenv(k, "")
+	}
+	for _, k := range []string{"JAMF_CLI_NO_UPDATE_CHECK", "HOMEBREW_PREFIX", "GOBIN", "GOPATH"} {
+		t.Setenv(k, "")
+	}
+}
+
+// useTempConfigDir points config.ConfigPath() — and therefore the update cache
+// — at a scratch directory.
+func useTempConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}
+
+// serveEndpoints redirects both release sources at test servers for the
+// duration of the test.
+func serveEndpoints(t *testing.T, proxy, github string) {
+	t.Helper()
+	origProxy, origGitHub := updateProxyBaseURL, updateGitHubBaseURL
+	t.Cleanup(func() {
+		updateProxyBaseURL, updateGitHubBaseURL = origProxy, origGitHub
+	})
+	if proxy != "" {
+		updateProxyBaseURL = proxy
+	}
+	if github != "" {
+		updateGitHubBaseURL = github
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"v1.25.2", "v1.25.2"},
+		{"1.25.2", "v1.25.2"},
+		{"  1.25.2  ", "v1.25.2"},
+		{"dev", "dev"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := normalizeVersion(tt.in); got != tt.want {
+			t.Errorf("normalizeVersion(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestIsReleaseVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"exact tag", "v1.25.2", true},
+		{"tag without v prefix", "1.25.2", true},
+		{"minor-only tag", "v1.25", true},
+		{"ldflags default", "dev", false},
+		{"empty", "", false},
+		{"git describe suffix", "v1.25.2-3-gabc1234", false},
+		{"dirty tree", "v1.25.2-dirty", false},
+		{"release candidate", "v1.26.0-rc.1", false},
+		{"build metadata", "v1.25.2+abc123", false},
+		{"not a version", "banana", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isReleaseVersion(tt.in); got != tt.want {
+				t.Errorf("isReleaseVersion(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewerAvailable(t *testing.T) {
+	tests := []struct {
+		name            string
+		current, latest string
+		want            bool
+	}{
+		{"newer patch", "v1.25.1", "v1.25.2", true},
+		{"newer minor", "v1.25.2", "v1.26.0", true},
+		{"newer major", "v1.25.2", "v2.0.0", true},
+		{"same version", "v1.25.2", "v1.25.2", false},
+		{"older latest", "v1.26.0", "v1.25.2", false},
+		{"double-digit minor sorts numerically", "v1.9.0", "v1.10.0", true},
+		{"missing v prefix on both sides", "1.25.1", "1.25.2", true},
+		{"dev build never notifies", "dev", "v1.26.0", false},
+		{"git describe build never notifies", "v1.25.2-4-gdeadbee", "v1.26.0", false},
+		{"prerelease latest is not offered", "v1.25.2", "v1.26.0-rc.1", false},
+		{"garbage latest", "v1.25.2", "not-a-version", false},
+		{"empty latest", "v1.25.2", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newerAvailable(tt.current, tt.latest); got != tt.want {
+				t.Errorf("newerAvailable(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateStateFresh(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		state updateState
+		want  bool
+	}{
+		{"zero value is stale", updateState{}, false},
+		{
+			name:  "recent success is fresh",
+			state: updateState{CheckedAt: now.Add(-2 * time.Hour), LatestVersion: "v1.25.2"},
+			want:  true,
+		},
+		{
+			name:  "success past the day is stale",
+			state: updateState{CheckedAt: now.Add(-25 * time.Hour), LatestVersion: "v1.25.2"},
+			want:  false,
+		},
+		{
+			name:  "recent failure cools down",
+			state: updateState{CheckedAt: now.Add(-30 * time.Minute)},
+			want:  true,
+		},
+		{
+			name:  "failure retries after an hour",
+			state: updateState{CheckedAt: now.Add(-90 * time.Minute)},
+			want:  false,
+		},
+		{
+			name:  "clock skew into the future counts as fresh",
+			state: updateState{CheckedAt: now.Add(48 * time.Hour), LatestVersion: "v1.25.2"},
+			want:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.state.fresh(now); got != tt.want {
+				t.Errorf("fresh() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateCacheRoundTrip(t *testing.T) {
+	useTempConfigDir(t)
+
+	if got := readUpdateCache(); got.LatestVersion != "" || !got.CheckedAt.IsZero() {
+		t.Fatalf("expected zero state with no cache file; got %+v", got)
+	}
+
+	want := updateState{
+		CheckedAt:     time.Now().UTC().Truncate(time.Second),
+		LatestVersion: "v1.26.0",
+		ReleasedAt:    time.Now().UTC().Add(-time.Hour).Truncate(time.Second),
+		ReleaseURL:    "https://example.test/tag/v1.26.0",
+	}
+	writeUpdateCache(want)
+
+	got := readUpdateCache()
+	if got.LatestVersion != want.LatestVersion || got.ReleaseURL != want.ReleaseURL {
+		t.Errorf("round trip mismatch: got %+v, want %+v", got, want)
+	}
+	if !got.CheckedAt.Equal(want.CheckedAt) || !got.ReleasedAt.Equal(want.ReleasedAt) {
+		t.Errorf("timestamps did not survive: got %+v, want %+v", got, want)
+	}
+
+	// The cache sits next to the config file and must not be world-readable:
+	// it is created in a directory that also holds credential references.
+	info, err := os.Stat(updateCachePath())
+	if err != nil {
+		t.Fatalf("stat cache: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("cache mode = %v, want 0600", perm)
+	}
+	if dir := filepath.Dir(updateCachePath()); dir != filepath.Dir(config.ConfigPath()) {
+		t.Errorf("cache dir %q is not the config dir %q", dir, filepath.Dir(config.ConfigPath()))
+	}
+}
+
+func TestReadUpdateCache_CorruptFileIsIgnored(t *testing.T) {
+	useTempConfigDir(t)
+	if err := os.MkdirAll(filepath.Dir(updateCachePath()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(updateCachePath(), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := readUpdateCache(); got.LatestVersion != "" {
+		t.Errorf("expected zero state for corrupt cache; got %+v", got)
+	}
+}
+
+func TestFetchLatestFromProxy(t *testing.T) {
+	var gotPath, gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotUA = r.URL.Path, r.Header.Get("User-Agent")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Version": "v1.26.0",
+			"Time":    "2026-07-29T10:14:32Z",
+		})
+	}))
+	defer srv.Close()
+	serveEndpoints(t, srv.URL, "https://github.test")
+
+	state, err := fetchLatestFromProxy(context.Background(), srv.Client(), "jamf-cli/v1.25.2")
+	if err != nil {
+		t.Fatalf("fetchLatestFromProxy: %v", err)
+	}
+	if state.LatestVersion != "v1.26.0" {
+		t.Errorf("version = %q, want v1.26.0", state.LatestVersion)
+	}
+	if want := "https://github.test/Jamf-Concepts/jamf-cli/releases/tag/v1.26.0"; state.ReleaseURL != want {
+		t.Errorf("release URL = %q, want %q", state.ReleaseURL, want)
+	}
+	if state.ReleasedAt.IsZero() {
+		t.Error("expected the publish time to be captured (it drives the Homebrew grace period)")
+	}
+	// Module paths escape capitals as !lowercase; getting this wrong 404s.
+	if want := "/github.com/!jamf-!concepts/jamf-cli/@latest"; gotPath != want {
+		t.Errorf("request path = %q, want %q", gotPath, want)
+	}
+	if gotUA != "jamf-cli/v1.25.2" {
+		t.Errorf("User-Agent = %q, want jamf-cli/v1.25.2", gotUA)
+	}
+}
+
+func TestFetchLatestFromProxy_Failures(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		wantErr string
+	}{
+		{"server error", http.StatusInternalServerError, "boom", "unexpected HTTP 500"},
+		{"not found", http.StatusNotFound, "not found", "unexpected HTTP 404"},
+		{"unparseable body", http.StatusOK, "<html>captive portal</html>", "parsing module proxy response"},
+		{"invalid version", http.StatusOK, `{"Version":"latest"}`, "invalid version"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+			serveEndpoints(t, srv.URL, "")
+
+			_, err := fetchLatestFromProxy(context.Background(), srv.Client(), "jamf-cli/v1.25.2")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFetchLatestFromGitHub_ReadsTagFromRedirect(t *testing.T) {
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		w.Header().Set("Location", "/Jamf-Concepts/jamf-cli/releases/tag/v1.30.1")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer srv.Close()
+	serveEndpoints(t, "", srv.URL)
+
+	state, err := fetchLatestFromGitHub(context.Background(), srv.Client(), "jamf-cli/v1.25.2")
+	if err != nil {
+		t.Fatalf("fetchLatestFromGitHub: %v", err)
+	}
+	if state.LatestVersion != "v1.30.1" {
+		t.Errorf("version = %q, want v1.30.1", state.LatestVersion)
+	}
+	if !strings.HasSuffix(state.ReleaseURL, "/releases/tag/v1.30.1") {
+		t.Errorf("release URL = %q, want it to point at the tag", state.ReleaseURL)
+	}
+	// HEAD keeps the fallback from pulling down the release page HTML.
+	if gotMethod != http.MethodHead {
+		t.Errorf("method = %q, want HEAD", gotMethod)
+	}
+}
+
+func TestFetchLatestFromGitHub_NoTagIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK) // no Location, so no tag to read
+	}))
+	defer srv.Close()
+	serveEndpoints(t, "", srv.URL)
+
+	if _, err := fetchLatestFromGitHub(context.Background(), srv.Client(), "jamf-cli/v1.25.2"); err == nil {
+		t.Fatal("expected an error when no release tag can be resolved")
+	}
+}
+
+func TestFetchLatestRelease_FallsBackToGitHub(t *testing.T) {
+	var proxyHits, githubHits atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		proxyHits.Add(1)
+		w.WriteHeader(http.StatusForbidden) // e.g. GOPROXY blocked by policy
+	}))
+	defer proxy.Close()
+	github := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		githubHits.Add(1)
+		w.Header().Set("Location", "/Jamf-Concepts/jamf-cli/releases/tag/v1.27.0")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer github.Close()
+	serveEndpoints(t, proxy.URL, github.URL)
+
+	state, err := fetchLatestRelease(context.Background(), proxy.Client(), "jamf-cli/v1.25.2")
+	if err != nil {
+		t.Fatalf("fetchLatestRelease: %v", err)
+	}
+	if state.LatestVersion != "v1.27.0" {
+		t.Errorf("version = %q, want v1.27.0", state.LatestVersion)
+	}
+	if proxyHits.Load() != 1 || githubHits.Load() != 1 {
+		t.Errorf("expected one attempt at each source; proxy=%d github=%d", proxyHits.Load(), githubHits.Load())
+	}
+}
+
+func TestFetchLatestRelease_PrefersProxy(t *testing.T) {
+	var githubHits atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"Version": "v1.26.0"})
+	}))
+	defer proxy.Close()
+	github := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		githubHits.Add(1)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer github.Close()
+	serveEndpoints(t, proxy.URL, github.URL)
+
+	state, err := fetchLatestRelease(context.Background(), proxy.Client(), "jamf-cli/v1.25.2")
+	if err != nil {
+		t.Fatalf("fetchLatestRelease: %v", err)
+	}
+	if state.LatestVersion != "v1.26.0" {
+		t.Errorf("version = %q, want v1.26.0", state.LatestVersion)
+	}
+	if githubHits.Load() != 0 {
+		t.Errorf("GitHub was contacted %d times; the proxy answer should be enough", githubHits.Load())
+	}
+}
+
+func TestFetchLatestRelease_BothSourcesDown(t *testing.T) {
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer down.Close()
+	serveEndpoints(t, down.URL, down.URL)
+
+	if _, err := fetchLatestRelease(context.Background(), down.Client(), "jamf-cli/v1.25.2"); err == nil {
+		t.Fatal("expected an error when neither source answers")
+	}
+}
+
+func TestFetchLatestRelease_HonoursContextCancellation(t *testing.T) {
+	blocked := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer blocked.Close()
+	serveEndpoints(t, blocked.URL, blocked.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	if _, err := fetchLatestRelease(ctx, blocked.Client(), "jamf-cli/v1.25.2"); err == nil {
+		t.Fatal("expected an error once the context expires")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("probe ran for %v after a 50ms deadline", elapsed)
+	}
+}
+
+func TestDetectInstallKind(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		env  map[string]string
+		want installKind
+	}{
+		{"homebrew cellar", "/opt/homebrew/Cellar/jamf-cli/1.25.2/bin/jamf-cli", nil, installHomebrew},
+		{"homebrew prefix path", "/opt/homebrew/bin/jamf-cli", nil, installHomebrew},
+		{"linuxbrew", "/home/linuxbrew/.linuxbrew/bin/jamf-cli", nil, installHomebrew},
+		{
+			name: "custom homebrew prefix from env",
+			path: "/custom/brew/bin/jamf-cli",
+			env:  map[string]string{"HOMEBREW_PREFIX": "/custom/brew"},
+			want: installHomebrew,
+		},
+		{
+			name: "gobin",
+			path: "/Users/dev/bin/jamf-cli",
+			env:  map[string]string{"GOBIN": "/Users/dev/bin"},
+			want: installGoInstall,
+		},
+		{
+			name: "gopath bin",
+			path: "/workspace/gopath/bin/jamf-cli",
+			env:  map[string]string{"GOPATH": "/workspace/gopath"},
+			want: installGoInstall,
+		},
+		{"default gopath layout", "/Users/dev/go/bin/jamf-cli", nil, installGoInstall},
+		{"packaged install", "/usr/local/bin/jamf-cli", nil, installUnknown},
+		{"manual download", "/Users/dev/Downloads/jamf-cli", nil, installUnknown},
+		{"unknown when path is unavailable", "", nil, installUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearUpdateEnv(t)
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			if got := detectInstallKind(tt.path); got != tt.want {
+				t.Errorf("detectInstallKind(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpgradeHint(t *testing.T) {
+	tests := []struct {
+		kind installKind
+		want string
+	}{
+		{installHomebrew, "brew upgrade jamf-cli"},
+		{installGoInstall, "go install github.com/Jamf-Concepts/jamf-cli/cmd/jamf-cli@latest"},
+		{installUnknown, "https://github.com/Jamf-Concepts/jamf-cli/releases/latest"},
+	}
+	for _, tt := range tests {
+		if got := upgradeHint(tt.kind); got != tt.want {
+			t.Errorf("upgradeHint(%v) = %q, want %q", tt.kind, got, tt.want)
+		}
+	}
+}
+
+func TestFormatUpdateNotice(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	newRelease := updateState{
+		LatestVersion: "v1.26.0",
+		ReleasedAt:    now.Add(-72 * time.Hour),
+		ReleaseURL:    "https://github.com/Jamf-Concepts/jamf-cli/releases/tag/v1.26.0",
+	}
+
+	t.Run("newer release names both versions, the upgrade command and the URL", func(t *testing.T) {
+		got := formatUpdateNotice("v1.25.2", newRelease, installHomebrew, now)
+		for _, want := range []string{"v1.25.2", "v1.26.0", "brew upgrade jamf-cli", newRelease.ReleaseURL} {
+			if !strings.Contains(got, want) {
+				t.Errorf("notice %q missing %q", got, want)
+			}
+		}
+		if lines := strings.Count(got, "\n"); lines != 2 {
+			t.Errorf("notice should be exactly two lines; got %d in %q", lines, got)
+		}
+	})
+
+	t.Run("silent cases", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			current string
+			latest  updateState
+			kind    installKind
+		}{
+			{"already current", "v1.26.0", newRelease, installUnknown},
+			{"ahead of the release", "v1.27.0", newRelease, installUnknown},
+			{"no cached answer", "v1.25.2", updateState{}, installUnknown},
+			{"dev build", "dev", newRelease, installUnknown},
+			{
+				name:    "homebrew tap has not caught up yet",
+				current: "v1.25.2",
+				latest:  updateState{LatestVersion: "v1.26.0", ReleasedAt: now.Add(-time.Hour)},
+				kind:    installHomebrew,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if got := formatUpdateNotice(tt.current, tt.latest, tt.kind, now); got != "" {
+					t.Errorf("expected silence; got %q", got)
+				}
+			})
+		}
+	})
+
+	t.Run("fresh release still notifies a non-homebrew install", func(t *testing.T) {
+		latest := updateState{LatestVersion: "v1.26.0", ReleasedAt: now.Add(-time.Minute)}
+		if got := formatUpdateNotice("v1.25.2", latest, installUnknown, now); got == "" {
+			t.Error("expected a notice: the tap grace period is Homebrew-only")
+		}
+	})
+
+	t.Run("release URL is derived when the cache lacks one", func(t *testing.T) {
+		latest := updateState{LatestVersion: "v1.26.0"}
+		got := formatUpdateNotice("v1.25.2", latest, installUnknown, now)
+		if !strings.Contains(got, "/releases/tag/v1.26.0") {
+			t.Errorf("notice %q should fall back to the derived tag URL", got)
+		}
+	})
+}
+
+func TestUpdateCheckGate(t *testing.T) {
+	allowed := updateCheckGate{Version: "v1.25.2", StdoutTTY: true, StderrTTY: true}
+	if !allowed.allowed() {
+		t.Fatal("baseline gate should allow the check")
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(g *updateCheckGate)
+	}{
+		{"opted out", func(g *updateCheckGate) { g.Disabled = true }},
+		{"quiet", func(g *updateCheckGate) { g.Quiet = true }},
+		{"hints suppressed", func(g *updateCheckGate) { g.NoHints = true }},
+		{"CI", func(g *updateCheckGate) { g.CI = true }},
+		{"machine-facing command", func(g *updateCheckGate) { g.SkipCmd = true }},
+		{"stdout piped", func(g *updateCheckGate) { g.StdoutTTY = false }},
+		{"stderr redirected", func(g *updateCheckGate) { g.StderrTTY = false }},
+		{"dev build", func(g *updateCheckGate) { g.Version = "dev" }},
+		{"local build from a tag", func(g *updateCheckGate) { g.Version = "v1.25.2-3-gabc1234" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := allowed
+			tt.mutate(&g)
+			if g.allowed() {
+				t.Error("expected the gate to veto the check")
+			}
+		})
+	}
+}
+
+func TestIsCIEnvironment(t *testing.T) {
+	t.Run("no markers", func(t *testing.T) {
+		clearUpdateEnv(t)
+		if isCIEnvironment() {
+			t.Error("expected false with every CI marker cleared")
+		}
+	})
+	for _, name := range updateCheckCIEnv {
+		t.Run(name, func(t *testing.T) {
+			clearUpdateEnv(t)
+			t.Setenv(name, "true")
+			if !isCIEnvironment() {
+				t.Errorf("%s=true should mark a CI run", name)
+			}
+		})
+	}
+	t.Run("build number style value", func(t *testing.T) {
+		clearUpdateEnv(t)
+		t.Setenv("BUILD_NUMBER", "1423")
+		if !isCIEnvironment() {
+			t.Error("a numeric build marker should still count as CI")
+		}
+	})
+}
+
+func TestUpdateCheckDisabled(t *testing.T) {
+	enabled, disabled := true, false
+	tests := []struct {
+		name string
+		flag bool
+		env  string
+		cfg  *config.Config
+		want bool
+	}{
+		{name: "default is enabled"},
+		{name: "flag", flag: true, want: true},
+		{name: "env true", env: "1", want: true},
+		{name: "env false leaves it on", env: "0"},
+		{name: "unparseable env is ignored", env: "yes-please"},
+		{name: "config false", cfg: &config.Config{UpdateCheck: &disabled}, want: true},
+		{name: "config true", cfg: &config.Config{UpdateCheck: &enabled}},
+		{name: "config unset", cfg: &config.Config{}},
+		{name: "nil config", cfg: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearUpdateEnv(t)
+			if tt.env != "" {
+				t.Setenv("JAMF_CLI_NO_UPDATE_CHECK", tt.env)
+			}
+			if got := updateCheckDisabled(tt.flag, tt.cfg); got != tt.want {
+				t.Errorf("updateCheckDisabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsUpdateCheckSkippedCommand(t *testing.T) {
+	root := &cobra.Command{Use: "jamf-cli"}
+	pro := &cobra.Command{Use: "pro"}
+	computers := &cobra.Command{Use: "computers"}
+	list := &cobra.Command{Use: "list"}
+	mcp := &cobra.Command{Use: "mcp"}
+	mcpServe := &cobra.Command{Use: "serve"}
+	complete := &cobra.Command{Use: cobra.ShellCompRequestCmd}
+
+	root.AddCommand(pro, mcp, complete)
+	pro.AddCommand(computers)
+	computers.AddCommand(list)
+	mcp.AddCommand(mcpServe)
+
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		want bool
+	}{
+		{"ordinary command", list, false},
+		{"parent of ordinary commands", pro, false},
+		{"mcp speaks JSON-RPC on stdio", mcp, true},
+		{"nested under mcp", mcpServe, true},
+		{"shell completion callback", complete, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUpdateCheckSkippedCommand(tt.cmd); got != tt.want {
+				t.Errorf("isUpdateCheckSkippedCommand(%q) = %v, want %v", tt.cmd.Name(), got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewUpdateChecker_ProbesWhenCacheIsStaleAndNotifies(t *testing.T) {
+	clearUpdateEnv(t)
+	useTempConfigDir(t)
+
+	var hits atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Version": "v9.9.9",
+			"Time":    "2026-01-01T00:00:00Z",
+		})
+	}))
+	defer proxy.Close()
+	serveEndpoints(t, proxy.URL, "https://github.test")
+
+	c := newUpdateChecker("v1.25.2", time.Now())
+	if c == nil {
+		t.Fatal("expected a checker")
+	}
+	var buf bytes.Buffer
+	c.notify(&buf)
+
+	if hits.Load() != 1 {
+		t.Errorf("expected exactly one probe; got %d", hits.Load())
+	}
+	if !strings.Contains(buf.String(), "v9.9.9") {
+		t.Errorf("expected a notice naming the new release; got %q", buf.String())
+	}
+	cached := readUpdateCache()
+	if cached.LatestVersion != "v9.9.9" || cached.CheckedAt.IsZero() {
+		t.Errorf("probe result was not cached: %+v", cached)
+	}
+}
+
+func TestNewUpdateChecker_FreshCacheSkipsTheNetwork(t *testing.T) {
+	clearUpdateEnv(t)
+	useTempConfigDir(t)
+
+	var hits atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+	}))
+	defer proxy.Close()
+	serveEndpoints(t, proxy.URL, "https://github.test")
+
+	writeUpdateCache(updateState{
+		CheckedAt:     time.Now(),
+		LatestVersion: "v2.0.0",
+		ReleaseURL:    "https://github.test/tag/v2.0.0",
+	})
+
+	c := newUpdateChecker("v1.25.2", time.Now())
+	var buf bytes.Buffer
+	c.notify(&buf)
+
+	if hits.Load() != 0 {
+		t.Errorf("a fresh cache must not hit the network; got %d requests", hits.Load())
+	}
+	if !strings.Contains(buf.String(), "v2.0.0") {
+		t.Errorf("expected the cached answer to be reported; got %q", buf.String())
+	}
+}
+
+func TestNewUpdateChecker_FailedProbeCachesTheFailureAndStaysSilent(t *testing.T) {
+	clearUpdateEnv(t)
+	useTempConfigDir(t)
+
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer down.Close()
+	serveEndpoints(t, down.URL, down.URL)
+
+	c := newUpdateChecker("v1.25.2", time.Now())
+	var buf bytes.Buffer
+	c.notify(&buf)
+
+	if buf.Len() != 0 {
+		t.Errorf("a failed probe must be silent; got %q", buf.String())
+	}
+	cached := readUpdateCache()
+	if cached.CheckedAt.IsZero() {
+		t.Error("expected the failure to be recorded so the next run cools down")
+	}
+	if cached.LatestVersion != "" {
+		t.Errorf("failure entry should carry no version; got %q", cached.LatestVersion)
+	}
+	if cached.fresh(time.Now().Add(2 * time.Hour)) {
+		t.Error("a failure entry should expire within the hour")
+	}
+}
+
+func TestUpdateChecker_Notify(t *testing.T) {
+	t.Run("nil checker is a no-op", func(t *testing.T) {
+		var c *updateChecker
+		var buf bytes.Buffer
+		c.notify(&buf) // must not panic
+		if buf.Len() != 0 {
+			t.Errorf("expected no output; got %q", buf.String())
+		}
+	})
+
+	t.Run("probe result wins over the stale cached answer", func(t *testing.T) {
+		result := make(chan updateState, 1)
+		result <- updateState{LatestVersion: "v3.0.0", CheckedAt: time.Now()}
+		c := &updateChecker{
+			current:  "v1.25.2",
+			cached:   updateState{LatestVersion: "v1.26.0"},
+			result:   result,
+			deadline: time.Second,
+		}
+		var buf bytes.Buffer
+		c.notify(&buf)
+		if !strings.Contains(buf.String(), "v3.0.0") || strings.Contains(buf.String(), "v1.26.0") {
+			t.Errorf("expected the fresh probe result; got %q", buf.String())
+		}
+	})
+
+	t.Run("a probe that overruns its budget says nothing", func(t *testing.T) {
+		c := &updateChecker{
+			current:  "v1.25.2",
+			cached:   updateState{LatestVersion: "v9.9.9"},
+			result:   make(chan updateState), // never delivers
+			deadline: 20 * time.Millisecond,
+		}
+		var buf bytes.Buffer
+		start := time.Now()
+		c.notify(&buf)
+		if buf.Len() != 0 {
+			t.Errorf("expected silence when the probe times out; got %q", buf.String())
+		}
+		if elapsed := time.Since(start); elapsed > time.Second {
+			t.Errorf("notify blocked for %v; it must respect its deadline", elapsed)
+		}
+	})
+}
+
+// TestRootWiring_UpdateCheck covers the plumbing rather than the policy: the
+// opt-out flag has to exist, be documented alongside the env var, and an
+// executed command must not emit a notice in a non-interactive process.
+func TestRootWiring_UpdateCheck(t *testing.T) {
+	clearUpdateEnv(t)
+	useTempConfigDir(t)
+
+	root := NewRootCmd("v1.25.2", "abc123", "2026-07-29", "unknown")
+
+	flag := root.PersistentFlags().Lookup("no-update-check")
+	if flag == nil {
+		t.Fatal("--no-update-check is not registered on the root command")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--no-update-check default = %q, want false (opt-out, not opt-in)", flag.DefValue)
+	}
+	if !strings.Contains(flag.Usage, "JAMF_CLI_NO_UPDATE_CHECK") {
+		t.Errorf("flag help should name the env var; got %q", flag.Usage)
+	}
+	for _, want := range []string{"JAMF_CLI_NO_UPDATE_CHECK", "update-check: false"} {
+		if !strings.Contains(root.Long, want) {
+			t.Errorf("root help should document %q", want)
+		}
+	}
+
+	// Executing a command in a test process (stdout is a pipe) must leave the
+	// checker unarmed, so nothing can be printed and nothing probed.
+	pendingUpdateCheck = &updateChecker{current: "v1.0.0", cached: updateState{LatestVersion: "v9.9.9"}}
+	t.Cleanup(func() { pendingUpdateCheck = nil })
+
+	outputFmt, noColor = "json", true
+	root.SetArgs([]string{"config", "path"})
+	root.SetOut(&bytes.Buffer{})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("config path failed: %v", err)
+	}
+	if pendingUpdateCheck != nil {
+		t.Error("expected PersistentPreRunE to disarm the check when stdout is piped")
+	}
+}
+
+func TestStartUpdateCheck_GateVetoReturnsNil(t *testing.T) {
+	clearUpdateEnv(t)
+	useTempConfigDir(t)
+
+	// Piped stdout alone is enough to veto, which is the case every test
+	// process is in — assert it explicitly rather than relying on it.
+	if got := startUpdateCheck(&cobra.Command{Use: "list"}, &config.Config{}, "v1.25.2", false); got != nil {
+		t.Error("expected nil checker when stdout is not a terminal")
+	}
+	// And an explicit opt-out must win even if everything else lines up.
+	if got := startUpdateCheck(&cobra.Command{Use: "list"}, &config.Config{}, "v1.25.2", true); got != nil {
+		t.Error("expected nil checker with --no-update-check")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	DefaultProfile string             `yaml:"default-profile"`
 	DefaultOutput  string             `yaml:"default-output,omitempty"`
 	Profiles       map[string]Profile `yaml:"profiles"`
+	// UpdateCheck gates the once-a-day "a newer jamf-cli is available"
+	// advisory. nil means enabled; `update-check: false` silences it for
+	// every invocation, which is how an admin turns it off across a fleet
+	// that upgrades through a deployed package rather than by hand.
+	UpdateCheck *bool `yaml:"update-check,omitempty"`
 }
 
 // Profile represents a server profile for a Jamf product.


### PR DESCRIPTION
## Why

jamf-cli ships weekly-ish (v1.23.0 → v1.25.2 in two weeks) across four install channels — Homebrew tap, `.pkg`, release tarball, `go install` — and none of them tells a user their build is stale. Admins then hit "no such command" on endpoints a newer build already generates. `checkTenantVersion` already warns about the mirror case (tenant older than the baked-in spec); this closes the other half.

## What it does

Once a day, an interactive release build prints one hint to stderr **after** the command's own output:

```
hint: new jamf-cli release: v1.25.2 → v1.26.0 (brew upgrade jamf-cli)
      https://github.com/Jamf-Concepts/jamf-cli/releases/tag/v1.26.0
```

## Design decisions worth reviewing

**Module proxy, not the GitHub API.** `api.github.com` caps unauthenticated callers at **60 requests/hour per IP** — a budget every admin behind one corporate egress IP shares, so it would fail silently and unpredictably. `proxy.golang.org/.../@latest` is CDN-backed, uncapped, credential-free, and already canonical for `go install`. Fallback is the `github.com/<repo>/releases/latest` 302, also not an API call. Nothing tenant-, profile-, or credential-related leaves the machine: the module path plus the current version in `User-Agent` is the whole request.

**Notify, never self-update.** A Homebrew- or pkg-managed binary lives in a path the invoking user often cannot write, and replacing a notarized binary under Homebrew's manifest breaks `brew doctor`. The notice instead names the upgrade that works for *that* install (`brew upgrade` / `go install` / releases URL), detected by path rather than by shelling out to `brew --prefix`. Homebrew installs get a 24h grace period so the hint never points at a version the tap hasn't picked up.

**One gate, printed from PostRun.** `updateCheckGate` holds the policy as data, so it's testable without a terminal or a network. It stays silent unless: the version is an exact release tag (not `dev`, a `git describe` suffix, `-dirty`, or a prerelease), **both** stdout and stderr are TTYs, no CI marker is set, the command isn't machine-facing (`mcp` speaks JSON-RPC on stdio; also `completion`, `agent-context`, `version`, `help`, `__complete*`), and neither `--quiet` nor `--no-hints` is in play. Printing from `PersistentPostRunE` means it can't delay or interleave with real output, and says nothing when the command failed.

**Cost is bounded.** Probe runs in a goroutine with a 2s deadline; results cache for 24h — **1h for failures, cached on purpose** so an offline machine stops paying the timeout on every command. Cache is `.update-cache.json` beside the config file, 0600, temp-file-then-rename: same shape as the tenant version cache.

**`resolveVersion` fallback.** `go install github.com/Jamf-Concepts/jamf-cli/cmd/jamf-cli@latest` gets no `-ldflags`, so it reported `dev` — untraceable in bug reports, and silently opted out of this check. Now falls back to `debug.ReadBuildInfo`.

## Opt-outs

`--no-update-check` · `JAMF_CLI_NO_UPDATE_CHECK=1` (value-parsed, so `=0` leaves it on) · `update-check: false` in `config.yaml`, for admins who deploy jamf-cli by package and don't want a nag users can't act on. Surfaced in `config show`.

## Tests

38 new cases in `internal/commands/update_check_test.go` plus 7 in `cmd/jamf-cli/main_test.go`: version-shape classification, comparison ordering, cache TTL/round-trip/permissions/corruption, both fetch sources against `httptest` (including proxy-path capital escaping, HEAD-only fallback, proxy→GitHub failover, source preference, context cancellation), install-kind detection, notice formatting and every silent case, the full gate veto matrix, CI-marker detection, all three opt-outs, command-skip walking, probe/cache/notify integration, timeout behaviour, and root wiring.

Also verified on a real binary under a pty: notice appears, cache lands, and it goes silent when piped, in CI, under `--quiet`, with the flag, with either env value, with `update-check: false`, on `version`, and when already on the latest release.

`make test` (28 packages), `make lint` (0 issues), `make verify-generated`, `make verify-site`, `go test -race`, `go fix`, `make fmt` all clean.

## Dependency

`golang.org/x/mod` v0.37.0 promoted from indirect to direct (`semver` + `module.EscapePath`). No new modules in the graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
