### PR TITLE
fix(classic): minimise payload source escaping before the CDATA wrap

### DIFF
--- a/docs/solutions/conventions/classic-profile-payload-ampersand-escaping-2026-07-30.md
+++ b/docs/solutions/conventions/classic-profile-payload-ampersand-escaping-2026-07-30.md
@@ -66,7 +66,16 @@ create/update/apply for both profile resources:
 
 1. Recover the true plist: CDATA content is already true form; text-form
    content (GET/backup XML piped back in) is entity-decoded once.
-2. Guard `]]>` → `]]&gt;`, then escape every `&` once and wrap in CDATA.
+2. Minimise source escaping (`minimizeClassicPlistSourceEscaping`): decode
+   every character reference except those encoding `&`/`<`. Verbatim-stored
+   payload types preserve the wire representation with zero decodes, so
+   avoidable references (`&#34;` for `"`, `&#xA;` for newlines — exactly
+   what howett.net/plist's encoding/xml backend emits when the update path
+   re-serialises for UUID injection) would surface as literal text in
+   stored values. This also shrinks the unavoidable corruption set to
+   genuine `&`/`<` characters.
+3. Guard `]]>` → `]]&gt;` (after minimising — decoding `&gt;` can resurrect
+   the terminator), then escape every `&` once and wrap in CDATA.
 
 `verifyClassicProfileStored` then GETs the stored payload after every
 successful write and compares it against the submitted plist

--- a/generator/classic/generator.go
+++ b/generator/classic/generator.go
@@ -1381,6 +1381,9 @@ import (
 	"path/filepath"
 	"strings"
 {{- end }}
+{{- if anyIsConfigProfile . }}
+	"strconv"
+{{- end }}
 {{- if or (anyNeedsClassicNameResolve .) (anyClassicFileFields .) (anyListSubset .) (anyHasGroupPath .) }}
 	"fmt"
 {{- end }}
@@ -1754,10 +1757,65 @@ func stripCDATASections(data []byte) []byte {
 	return []byte(b.String())
 }
 
+// minimizeClassicPlistSourceEscaping decodes every character/entity
+// reference in plist XML source EXCEPT those encoding "&" and "<" — e.g.
+// "&quot;"/"&#34;" become a literal quote, "&#xA;" a literal newline,
+// "&gt;" a literal ">". Both representations parse to identical values,
+// but the wire representation is what the server's verbatim-stored
+// payload types preserve (PI-827): avoidable references would surface as
+// literal text in stored values. This matters for the update path, where
+// injectClassicProfilePayloadUUIDs re-serialises the plist via
+// howett.net/plist, whose encoding/xml backend escapes quotes and value
+// newlines/tabs numerically.
+func minimizeClassicPlistSourceEscaping(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c != '&' {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		semi := strings.IndexByte(s[i:], ';')
+		if semi < 0 || semi > 12 {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		ref := s[i+1 : i+semi]
+		var r rune = -1
+		switch {
+		case ref == "quot":
+			r = '"'
+		case ref == "apos":
+			r = '\''
+		case ref == "gt":
+			r = '>'
+		case strings.HasPrefix(ref, "#x") || strings.HasPrefix(ref, "#X"):
+			if n, err := strconv.ParseInt(ref[2:], 16, 32); err == nil {
+				r = rune(n)
+			}
+		case strings.HasPrefix(ref, "#"):
+			if n, err := strconv.ParseInt(ref[1:], 10, 32); err == nil {
+				r = rune(n)
+			}
+		}
+		if r < 0 || r == '&' || r == '<' {
+			b.WriteString(s[i : i+semi+1])
+		} else {
+			b.WriteRune(r)
+		}
+		i += semi + 1
+	}
+	return b.String()
+}
+
 // normalizeClassicProfilePayloadsForSend rewrites the <payloads> element
 // into the only wire form the Classic API accepts for entity-bearing
-// plists, immediately before the request is sent: the true plist inside a
-// single CDATA section, "]]>" entity-guarded, with every "&" escaped once.
+// plists, immediately before the request is sent: the plist inside a
+// single CDATA section with source escaping minimised (see
+// minimizeClassicPlistSourceEscaping), "]]>" entity-guarded, and every
+// "&" escaped once.
 // Text-form payloads (e.g. a GET/backup response piped back in) are
 // entity-decoded once to recover the plist first. Bodies without a
 // non-empty <payloads> element are returned unchanged.
@@ -1807,6 +1865,7 @@ func normalizeClassicProfilePayloadsForSend(body []byte) []byte {
 	if inner == "" {
 		return body
 	}
+	inner = minimizeClassicPlistSourceEscaping(inner)
 	inner = strings.ReplaceAll(inner, "]]>", "]]&gt;")
 	inner = strings.ReplaceAll(inner, "&", "&amp;")
 	return []byte(s[:ci] + "<![CDATA[" + inner + "]]></payloads>" + s[restAt:])

--- a/internal/commands/pro/generated/classic_payload_escape_test.go
+++ b/internal/commands/pro/generated/classic_payload_escape_test.go
@@ -45,8 +45,36 @@ func TestNormalizePayloads_CDATA_EscapedOnce(t *testing.T) {
 	for _, p := range plists {
 		body := `<os_x_configuration_profile><general><payloads><![CDATA[` + p + `]]></payloads></general></os_x_configuration_profile>`
 		escaped := cdataContent(t, string(normalizeClassicProfilePayloadsForSend([]byte(body))))
-		if decoded := strings.ReplaceAll(escaped, "&amp;", "&"); decoded != p {
-			t.Errorf("server-side decode would store %q, want %q", decoded, p)
+		want := strings.ReplaceAll(minimizeClassicPlistSourceEscaping(p), "]]>", "]]&gt;")
+		if decoded := strings.ReplaceAll(escaped, "&amp;", "&"); decoded != want {
+			t.Errorf("server-side decode would store %q, want %q", decoded, want)
+		}
+	}
+}
+
+func TestMinimizeClassicPlistSourceEscaping(t *testing.T) {
+	cases := map[string]string{
+		"&quot;":    `"`,
+		"&#34;":     `"`,
+		"&#x22;":    `"`,
+		"&apos;":    "'",
+		"&#39;":     "'",
+		"&gt;":      ">",
+		"&#xA;":     "\n",
+		"&#9;":      "\t",
+		"&amp;":     "&amp;",
+		"&lt;":      "&lt;",
+		"&#38;":     "&#38;",
+		"&#x26;":    "&#x26;",
+		"&#60;":     "&#60;",
+		"&bogus;":   "&bogus;",
+		"A & B; C":  "A & B; C",
+		"&amp;#34;": "&amp;#34;",
+		"a]]&gt;b":  "a]]>b",
+	}
+	for in, want := range cases {
+		if got := minimizeClassicPlistSourceEscaping(in); got != want {
+			t.Errorf("minimize(%q) = %q, want %q", in, got, want)
 		}
 	}
 }
@@ -58,8 +86,9 @@ func TestNormalizePayloads_TextForm_ConvertedToCDATA(t *testing.T) {
 	escapedOnce := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(truePlist)
 	body := `<os_x_configuration_profile><general><payloads>` + escapedOnce + `</payloads></general></os_x_configuration_profile>`
 	escaped := cdataContent(t, string(normalizeClassicProfilePayloadsForSend([]byte(body))))
-	if decoded := strings.ReplaceAll(escaped, "&amp;", "&"); decoded != truePlist {
-		t.Errorf("text-form round-trip: server would store %q, want %q", decoded, truePlist)
+	want := minimizeClassicPlistSourceEscaping(truePlist)
+	if decoded := strings.ReplaceAll(escaped, "&amp;", "&"); decoded != want {
+		t.Errorf("text-form round-trip: server would store %q, want %q", decoded, want)
 	}
 }
 

--- a/internal/commands/pro/generated/classic_registry.go
+++ b/internal/commands/pro/generated/classic_registry.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -416,10 +417,65 @@ func stripCDATASections(data []byte) []byte {
 	return []byte(b.String())
 }
 
+// minimizeClassicPlistSourceEscaping decodes every character/entity
+// reference in plist XML source EXCEPT those encoding "&" and "<" — e.g.
+// "&quot;"/"&#34;" become a literal quote, "&#xA;" a literal newline,
+// "&gt;" a literal ">". Both representations parse to identical values,
+// but the wire representation is what the server's verbatim-stored
+// payload types preserve (PI-827): avoidable references would surface as
+// literal text in stored values. This matters for the update path, where
+// injectClassicProfilePayloadUUIDs re-serialises the plist via
+// howett.net/plist, whose encoding/xml backend escapes quotes and value
+// newlines/tabs numerically.
+func minimizeClassicPlistSourceEscaping(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c != '&' {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		semi := strings.IndexByte(s[i:], ';')
+		if semi < 0 || semi > 12 {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		ref := s[i+1 : i+semi]
+		var r rune = -1
+		switch {
+		case ref == "quot":
+			r = '"'
+		case ref == "apos":
+			r = '\''
+		case ref == "gt":
+			r = '>'
+		case strings.HasPrefix(ref, "#x") || strings.HasPrefix(ref, "#X"):
+			if n, err := strconv.ParseInt(ref[2:], 16, 32); err == nil {
+				r = rune(n)
+			}
+		case strings.HasPrefix(ref, "#"):
+			if n, err := strconv.ParseInt(ref[1:], 10, 32); err == nil {
+				r = rune(n)
+			}
+		}
+		if r < 0 || r == '&' || r == '<' {
+			b.WriteString(s[i : i+semi+1])
+		} else {
+			b.WriteRune(r)
+		}
+		i += semi + 1
+	}
+	return b.String()
+}
+
 // normalizeClassicProfilePayloadsForSend rewrites the <payloads> element
 // into the only wire form the Classic API accepts for entity-bearing
-// plists, immediately before the request is sent: the true plist inside a
-// single CDATA section, "]]>" entity-guarded, with every "&" escaped once.
+// plists, immediately before the request is sent: the plist inside a
+// single CDATA section with source escaping minimised (see
+// minimizeClassicPlistSourceEscaping), "]]>" entity-guarded, and every
+// "&" escaped once.
 // Text-form payloads (e.g. a GET/backup response piped back in) are
 // entity-decoded once to recover the plist first. Bodies without a
 // non-empty <payloads> element are returned unchanged.
@@ -469,6 +525,7 @@ func normalizeClassicProfilePayloadsForSend(body []byte) []byte {
 	if inner == "" {
 		return body
 	}
+	inner = minimizeClassicPlistSourceEscaping(inner)
 	inner = strings.ReplaceAll(inner, "]]>", "]]&gt;")
 	inner = strings.ReplaceAll(inner, "&", "&amp;")
 	return []byte(s[:ci] + "<![CDATA[" + inner + "]]></payloads>" + s[restAt:])


### PR DESCRIPTION
Follow-up to #310, mirroring Jamf-Concepts/jamfplatform-go-sdk#45.

## Problem

The update path re-serialises the plist for UUID injection via `howett.net/plist`, whose `encoding/xml` backend escapes quotes, apostrophes, and value newlines/tabs as numeric references (`&#34;`, `&#39;`, `&#xA;`). Verbatim-stored payload types preserve the wire representation with **zero decodes** (PI-827), so those avoidable references surfaced as literal text in stored values — a TCC `CodeRequirement` updated through the CLI came back as `identifier &#34;com...&#34;` (breaking the signing requirement) and tripped the post-write verification warning.

## Fix

`normalizeClassicProfilePayloadsForSend` now minimises source escaping before guarding and escaping: every character/entity reference **except** those encoding `&` and `<` is decoded to its literal character. Both representations parse to identical values — only the wire form changes — but the wire form is what verbatim storage preserves. Ordering is load-bearing: the `]]>` guard runs after minimising (decoding `&gt;` can resurrect the terminator).

Side benefit: the unavoidable verbatim-storage corruption shrinks to genuine `&`/`<` characters — entity-form `>`, quotes, and apostrophes in user mobileconfigs now store value-correct on the mobile endpoint and in verbatim macOS payload types, not just in MCX-family payloads.

## Verification

Wire-verified live: an entity-free TCC profile survives create **and update** byte-exact with zero verification warnings — quotes in `CodeRequirement` stay literal through the howett re-serialisation (previously corrupted on every update). Unit tests cover the minimisation table (decoded vs must-preserve references, unknown entities, bare ampersands, terminator resurrection); full suite green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)