### PR TITLE
fix(report): stop printing a stale hand-written subcommand list

### DIFF
--- a/internal/commands/help_text_test.go
+++ b/internal/commands/help_text_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026, Jamf Software LLC
+
+package commands
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestLongHelpDoesNotEnumerateSubcommands guards the fix for issue #327.
+//
+// A parent command that hand-writes its child list into `Long` makes the help
+// output print two lists: cobra's auto-generated "Available Commands:" section
+// and the hand-maintained copy. The copy has no test or CI reader, so it rots
+// — `pro report` shipped a 10-entry block against 15 real subcommands, five of
+// whose descriptions no longer matched the child's `Short`.
+//
+// The parent's `Long` is for prose only; cobra owns the inventory. This test
+// flags any indented line in a `Long` string whose first token is one of that
+// command's own subcommand names, which is the shape such a block always takes.
+func TestLongHelpDoesNotEnumerateSubcommands(t *testing.T) {
+	root := NewRootCmd("test", "abc123", "2024-01-01", "unknown")
+
+	walkCommands(root, func(cmd *cobra.Command) {
+		if cmd.Long == "" {
+			return
+		}
+		children := cmd.Commands()
+		if len(children) == 0 {
+			return
+		}
+
+		names := make(map[string]bool, len(children))
+		for _, child := range children {
+			names[child.Name()] = true
+		}
+
+		var enumerated []string
+		for _, line := range strings.Split(cmd.Long, "\n") {
+			if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+				continue // prose, not a list entry
+			}
+			fields := strings.Fields(line)
+			if len(fields) == 0 {
+				continue
+			}
+			if names[fields[0]] {
+				enumerated = append(enumerated, fields[0])
+			}
+		}
+		if len(enumerated) == 0 {
+			return
+		}
+
+		sort.Strings(enumerated)
+		t.Errorf("%q enumerates its own subcommands in Long (%s) — remove the list; "+
+			"cobra renders the complete, current one under \"Available Commands:\" "+
+			"from the AddCommand calls (see issue #327)",
+			cmd.CommandPath(), strings.Join(enumerated, ", "))
+	})
+}

--- a/internal/commands/pro_report.go
+++ b/internal/commands/pro_report.go
@@ -13,20 +13,11 @@ func newReportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "report",
 		Short: "Generate operational reports from Jamf Pro data",
+		// Do not enumerate subcommands here — cobra renders the real, complete
+		// list under "Available Commands:" from the AddCommand calls below.
+		// A hand-maintained copy drifts (see issue #327).
 		Long: `Generate operational reports by aggregating Jamf Pro inventory and
-configuration data into tabular summaries.
-
-Available subcommands:
-  patch-status       Per-title patch compliance across the fleet
-  device-compliance  Devices with stale check-ins, failed commands, or missing profiles
-  inventory-summary  Hardware model and OS version breakdown
-  software-installs  Installed software version distribution
-  ea-results         Extension attribute results across devices
-  policy-status      Policy execution status and health checks
-  profile-status     Configuration profile deployment failures
-  app-status         Managed app deployment failures
-  update-status      Managed software update deployment status
-  duplicate-serials  Computer records sharing a serial number`,
+configuration data into tabular summaries.`,
 	}
 
 	cmd.AddCommand(newReportPatchStatusCmd(cliCtx))


### PR DESCRIPTION
Fixes #327

## Problem

`jamf-cli pro report --help` printed two lists — cobra's auto-generated `Available Commands:` section, plus a hand-maintained copy inside the parent's `Long` string.

The hand-written copy had no test or CI reader, so it rotted:

| | hand-written block | cobra |
|---|---|---|
| entries | 10 | 15 |

Missing entirely: `security`, `blueprint-status`, `compliance-rules`, `compliance-devices`, `ddm-status`.

And 5 of the 10 shared entries no longer matched the child's actual `Short`:

- `patch-status`: "Per-title patch compliance across the fleet" → actual "Patch compliance and policy failure report"
- `device-compliance`: "…failed commands, or missing profiles" → actual "…or outdated OS versions"
- `policy-status`: "Policy execution status and health checks" → "Fleet-wide policy health check"
- `profile-status` / `app-status`: "…deployment failures" → "…deployment health"

### How it drifted

`git log --follow` on `internal/commands/pro_report.go` shows two habits colliding. Commits that added a single report updated both places (`ac60a6f`, `bb1d632`, `421e123`, `b7dc65a` each appended an `AddCommand` **and** a `Long` line). Commits where report was a side dish did not: `4604b56` ("add operational commands…") added `newReportSecurityCmd` as a one-line diff to this file, and `a44efbd` (Platform API integration) added all four Platform reports the same way. Nothing asserted the two lists agreed, and the site catalog introspects the built binary — so `commands.json` always showed the true 15 and the stale copy never surfaced downstream.

Note: the issue says "not all these commands actually exist" — all 10 listed commands do exist. The failure ran the other way: the block was a stale subset. The requested remedy (one merged section) is still the right fix.

## Change

- Drop the enumerated list from `report`'s `Long`. Cobra renders the inventory sorted, complete, and with the real `Short` strings; the parent's `Long` is prose only. A comment on the field records why not to re-add it.
- Add `TestLongHelpDoesNotEnumerateSubcommands` (`internal/commands/help_text_test.go`): walks the whole command tree and fails on any indented `Long` line whose first token is one of that command's own subcommand names — the shape such a block always takes.

## Scope

Isolated. `grep "Available subcommands"` returned this one hit. `pro_bulk_commands.go`'s "Available commands:" list is MDM command *values*, not subcommands, and is in sync with `validMDMCommands` (12/12). No docs or wiki repeated the stale list.

## Verification

- `pro report --help` now prints one section with all 15 subcommands.
- Guard test verified to **fail** against the pre-fix `pro report` (reverted the file, ran the test, got the expected failure listing all 10 enumerated names), then pass after.
- `go test ./...` clean; `make lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)