### PR TITLE
fix(pro): diff read one directory level, hiding every nested resource

### DIFF
--- a/docs/solutions/logic-errors/diff-missed-nested-backup-subdirs-2026-08-19.md
+++ b/docs/solutions/logic-errors/diff-missed-nested-backup-subdirs-2026-08-19.md
@@ -1,0 +1,112 @@
+---
+title: "pro diff read one directory level, so every nested resource — config profiles included — silently reported no change"
+date: 2026-08-19
+category: logic-errors
+module: internal/commands
+problem_type: bug
+severity: high
+applies_when:
+  - "Adding a BackupResource whose SubDir has more than one segment"
+  - "Changing how `diff` loads a backup directory, or how it keys objects"
+  - "A user reports `diff` finding changes for some resources but not others"
+  - "Comparing a backup directory against a live instance"
+tags:
+  - diff
+  - backup
+  - snapshot
+  - directory-layout
+  - silent-failure
+  - config-profiles
+issue: 331
+---
+
+# `diff` read one directory level, so nested resources reported no change
+
+## Context
+
+`pro diff` builds a `resourceSnapshot` — `resource → object name → fields` — from
+each side, then compares them. A side is either a live instance
+(`loadSnapshotFromProfile`) or a backup directory (`loadSnapshotFromDirectory`).
+`backup` lays a directory out from each curated resource's `SubDir`
+(`internal/commands/pro_resources.go`), and thirteen of those nest two levels:
+
+```
+profiles/macos            profiles/ios
+prestages/computers       prestages/mobile
+extension-attributes/{computer,mobile,user}
+smart-groups/{computers,mobile}
+static-groups/{computers,mobile}
+accounts/{users,groups}
+```
+
+## The bug
+
+The directory loader walked exactly one level (`os.ReadDir`, "each subdir is a
+resource type") and `readObjectsFromSubdir` skips directory entries. So for
+`profiles/` it found zero files, and because a bucket is only added to the
+snapshot when it holds at least one object, the key never appeared on *either*
+side. `compareSnapshots` had nothing to compare, so it reported nothing.
+
+That is the worst possible failure shape for a diff: not an error, not a warning,
+exit 0, and output that is indistinguishable from "these two instances agree".
+The reporter saw it as "diff doesn't work with configuration profiles"; profiles
+were just the resource they happened to change. Prestages, extension attributes,
+smart groups, static groups and accounts were equally invisible.
+
+Two adjacent mismatches came out of the same repro:
+
+- **Directory and live mode bucketed under different keys.** Live mode buckets by
+  `FilterName` (`profiles`), the directory loader by top-level directory name. For
+  flat resources those strings coincide, which is why the bug looked
+  profile-specific. For nested ones, a directory-vs-instance diff had the key
+  populated on one side only — so every profile reported as `added` or `removed`.
+- **Objects were keyed by filename stem for Classic resources.** The loader read
+  `obj["name"]`, but a Classic detail nests its name under `general`, and a
+  prestage calls it `displayName`. Falling through to the stem meant the key was
+  `SlugifyName` output — possibly with a `DeduplicateSlug` suffix — while live
+  mode used the real name from the list item. So `diff --source ./backup --target
+  production` reported every Classic object as removed *and* added.
+
+## Fix
+
+`BackupSubDirs()` (`pro_resources.go`) maps each `SubDir` to its `FilterName`, so
+the two loaders derive their keys from one table instead of two conventions.
+`loadSnapshotFromDirectory` now walks the tree with `filepath.WalkDir` and, per
+directory:
+
+- a path in `BackupSubDirs()` is read and then `fs.SkipDir` — a resource directory
+  owns its *files*, not its subdirectories, which is what keeps
+  `packages/files` (downloaded package binaries) out of the snapshot;
+- a parent of a nested resource path (`profiles`) is descended through, never read
+  as a resource itself;
+- an unknown *top-level* directory keeps the old behaviour, keyed by its own name
+  — that is what carries the SDK-backed resources written straight to the backup
+  root (`blueprints`, `compliance-benchmarks`) and any hand-assembled tree;
+- an unknown *nested* directory is skipped.
+
+Buckets merge with `maps.Copy` exactly as live mode does, so macOS + iOS profiles
+(and account users + groups) land in one bucket on both sides.
+
+`backupObjectName` replaces the inline `obj["name"]` read: `name`, then
+`displayName`, then `general.name`, then the stem as a last resort.
+
+## Guardrails
+
+`TestLoadSnapshotFromDirectory_EveryCuratedSubDirIsRead` writes one file into
+*every* `BackupResource.SubDir` and asserts each is readable under its
+`FilterName`. That is deliberately a test over the table rather than over the
+thirteen paths, so a nested resource added later cannot reintroduce the class.
+
+`TestBackupObjectName_MatchesLiveNameExtraction` asserts the directory key equals
+`extractName` of the corresponding list item — the two loaders are only
+comparable if they agree on this, and nothing else in the codebase forces it.
+
+## Watch for
+
+- A resource whose live list name differs from anything in its detail body would
+  break key parity again; `backupObjectName` can only see the file on disk.
+- `NameField` in the generated backup registry accepts dotted paths
+  (`computers-inventory` declares `general.name`) but `extractName` does not
+  traverse them. No curated backup resource relies on it today.
+- `diff` still says nothing when a resource directory exists but is empty on both
+  sides, which is correct but reads the same as "no such resource".

--- a/docs/solutions/logic-errors/diff-missed-nested-backup-subdirs-2026-08-19.md
+++ b/docs/solutions/logic-errors/diff-missed-nested-backup-subdirs-2026-08-19.md
@@ -71,24 +71,46 @@ Two adjacent mismatches came out of the same repro:
 
 `BackupSubDirs()` (`pro_resources.go`) maps each `SubDir` to its `FilterName`, so
 the two loaders derive their keys from one table instead of two conventions.
-`loadSnapshotFromDirectory` now walks the tree with `filepath.WalkDir` and, per
-directory:
+`loadSnapshotFromDirectory` then **reads that table instead of walking the tree**:
 
-- a path in `BackupSubDirs()` is read and then `fs.SkipDir` — a resource directory
-  owns its *files*, not its subdirectories, which is what keeps
-  `packages/files` (downloaded package binaries) out of the snapshot;
-- a parent of a nested resource path (`profiles`) is descended through, never read
-  as a resource itself;
-- an unknown *top-level* directory keeps the old behaviour, keyed by its own name
-  — that is what carries the SDK-backed resources written straight to the backup
-  root (`blueprints`, `compliance-benchmarks`) and any hand-assembled tree;
-- an unknown *nested* directory is skipped.
+- one `os.ReadDir` of the backup root picks up the directories no curated
+  `SubDir` claims, keyed by their own name — the SDK-backed resources written
+  straight to the root (`blueprints`, `compliance-benchmarks`), any
+  hand-assembled tree, and object files left directly in a parent of a nested
+  resource (`profiles/*.yaml` beside `profiles/macos/`), where the directory name
+  is already the `FilterName`. A failure to read the root is returned as an
+  error, not warned about: an empty snapshot there is not a partial result, it is
+  "the source was never read", and reporting that as no differences is the same
+  silent success this fix exists to remove;
+- then every entry of `BackupResources`, in slice order, read at
+  `filepath.Join(dir, r.SubDir)`. A missing directory is simply skipped.
 
-Buckets merge with `maps.Copy` exactly as live mode does, so macOS + iOS profiles
-(and account users + groups) land in one bucket on both sides.
+Reading the table rather than walking it is what makes the two loaders agree on
+more than the key. Both merge shared buckets with `maps.Copy` in
+`BackupResources` order, so the entry listed *last* wins a name collision on both
+sides — a macOS and an iOS profile both called `Corporate Wi-Fi` resolve to the
+same object on disk as they do live. A walk visits lexically (`profiles/ios`
+before `profiles/macos`, `accounts/groups` before `accounts/users`) and inverts
+that for exactly those two `FilterName`s, which turns a hidden object into a diff
+reporting every field of the survivor as modified. Reading by path also bounds
+the read to the directories the table names, which is what keeps `packages/files`
+(downloaded package binaries) out of the snapshot, and it drops the nested-parent
+bookkeeping, the `fs.SkipDir` handling and the depth assumptions with it.
 
-`backupObjectName` replaces the inline `obj["name"]` read: `name`, then
-`displayName`, then `general.name`, then the stem as a last resort.
+One behaviour is genuinely new rather than preserved: a resource directory may be
+a **symlink**. The old loader skipped symlinks (`os.ReadDir` reports a
+symlink-to-directory with `IsDir() == false`); reading the curated resources by
+path follows them for free, and `entryIsDir` keeps the root-level scan consistent
+with that. Worth knowing when handed an untrusted tree — `diff` will read and
+print field values from outside it.
+
+`backupObjectName` replaces the inline `obj["name"]` read and takes the
+resource's `BackupEndpoint.NameField`, checked first for the same reason
+`extractName` checks it first: it is where the resources that do not call their
+name `name` keep it — prestages use `displayName`, mobile-device smart and static
+groups use `groupName`. Then `name`, then the two shapes no registry field names
+(a Classic detail nesting its name under `general`, and `displayName` for a
+directory read without a `NameField`), then the filename stem as a last resort.
 
 ## Guardrails
 
@@ -97,16 +119,31 @@ Buckets merge with `maps.Copy` exactly as live mode does, so macOS + iOS profile
 `FilterName`. That is deliberately a test over the table rather than over the
 thirteen paths, so a nested resource added later cannot reintroduce the class.
 
+`TestLoadSnapshotFromDirectory_EveryCuratedNameFieldIsHonoured` is the same idea
+for the key: for every curated resource it writes an object carrying *only* its
+declared `NameField`, so a resource added later whose name lives somewhere new
+fails rather than silently falling back to the stem.
+
 `TestBackupObjectName_MatchesLiveNameExtraction` asserts the directory key equals
 `extractName` of the corresponding list item — the two loaders are only
 comparable if they agree on this, and nothing else in the codebase forces it.
+
+`TestLoadSnapshotFromDirectory_SharedBucketCollisionMatchesLiveOrder` pins the
+collision winner for `profiles` and `accounts` by reading it out of
+`BackupResources`, so reordering the table moves the expectation with it.
+
+`TestLoadSnapshotFromDirectory_UnreadableRootIsAnError` and
+`TestRunDiff_UnreadableSourceDirectoryErrors` keep an unreadable source out of
+the "No differences found" path, at the loader and at the command boundary.
 
 ## Watch for
 
 - A resource whose live list name differs from anything in its detail body would
   break key parity again; `backupObjectName` can only see the file on disk.
 - `NameField` in the generated backup registry accepts dotted paths
-  (`computers-inventory` declares `general.name`) but `extractName` does not
-  traverse them. No curated backup resource relies on it today.
+  (`computers-inventory` declares `general.name`) but neither `extractName` nor
+  `backupObjectName` traverses them — the latter happens to land on the right
+  value through its `general.name` branch, not because the dotted field was
+  honoured. No curated backup resource relies on it today.
 - `diff` still says nothing when a resource directory exists but is empty on both
   sides, which is correct but reads the same as "no such resource".

--- a/internal/commands/pro_diff.go
+++ b/internal/commands/pro_diff.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -134,31 +135,99 @@ func loadSnapshotFromDirectory(dir string, nameFilter []string) (resourceSnapsho
 
 	snapshot := make(resourceSnapshot)
 
-	// Walk one level of subdirectories; each subdir is a resource type.
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, fmt.Errorf("reading directory %q: %w", dir, err)
+	// knownSubDirs maps a resource's on-disk path to the FilterName it is
+	// bucketed under; nestedParents holds the directories that merely contain
+	// those paths (e.g. "profiles" contains profiles/macos and profiles/ios) and
+	// are walked through rather than read as a resource.
+	knownSubDirs := BackupSubDirs()
+	nestedParents := make(map[string]bool)
+	for sub := range knownSubDirs {
+		if i := strings.Index(sub, "/"); i > 0 {
+			nestedParents[sub[:i]] = true
+		}
 	}
 
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue // skip files at the root (e.g., _failures.yaml)
-		}
-
-		resourceName := entry.Name()
-		if len(allowedResources) > 0 && !allowedResources[resourceName] {
-			continue
-		}
-
-		subDir := filepath.Join(dir, resourceName)
-		objects, err := readObjectsFromSubdir(subDir)
+	// readInto reads one resource directory and merges it into the snapshot
+	// under resourceName. Several curated resources share a FilterName (macOS +
+	// iOS profiles, account users + groups) and so merge into one bucket — the
+	// same shape live mode produces, which is what makes the two comparable.
+	readInto := func(resourceName, path string) {
+		objects, err := readObjectsFromSubdir(path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARNING: reading %s: %v\n", subDir, err)
-			continue
+			fmt.Fprintf(os.Stderr, "WARNING: reading %s: %v\n", path, err)
+			return
 		}
-		if len(objects) > 0 {
+		if len(objects) == 0 {
+			return
+		}
+		if existing, ok := snapshot[resourceName]; ok {
+			maps.Copy(existing, objects)
+		} else {
 			snapshot[resourceName] = objects
 		}
+	}
+
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: walking %s: %v\n", path, err)
+			return nil
+		}
+
+		// A symlinked resource directory is read in place: WalkDir reports it as
+		// a non-directory entry and never descends into it.
+		symlinkedDir := false
+		if !d.IsDir() && d.Type()&fs.ModeSymlink != 0 {
+			if info, statErr := os.Stat(path); statErr == nil && info.IsDir() {
+				symlinkedDir = true
+			}
+		}
+		if !d.IsDir() && !symlinkedDir {
+			return nil // object files are read by readObjectsFromSubdir
+		}
+
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "." {
+			return nil
+		}
+
+		// skip stops the walk from descending, except for a symlinked entry
+		// where fs.SkipDir would skip the *containing* directory instead.
+		skip := fs.SkipDir
+		if symlinkedDir {
+			skip = nil
+		}
+
+		resourceName, known := knownSubDirs[rel]
+		switch {
+		case known:
+			// Read it, then stop: a resource directory owns its files, not its
+			// subdirectories — packages/files holds downloaded package
+			// binaries, which are not config objects.
+		case nestedParents[rel] && !symlinkedDir:
+			return nil // container — descend to the resource directories inside
+		case !strings.Contains(rel, "/"):
+			// A top-level directory outside the curated set, keyed by its own
+			// name. Covers the SDK-backed resources written straight to the
+			// backup root (blueprints, compliance-benchmarks) and any
+			// hand-assembled tree.
+			resourceName = rel
+		default:
+			return skip // unknown nested directory
+		}
+
+		if len(allowedResources) > 0 && !allowedResources[resourceName] {
+			return skip
+		}
+
+		readInto(resourceName, path)
+		return skip
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("reading directory %q: %w", dir, walkErr)
 	}
 
 	return snapshot, nil
@@ -209,19 +278,34 @@ func readObjectsFromSubdir(subDir string) (map[string]map[string]any, error) {
 		// Strip _meta block added by backup — not part of the config.
 		delete(obj, "_meta")
 
-		// Use the "name" field as the object key; fall back to the filename stem.
-		objName := ""
-		if n, ok := obj["name"].(string); ok && n != "" {
-			objName = n
-		} else {
-			stem := strings.TrimSuffix(strings.TrimSuffix(name, ".yaml"), ".json")
-			objName = stem
-		}
-
-		objects[objName] = obj
+		stem := strings.TrimSuffix(strings.TrimSuffix(name, ".yaml"), ".json")
+		objects[backupObjectName(obj, stem)] = obj
 	}
 
 	return objects, nil
+}
+
+// backupObjectName picks the snapshot key for one object read off disk. It has
+// to agree with live mode, which keys on the list item's name — otherwise a
+// directory diffed against an instance reports every object as removed *and*
+// added. Modern resources carry "name", prestages carry "displayName", and
+// Classic details nest theirs under "general". Only when none of those is
+// present does the filename stem stand in, and a stem is a poor key: it is
+// SlugifyName output, possibly carrying a DeduplicateSlug suffix, so it never
+// equals the name the live side uses.
+func backupObjectName(obj map[string]any, fileStem string) string {
+	if n, ok := obj["name"].(string); ok && n != "" {
+		return n
+	}
+	if n, ok := obj["displayName"].(string); ok && n != "" {
+		return n
+	}
+	if general, ok := obj["general"].(map[string]any); ok {
+		if n, ok := general["name"].(string); ok && n != "" {
+			return n
+		}
+	}
+	return fileStem
 }
 
 // normaliseViaJSON round-trips a map through JSON to coerce yaml.v3 types

--- a/internal/commands/pro_diff.go
+++ b/internal/commands/pro_diff.go
@@ -5,6 +5,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"maps"
@@ -135,26 +136,24 @@ func loadSnapshotFromDirectory(dir string, nameFilter []string) (resourceSnapsho
 
 	snapshot := make(resourceSnapshot)
 
-	// knownSubDirs maps a resource's on-disk path to the FilterName it is
-	// bucketed under; nestedParents holds the directories that merely contain
-	// those paths (e.g. "profiles" contains profiles/macos and profiles/ios) and
-	// are walked through rather than read as a resource.
-	knownSubDirs := BackupSubDirs()
-	nestedParents := make(map[string]bool)
-	for sub := range knownSubDirs {
-		if i := strings.Index(sub, "/"); i > 0 {
-			nestedParents[sub[:i]] = true
+	// readInto reads the object files sitting directly in one directory and
+	// merges them into the snapshot under resourceName. Several curated
+	// resources share a FilterName (macOS + iOS profiles, account users +
+	// groups) and so merge into one bucket — the same shape live mode produces,
+	// which is what makes the two comparable. nameField is the resource's
+	// BackupEndpoint.NameField, so an object read off disk is keyed by the same
+	// field live mode reads off the list item.
+	readInto := func(resourceName, nameField, path string) {
+		if len(allowedResources) > 0 && !allowedResources[resourceName] {
+			return
 		}
-	}
-
-	// readInto reads one resource directory and merges it into the snapshot
-	// under resourceName. Several curated resources share a FilterName (macOS +
-	// iOS profiles, account users + groups) and so merge into one bucket — the
-	// same shape live mode produces, which is what makes the two comparable.
-	readInto := func(resourceName, path string) {
-		objects, err := readObjectsFromSubdir(path)
+		objects, err := readObjectsFromSubdir(path, nameField)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARNING: reading %s: %v\n", path, err)
+			// A curated resource absent from this backup is not a problem —
+			// only an unreadable directory is.
+			if !errors.Is(err, fs.ErrNotExist) {
+				fmt.Fprintf(os.Stderr, "WARNING: reading %s: %v\n", path, err)
+			}
 			return
 		}
 		if len(objects) == 0 {
@@ -167,75 +166,76 @@ func loadSnapshotFromDirectory(dir string, nameFilter []string) (resourceSnapsho
 		}
 	}
 
-	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARNING: walking %s: %v\n", path, err)
-			return nil
+	// First, directories in the backup root that no curated resource claims,
+	// keyed by their own name. That covers the SDK-backed resources written
+	// straight to the root (blueprints, compliance-benchmarks), any
+	// hand-assembled tree, and object files left directly in a parent of a
+	// nested resource (profiles/*.yaml beside profiles/macos/) — for those the
+	// directory name is already the FilterName, so they land in the right
+	// bucket. Reading them before the curated pass means the layout `backup`
+	// actually writes wins a name collision.
+	//
+	// Failing to read the root is fatal rather than a warning: an empty
+	// snapshot there is not a partial result, it is "the source was never
+	// read", and reporting that as no differences is exactly the silent
+	// success this loader exists to remove.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading directory %q: %w", dir, err)
+	}
+	curatedDirs := BackupSubDirs()
+	for _, entry := range entries {
+		name := entry.Name()
+		if _, curated := curatedDirs[name]; curated {
+			continue // read by the curated pass below, under its FilterName
 		}
+		if !entryIsDir(dir, entry) {
+			continue
+		}
+		readInto(name, "", filepath.Join(dir, name))
+	}
 
-		// A symlinked resource directory is read in place: WalkDir reports it as
-		// a non-directory entry and never descends into it.
-		symlinkedDir := false
-		if !d.IsDir() && d.Type()&fs.ModeSymlink != 0 {
-			if info, statErr := os.Stat(path); statErr == nil && info.IsDir() {
-				symlinkedDir = true
-			}
-		}
-		if !d.IsDir() && !symlinkedDir {
-			return nil // object files are read by readObjectsFromSubdir
-		}
-
-		rel, relErr := filepath.Rel(dir, path)
-		if relErr != nil {
-			return nil
-		}
-		rel = filepath.ToSlash(rel)
-		if rel == "." {
-			return nil
-		}
-
-		// skip stops the walk from descending, except for a symlinked entry
-		// where fs.SkipDir would skip the *containing* directory instead.
-		skip := fs.SkipDir
-		if symlinkedDir {
-			skip = nil
-		}
-
-		resourceName, known := knownSubDirs[rel]
-		switch {
-		case known:
-			// Read it, then stop: a resource directory owns its files, not its
-			// subdirectories — packages/files holds downloaded package
-			// binaries, which are not config objects.
-		case nestedParents[rel] && !symlinkedDir:
-			return nil // container — descend to the resource directories inside
-		case !strings.Contains(rel, "/"):
-			// A top-level directory outside the curated set, keyed by its own
-			// name. Covers the SDK-backed resources written straight to the
-			// backup root (blueprints, compliance-benchmarks) and any
-			// hand-assembled tree.
-			resourceName = rel
-		default:
-			return skip // unknown nested directory
-		}
-
-		if len(allowedResources) > 0 && !allowedResources[resourceName] {
-			return skip
-		}
-
-		readInto(resourceName, path)
-		return skip
-	})
-	if walkErr != nil {
-		return nil, fmt.Errorf("reading directory %q: %w", dir, walkErr)
+	// Then every curated resource, read at the path `backup` writes it to and
+	// in BackupResources order. Reading the table instead of walking the tree
+	// gives both loaders one iteration order, so two objects sharing a name in
+	// one bucket (a macOS and an iOS profile both called "Corporate Wi-Fi")
+	// resolve to the same object on disk as they do live. It also bounds the
+	// read to the directories the table names: a resource directory owns its
+	// files, not its subdirectories, which is what keeps packages/files —
+	// downloaded package binaries, not config objects — out of the snapshot.
+	defs, err := ResolveBackupResources(nameFilter)
+	if err != nil {
+		return nil, err
+	}
+	for _, def := range defs {
+		readInto(def.FilterName, def.NameField, filepath.Join(dir, filepath.FromSlash(def.SubDir)))
 	}
 
 	return snapshot, nil
 }
 
+// entryIsDir reports whether entry names a directory, following a symlink.
+// os.ReadDir returns the entry as it appears in the directory itself, so a
+// symlink to a directory reports IsDir() == false; diff follows it, so a
+// backup tree may point a resource directory somewhere else. Reading the
+// curated resources by path follows symlinks for free — this keeps the
+// root-level scan consistent with that.
+func entryIsDir(parent string, entry fs.DirEntry) bool {
+	if entry.IsDir() {
+		return true
+	}
+	if entry.Type()&fs.ModeSymlink == 0 {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(parent, entry.Name()))
+	return err == nil && info.IsDir()
+}
+
 // readObjectsFromSubdir reads all .yaml and .json files in subDir and returns
-// a map of object name → fields (with _meta stripped).
-func readObjectsFromSubdir(subDir string) (map[string]map[string]any, error) {
+// a map of object name → fields (with _meta stripped). nameField is the
+// resource's BackupEndpoint.NameField — the field live mode keys on — or empty
+// for a directory outside the curated set.
+func readObjectsFromSubdir(subDir, nameField string) (map[string]map[string]any, error) {
 	entries, err := os.ReadDir(subDir)
 	if err != nil {
 		return nil, err
@@ -279,7 +279,7 @@ func readObjectsFromSubdir(subDir string) (map[string]map[string]any, error) {
 		delete(obj, "_meta")
 
 		stem := strings.TrimSuffix(strings.TrimSuffix(name, ".yaml"), ".json")
-		objects[backupObjectName(obj, stem)] = obj
+		objects[backupObjectName(obj, nameField, stem)] = obj
 	}
 
 	return objects, nil
@@ -288,12 +288,21 @@ func readObjectsFromSubdir(subDir string) (map[string]map[string]any, error) {
 // backupObjectName picks the snapshot key for one object read off disk. It has
 // to agree with live mode, which keys on the list item's name — otherwise a
 // directory diffed against an instance reports every object as removed *and*
-// added. Modern resources carry "name", prestages carry "displayName", and
-// Classic details nest theirs under "general". Only when none of those is
-// present does the filename stem stand in, and a stem is a poor key: it is
-// SlugifyName output, possibly carrying a DeduplicateSlug suffix, so it never
-// equals the name the live side uses.
-func backupObjectName(obj map[string]any, fileStem string) string {
+// added. nameField is the resource's declared NameField, checked first for the
+// same reason extractName checks it first: it is where the resources that do
+// not call their name "name" keep it (prestages use displayName, mobile-device
+// groups use groupName). Then "name", then the two shapes no registry field
+// names — a Classic detail nesting its name under "general", and displayName on
+// a directory read without a NameField. Only when none of those is present does
+// the filename stem stand in, and a stem is a poor key: it is SlugifyName
+// output, possibly carrying a DeduplicateSlug suffix, so it never equals the
+// name the live side uses.
+func backupObjectName(obj map[string]any, nameField, fileStem string) string {
+	if nameField != "" {
+		if n, ok := obj[nameField].(string); ok && n != "" {
+			return n
+		}
+	}
 	if n, ok := obj["name"].(string); ok && n != "" {
 		return n
 	}

--- a/internal/commands/pro_diff_test.go
+++ b/internal/commands/pro_diff_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -866,6 +867,13 @@ func TestBackupObjectName_MatchesLiveNameExtraction(t *testing.T) {
 			stem:     "standard-mac",
 		},
 		{
+			name:     "mobile-device group uses groupName",
+			detail:   map[string]any{"groupName": "Static iPads"},
+			listItem: map[string]any{"groupId": "6", "groupName": "Static iPads"},
+			nameFld:  "groupName",
+			stem:     "static-ipads",
+		},
+		{
 			name:     "de-duplicated slug must not become the key",
 			detail:   map[string]any{"general": map[string]any{"name": "Corp WiFi"}},
 			listItem: map[string]any{"id": "9", "name": "Corp WiFi"},
@@ -875,7 +883,7 @@ func TestBackupObjectName_MatchesLiveNameExtraction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fromDisk := backupObjectName(tt.detail, tt.stem)
+			fromDisk := backupObjectName(tt.detail, tt.nameFld, tt.stem)
 			fromLive := extractName(tt.listItem, tt.nameFld, "")
 			if fromDisk != fromLive {
 				t.Errorf("snapshot keys disagree: directory %q vs live %q", fromDisk, fromLive)
@@ -885,7 +893,7 @@ func TestBackupObjectName_MatchesLiveNameExtraction(t *testing.T) {
 }
 
 func TestBackupObjectName_FallsBackToStem(t *testing.T) {
-	got := backupObjectName(map[string]any{"priority": float64(5)}, "productivity")
+	got := backupObjectName(map[string]any{"priority": float64(5)}, "", "productivity")
 	if got != "productivity" {
 		t.Errorf("expected filename stem 'productivity', got %q", got)
 	}
@@ -900,17 +908,28 @@ func snapshotKeys(s resourceSnapshot) []string {
 	return keys
 }
 
-// TestLoadSnapshotFromDirectory_SymlinkedResourceDir keeps a capability the
-// pre-WalkDir loader had for free: os.ReadDir followed a symlinked resource
-// directory. WalkDir does not descend into symlinks, so they are read in place.
+// TestLoadSnapshotFromDirectory_SymlinkedResourceDir pins a capability this
+// loader adds: a resource directory may be a symlink. The old loader skipped
+// them (os.ReadDir reports a symlink-to-directory with IsDir() == false);
+// reading the curated resources by path follows them for free, and entryIsDir
+// keeps the root-level scan consistent with that.
 func TestLoadSnapshotFromDirectory_SymlinkedResourceDir(t *testing.T) {
 	real := t.TempDir()
 	writeBackupFileForTest(t, filepath.Join(real, "shared-scripts", "deploy.yaml"), map[string]any{
 		"name": "Deploy Script",
 	}, "yaml")
 
+	writeBackupFileForTest(t, filepath.Join(real, "shared-blueprints", "baseline.yaml"), map[string]any{
+		"name": "Baseline",
+	}, "yaml")
+
 	dir := t.TempDir()
 	if err := os.Symlink(filepath.Join(real, "shared-scripts"), filepath.Join(dir, "scripts")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	// blueprints is outside the curated table, so it goes through the
+	// root-level scan and entryIsDir rather than through a table path.
+	if err := os.Symlink(filepath.Join(real, "shared-blueprints"), filepath.Join(dir, "blueprints")); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)
 	}
 
@@ -921,4 +940,180 @@ func TestLoadSnapshotFromDirectory_SymlinkedResourceDir(t *testing.T) {
 	if _, ok := snapshot["scripts"]["Deploy Script"]; !ok {
 		t.Errorf("expected symlinked scripts directory to be read, got %v", snapshot)
 	}
+	if _, ok := snapshot["blueprints"]["Baseline"]; !ok {
+		t.Errorf("expected symlinked blueprints directory to be read, got %v", snapshot)
+	}
+}
+
+// TestLoadSnapshotFromDirectory_EveryCuratedNameFieldIsHonoured guards the key
+// resolver over the table rather than over the field names that happened to be
+// wrong. For every curated resource, an object carrying *only* its declared
+// NameField must be keyed by that field's value: mobile-device groups keep
+// theirs in groupName and prestages in displayName, and a resource whose name
+// is not found falls back to the filename stem — the slugified, possibly
+// de-duplicated key live mode never produces, so every object is reported
+// removed and added. A resource added later with a new NameField fails here.
+func TestLoadSnapshotFromDirectory_EveryCuratedNameFieldIsHonoured(t *testing.T) {
+	defs, err := ResolveBackupResources(nil)
+	if err != nil {
+		t.Fatalf("resolving curated resources: %v", err)
+	}
+
+	dir := t.TempDir()
+	type expectation struct{ filterName, objName string }
+	var want []expectation
+	for _, def := range defs {
+		field := def.NameField
+		if field == "" {
+			field = "name"
+		}
+		objName := "named-" + def.Key
+		writeBackupFileForTest(t, filepath.Join(dir, filepath.FromSlash(def.SubDir), "obj.yaml"),
+			map[string]any{field: objName}, "yaml")
+		want = append(want, expectation{def.FilterName, objName})
+	}
+
+	snapshot, err := loadSnapshotFromDirectory(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, w := range want {
+		if _, ok := snapshot[w.filterName][w.objName]; !ok {
+			t.Errorf("resource %q: object not keyed on its NameField, bucket holds %v", w.filterName, snapshot[w.filterName])
+		}
+	}
+}
+
+// TestLoadSnapshotFromDirectory_SharedBucketCollisionMatchesLiveOrder pins the
+// merge order where two curated entries share a FilterName and the table order
+// disagrees with the alphabet: profiles (macos then ios) and accounts (users
+// then groups). Both loaders merge with maps.Copy in BackupResources order, so
+// the entry listed last wins a name collision. A walk of the tree visits
+// lexically and inverts both, which leaves the two sides keeping different
+// objects under one key — every field of the survivor reported as modified,
+// and the other object never compared at all.
+func TestLoadSnapshotFromDirectory_SharedBucketCollisionMatchesLiveOrder(t *testing.T) {
+	dir := t.TempDir()
+
+	// Each file records the leaf directory it came from, so the surviving
+	// object identifies which curated entry won.
+	writeBackupFileForTest(t, filepath.Join(dir, "profiles", "macos", "wifi.yaml"), map[string]any{
+		"general": map[string]any{"name": "Corporate Wi-Fi"}, "from": "macos",
+	}, "yaml")
+	writeBackupFileForTest(t, filepath.Join(dir, "profiles", "ios", "wifi.yaml"), map[string]any{
+		"general": map[string]any{"name": "Corporate Wi-Fi"}, "from": "ios",
+	}, "yaml")
+	writeBackupFileForTest(t, filepath.Join(dir, "accounts", "users", "admin.yaml"), map[string]any{
+		"name": "admin", "from": "users",
+	}, "yaml")
+	writeBackupFileForTest(t, filepath.Join(dir, "accounts", "groups", "admin.yaml"), map[string]any{
+		"name": "admin", "from": "groups",
+	}, "yaml")
+
+	// lastLeaf reads the winner out of the table instead of hard-coding it, so
+	// reordering BackupResources moves the expectation with it.
+	lastLeaf := func(filterName string) string {
+		leaf := ""
+		for _, r := range BackupResources {
+			if r.FilterName == filterName {
+				leaf = r.SubDir[strings.LastIndex(r.SubDir, "/")+1:]
+			}
+		}
+		return leaf
+	}
+
+	snapshot, err := loadSnapshotFromDirectory(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, tc := range []struct{ resource, objName string }{
+		{"profiles", "Corporate Wi-Fi"},
+		{"accounts", "admin"},
+	} {
+		obj, ok := snapshot[tc.resource][tc.objName]
+		if !ok {
+			t.Errorf("%s: %q missing from the merged bucket, got %v", tc.resource, tc.objName, snapshot[tc.resource])
+			continue
+		}
+		if want := lastLeaf(tc.resource); obj["from"] != want {
+			t.Errorf("%s: collision kept the object from %v, want %q (the entry listed last in BackupResources, which is what live mode keeps)", tc.resource, obj["from"], want)
+		}
+		if len(snapshot[tc.resource]) != 1 {
+			t.Errorf("%s: expected the collision to leave one object, got %d", tc.resource, len(snapshot[tc.resource]))
+		}
+	}
+}
+
+// TestLoadSnapshotFromDirectory_ObjectFilesInNestedParent covers a
+// hand-assembled tree that drops profiles straight into profiles/ rather than
+// profiles/macos: the parent directory name is already the FilterName, so its
+// files merge into the same bucket the curated subdirectories fill.
+func TestLoadSnapshotFromDirectory_ObjectFilesInNestedParent(t *testing.T) {
+	dir := t.TempDir()
+
+	writeBackupFileForTest(t, filepath.Join(dir, "profiles", "loose.yaml"), map[string]any{
+		"general": map[string]any{"name": "Loose Profile"},
+	}, "yaml")
+	writeBackupFileForTest(t, filepath.Join(dir, "profiles", "macos", "wifi.yaml"), map[string]any{
+		"general": map[string]any{"name": "WiFi"},
+	}, "yaml")
+
+	snapshot, err := loadSnapshotFromDirectory(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	profiles := snapshot["profiles"]
+	if len(profiles) != 2 {
+		t.Fatalf("expected the parent's files and the subdirectory's to merge, got %d: %v", len(profiles), profiles)
+	}
+	for _, want := range []string{"Loose Profile", "WiFi"} {
+		if _, ok := profiles[want]; !ok {
+			t.Errorf("expected %q in the profiles bucket", want)
+		}
+	}
+}
+
+// TestLoadSnapshotFromDirectory_UnreadableRootIsAnError keeps an unreadable
+// source out of the "no differences found" path. An empty snapshot there is not
+// a partial read, it is no read at all, and reporting it as agreement with exit
+// 0 is the same silent success this loader was fixed to remove.
+func TestLoadSnapshotFromDirectory_UnreadableRootIsAnError(t *testing.T) {
+	dir := unreadableBackupDirForTest(t)
+
+	if _, err := loadSnapshotFromDirectory(dir, nil); err == nil {
+		t.Error("expected an error for an unreadable source directory, got nil")
+	}
+}
+
+// TestRunDiff_UnreadableSourceDirectoryErrors is the same check at the command
+// boundary: a non-nil error is what gives the process a non-zero exit status,
+// which is what a CI gate reads.
+func TestRunDiff_UnreadableSourceDirectoryErrors(t *testing.T) {
+	src := unreadableBackupDirForTest(t)
+	tgt := t.TempDir()
+
+	if err := runDiff(context.Background(), diffOptions{Source: src, Target: tgt}); err == nil {
+		t.Error("expected runDiff to fail on an unreadable source, got nil (diff would print \"No differences found\" and exit 0)")
+	}
+}
+
+// unreadableBackupDirForTest returns a backup directory that stats as a
+// directory but cannot be listed: mode 0111 is searchable, not readable.
+func unreadableBackupDirForTest(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory permissions")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+
+	dir := filepath.Join(t.TempDir(), "backup")
+	writeBackupFileForTest(t, filepath.Join(dir, "policies", "test.yaml"), map[string]any{"name": "Test"}, "yaml")
+	if err := os.Chmod(dir, 0o111); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	return dir
 }

--- a/internal/commands/pro_diff_test.go
+++ b/internal/commands/pro_diff_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -642,5 +643,282 @@ func TestJSONRoundTrip(t *testing.T) {
 
 	if parsed["name"] != "Round Trip Script" {
 		t.Errorf("name mismatch: %v", parsed["name"])
+	}
+}
+
+// --- nested backup subdirectories (issue #331) ---
+
+// TestLoadSnapshotFromDirectory_NestedSubdirs covers the reported bug directly:
+// configuration profiles live two levels deep (profiles/macos, profiles/ios) and
+// were invisible to the directory loader, so `diff` reported no change.
+func TestLoadSnapshotFromDirectory_NestedSubdirs(t *testing.T) {
+	dir := t.TempDir()
+
+	writeBackupFileForTest(t, filepath.Join(dir, "profiles", "macos", "wifi.yaml"), map[string]any{
+		"general": map[string]any{"name": "WiFi", "description": "corp wifi"},
+	}, "yaml")
+	writeBackupFileForTest(t, filepath.Join(dir, "profiles", "ios", "vpn.yaml"), map[string]any{
+		"general": map[string]any{"name": "VPN", "description": "corp vpn"},
+	}, "yaml")
+
+	snapshot, err := loadSnapshotFromDirectory(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	profiles, ok := snapshot["profiles"]
+	if !ok {
+		t.Fatalf("expected 'profiles' in snapshot, got keys %v", snapshotKeys(snapshot))
+	}
+	// macOS and iOS profiles share one FilterName, so they must merge into one
+	// bucket — the same shape live mode produces.
+	if len(profiles) != 2 {
+		t.Fatalf("expected 2 merged profiles, got %d: %v", len(profiles), profiles)
+	}
+	for _, want := range []string{"WiFi", "VPN"} {
+		if _, ok := profiles[want]; !ok {
+			t.Errorf("expected profile %q in the merged bucket", want)
+		}
+	}
+	// The intermediate directory names must never become resource keys.
+	for _, unwanted := range []string{"macos", "ios"} {
+		if _, ok := snapshot[unwanted]; ok {
+			t.Errorf("directory %q leaked into the snapshot as a resource", unwanted)
+		}
+	}
+}
+
+// TestLoadSnapshotFromDirectory_EveryCuratedSubDirIsRead guards the whole bug
+// class rather than the one resource that was reported: every curated resource
+// must be discoverable at the path `backup` writes it to, bucketed under the
+// FilterName live mode uses. A new nested resource added to BackupResources
+// fails here if the loader cannot see it.
+func TestLoadSnapshotFromDirectory_EveryCuratedSubDirIsRead(t *testing.T) {
+	dir := t.TempDir()
+
+	want := make(map[string][]string)
+	for _, r := range BackupResources {
+		objName := "obj-" + r.Key
+		writeBackupFileForTest(t, filepath.Join(dir, filepath.FromSlash(r.SubDir), r.Key+".yaml"),
+			map[string]any{"name": objName}, "yaml")
+		want[r.FilterName] = append(want[r.FilterName], objName)
+	}
+
+	snapshot, err := loadSnapshotFromDirectory(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for filterName, objNames := range want {
+		bucket, ok := snapshot[filterName]
+		if !ok {
+			t.Errorf("resource %q missing from snapshot (keys: %v)", filterName, snapshotKeys(snapshot))
+			continue
+		}
+		for _, objName := range objNames {
+			if _, ok := bucket[objName]; !ok {
+				t.Errorf("resource %q: object %q not read from disk", filterName, objName)
+			}
+		}
+	}
+}
+
+// TestLoadSnapshotFromDirectory_NestedResourceFilter checks --resources still
+// selects by FilterName once the files it names sit two levels down.
+func TestLoadSnapshotFromDirectory_NestedResourceFilter(t *testing.T) {
+	dir := t.TempDir()
+
+	writeBackupFileForTest(t, filepath.Join(dir, "profiles", "macos", "wifi.yaml"), map[string]any{
+		"general": map[string]any{"name": "WiFi"},
+	}, "yaml")
+	writeBackupFileForTest(t, filepath.Join(dir, "smart-groups", "computers", "all.yaml"), map[string]any{
+		"name": "All Macs",
+	}, "yaml")
+
+	snapshot, err := loadSnapshotFromDirectory(dir, []string{"profiles"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := snapshot["profiles"]; !ok {
+		t.Error("expected nested 'profiles' to match filter 'profiles'")
+	}
+	if _, ok := snapshot["smart-groups"]; ok {
+		t.Error("smart-groups should be excluded when the filter is 'profiles'")
+	}
+}
+
+// TestLoadSnapshotFromDirectory_IgnoresPackageFiles pins the reason a resource
+// directory is not walked recursively: `backup --download-packages` writes
+// package binaries under packages/files, and those are not config objects.
+func TestLoadSnapshotFromDirectory_IgnoresPackageFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	writeBackupFileForTest(t, filepath.Join(dir, "packages", "chrome.yaml"), map[string]any{
+		"name": "Chrome.pkg",
+	}, "yaml")
+	filesDir := filepath.Join(dir, "packages", "files")
+	if err := os.MkdirAll(filesDir, 0o755); err != nil {
+		t.Fatalf("creating dirs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(filesDir, "manifest.json"), []byte(`{"name":"not a config object"}`), 0o644); err != nil {
+		t.Fatalf("writing package file: %v", err)
+	}
+
+	snapshot, err := loadSnapshotFromDirectory(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	packages := snapshot["packages"]
+	if len(packages) != 1 {
+		t.Fatalf("expected only the package record, got %d: %v", len(packages), packages)
+	}
+	if _, ok := packages["Chrome.pkg"]; !ok {
+		t.Errorf("expected 'Chrome.pkg', got %v", packages)
+	}
+	if _, ok := snapshot["files"]; ok {
+		t.Error("packages/files leaked into the snapshot as a resource")
+	}
+}
+
+// TestLoadSnapshotFromDirectory_UnknownTopLevelDirStillRead keeps the old
+// behaviour for directories outside the curated set — the SDK-backed resources
+// (blueprints, compliance-benchmarks) and hand-assembled trees.
+func TestLoadSnapshotFromDirectory_UnknownTopLevelDirStillRead(t *testing.T) {
+	dir := t.TempDir()
+
+	writeBackupFileForTest(t, filepath.Join(dir, "blueprints", "baseline.yaml"), map[string]any{
+		"name": "Baseline",
+	}, "yaml")
+
+	snapshot, err := loadSnapshotFromDirectory(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := snapshot["blueprints"]["Baseline"]; !ok {
+		t.Errorf("expected blueprints/Baseline, got %v", snapshot)
+	}
+}
+
+// TestRunDiff_NestedProfileModified is the end-to-end shape from the issue:
+// two backup directories differing only in one configuration profile.
+func TestRunDiff_NestedProfileModified(t *testing.T) {
+	srcDir := t.TempDir()
+	tgtDir := t.TempDir()
+
+	writeBackupFileForTest(t, filepath.Join(srcDir, "profiles", "macos", "wifi.yaml"), map[string]any{
+		"general": map[string]any{"name": "WiFi", "description": "old"},
+	}, "yaml")
+	writeBackupFileForTest(t, filepath.Join(tgtDir, "profiles", "macos", "wifi.yaml"), map[string]any{
+		"general": map[string]any{"name": "WiFi", "description": "new"},
+	}, "yaml")
+
+	src, err := loadSnapshotFromDirectory(srcDir, nil)
+	if err != nil {
+		t.Fatalf("loading src: %v", err)
+	}
+	tgt, err := loadSnapshotFromDirectory(tgtDir, nil)
+	if err != nil {
+		t.Fatalf("loading tgt: %v", err)
+	}
+
+	results := compareSnapshots(src, tgt)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 modified profile, got %d: %+v", len(results), results)
+	}
+	if results[0].Resource != "profiles" || results[0].Name != "WiFi" || results[0].Change != diffModified {
+		t.Errorf("unexpected result: %+v", results[0])
+	}
+}
+
+// --- backupObjectName ---
+
+// TestBackupObjectName_MatchesLiveNameExtraction asserts the directory loader
+// and the live loader agree on the snapshot key. They diverged for Classic
+// resources, whose detail nests the name under "general": the directory side
+// fell through to the filename stem (slugified, possibly de-duplicated) while
+// the live side used the real name, so every Classic object in a
+// directory-vs-instance diff was reported removed and added.
+func TestBackupObjectName_MatchesLiveNameExtraction(t *testing.T) {
+	tests := []struct {
+		name     string
+		detail   map[string]any // what backup wrote to disk
+		listItem map[string]any // what live mode lists
+		nameFld  string         // BackupEndpoint.NameField
+		stem     string
+	}{
+		{
+			name:     "modern resource with top-level name",
+			detail:   map[string]any{"name": "Deploy Chrome"},
+			listItem: map[string]any{"id": "3", "name": "Deploy Chrome"},
+			stem:     "deploy-chrome",
+		},
+		{
+			name:     "classic detail nests name under general",
+			detail:   map[string]any{"general": map[string]any{"name": "Corp WiFi"}},
+			listItem: map[string]any{"id": "7", "name": "Corp WiFi"},
+			stem:     "corp-wifi",
+		},
+		{
+			name:     "prestage uses displayName",
+			detail:   map[string]any{"displayName": "Standard Mac"},
+			listItem: map[string]any{"id": "1", "displayName": "Standard Mac"},
+			nameFld:  "displayName",
+			stem:     "standard-mac",
+		},
+		{
+			name:     "de-duplicated slug must not become the key",
+			detail:   map[string]any{"general": map[string]any{"name": "Corp WiFi"}},
+			listItem: map[string]any{"id": "9", "name": "Corp WiFi"},
+			stem:     "corp-wifi-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fromDisk := backupObjectName(tt.detail, tt.stem)
+			fromLive := extractName(tt.listItem, tt.nameFld, "")
+			if fromDisk != fromLive {
+				t.Errorf("snapshot keys disagree: directory %q vs live %q", fromDisk, fromLive)
+			}
+		})
+	}
+}
+
+func TestBackupObjectName_FallsBackToStem(t *testing.T) {
+	got := backupObjectName(map[string]any{"priority": float64(5)}, "productivity")
+	if got != "productivity" {
+		t.Errorf("expected filename stem 'productivity', got %q", got)
+	}
+}
+
+func snapshotKeys(s resourceSnapshot) []string {
+	keys := make([]string, 0, len(s))
+	for k := range s {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestLoadSnapshotFromDirectory_SymlinkedResourceDir keeps a capability the
+// pre-WalkDir loader had for free: os.ReadDir followed a symlinked resource
+// directory. WalkDir does not descend into symlinks, so they are read in place.
+func TestLoadSnapshotFromDirectory_SymlinkedResourceDir(t *testing.T) {
+	real := t.TempDir()
+	writeBackupFileForTest(t, filepath.Join(real, "shared-scripts", "deploy.yaml"), map[string]any{
+		"name": "Deploy Script",
+	}, "yaml")
+
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(real, "shared-scripts"), filepath.Join(dir, "scripts")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	snapshot, err := loadSnapshotFromDirectory(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := snapshot["scripts"]["Deploy Script"]; !ok {
+		t.Errorf("expected symlinked scripts directory to be read, got %v", snapshot)
 	}
 }

--- a/internal/commands/pro_resources.go
+++ b/internal/commands/pro_resources.go
@@ -186,3 +186,21 @@ func BackupFilterNames() []string {
 	sort.Strings(names)
 	return names
 }
+
+// BackupSubDirs maps each curated resource's on-disk subdirectory (relative to
+// the backup root, slash-separated) to the FilterName that owns it. `diff` uses
+// it to bucket files read off disk under exactly the key live mode uses, so a
+// directory and an instance are comparable.
+//
+// It matters because thirteen of the curated resources nest two levels deep
+// (profiles/macos, smart-groups/computers, accounts/users, …). `diff` used to
+// treat every top-level directory as a resource and read only the files sitting
+// directly inside it, so those thirteen contributed nothing to either snapshot
+// and their changes were reported as no change at all — silently, exit 0.
+func BackupSubDirs() map[string]string {
+	out := make(map[string]string, len(BackupResources))
+	for _, r := range BackupResources {
+		out[r.SubDir] = r.FilterName
+	}
+	return out
+}

--- a/internal/commands/pro_resources.go
+++ b/internal/commands/pro_resources.go
@@ -188,9 +188,11 @@ func BackupFilterNames() []string {
 }
 
 // BackupSubDirs maps each curated resource's on-disk subdirectory (relative to
-// the backup root, slash-separated) to the FilterName that owns it. `diff` uses
-// it to bucket files read off disk under exactly the key live mode uses, so a
-// directory and an instance are comparable.
+// the backup root, slash-separated) to the FilterName that owns it. `diff`
+// reads this table rather than walking the backup tree, so files off disk are
+// bucketed under exactly the key live mode uses and a directory and an instance
+// are comparable; it also uses the key set to tell which directories in the
+// backup root a curated resource already owns from those it must key by name.
 //
 // It matters because thirteen of the curated resources nest two levels deep
 // (profiles/macos, smart-groups/computers, accounts/users, …). `diff` used to


### PR DESCRIPTION
Fixes #331.

## The report

`pro diff --source <dir> --target <dir>` found changes in other resources but never in configuration profiles.

## Root cause

`loadSnapshotFromDirectory` walked exactly one level of subdirectories and `readObjectsFromSubdir` skips directory entries. But `backup` lays out each resource at its `SubDir`, and **thirteen** curated resources nest two levels:

```
profiles/macos            profiles/ios
prestages/computers       prestages/mobile
extension-attributes/{computer,mobile,user}
smart-groups/{computers,mobile}
static-groups/{computers,mobile}
accounts/{users,groups}
```

For `profiles/` the loader found zero files. A bucket is only added to the snapshot when it holds at least one object, so the key never appeared on **either** side and `compareSnapshots` had nothing to compare. Exit 0, no warning, output indistinguishable from "these two instances agree" — the worst failure shape a diff can have. Profiles were just the resource the reporter happened to change; prestages, extension attributes, smart groups, static groups and accounts were equally invisible.

Repro on `main` (synthetic tree, one changed `profiles/macos` profile, one changed `smart-groups/computers` group, one changed flat policy):

```
$ bin/jamf-cli pro diff --source ./a --target ./b
[ { "resource": "policies", "change": "modified", ... } ]   ← only the flat resource
exit=0
```

Same tree after this change reports all three, with real object names.

## Two adjacent mismatches from the same repro

- **The loaders bucketed under different keys.** Live mode buckets by `FilterName` (`profiles`), the directory loader by top-level directory name. Those strings coincide for flat resources — which is why the bug looked profile-specific. For nested ones, `diff --source ./backup --target production` had the key populated on one side only, so every profile came back `added` or `removed`.
- **Classic objects were keyed by filename stem.** The loader read `obj["name"]`, but a Classic detail nests its name under `general` and a prestage calls it `displayName`. The stem is `SlugifyName` output, possibly carrying a `DeduplicateSlug` suffix, so it never equals the name live mode takes from the list item — every Classic object in a directory-vs-instance diff was reported removed **and** added.

## The fix

- `BackupSubDirs()` (`pro_resources.go`) maps each `SubDir` → `FilterName`, so both loaders derive keys from one table instead of two conventions.
- `loadSnapshotFromDirectory` **reads that table instead of walking the tree**: one `os.ReadDir` of the backup root picks up the directories no curated `SubDir` claims — keyed by their own name, which carries `blueprints` / `compliance-benchmarks`, hand-assembled trees, and object files left directly in a nested parent (`profiles/*.yaml` beside `profiles/macos/`, where the directory name is already the `FilterName`) — then every `BackupResources` entry in slice order, read at `filepath.Join(dir, r.SubDir)`. A missing directory is skipped; an unreadable **root** is an error, not a warning.
- That is what makes the two loaders agree on more than the key. Both merge shared buckets with `maps.Copy` in `BackupResources` order, so the entry listed *last* wins a name collision on both sides — a macOS and an iOS profile both called `Corporate Wi-Fi` resolve to the same object on disk as they do live. A walk visits lexically and inverts that for `profiles` and `accounts`. Reading by path also bounds the read to the paths the table names (which is what keeps `packages/files`, holding downloaded package binaries, out of the snapshot) and drops the nested-parent bookkeeping, the `fs.SkipDir` handling and the depth assumptions with it.
- `backupObjectName` replaces the inline `obj["name"]` read and takes the resource's `BackupEndpoint.NameField` — checked first for the same reason `extractName` checks it first: it is where the resources that do not call their name `name` keep it (prestages `displayName`, mobile-device smart/static groups `groupName`). Then `name`, then the two shapes no registry field names (a Classic detail nesting its name under `general`, and `displayName` for a directory read without a `NameField`), then the filename stem.
- Following a **symlinked** resource directory is a capability this loader *adds*, not one it preserves: `os.ReadDir` reports a symlink-to-directory with `IsDir() == false`, so the old loader skipped it. Reading the curated resources by path follows them for free, and `entryIsDir` keeps the root-level scan consistent with that. Worth knowing when handed an untrusted tree — `diff` will read and print field values from outside it.

## Tests

Twelve new tests. The ones written to hold the line rather than the symptom:

- `TestLoadSnapshotFromDirectory_EveryCuratedSubDirIsRead` writes a file into **every** `BackupResource.SubDir` and asserts each is readable under its `FilterName` — a test over the table, so a nested resource added later cannot reintroduce the class.
- `TestLoadSnapshotFromDirectory_EveryCuratedNameFieldIsHonoured` does the same for the key: an object carrying *only* its resource's declared `NameField` must be keyed by that value, so a resource added later whose name lives somewhere new fails rather than silently falling back to the stem.
- `TestBackupObjectName_MatchesLiveNameExtraction` asserts the directory key equals `extractName` of the equivalent live list item; nothing else in the codebase forced the two loaders to agree.
- `TestLoadSnapshotFromDirectory_SharedBucketCollisionMatchesLiveOrder` pins the collision winner for `profiles` and `accounts` by reading it out of `BackupResources`, so reordering the table moves the expectation with it.
- `TestLoadSnapshotFromDirectory_UnreadableRootIsAnError` + `TestRunDiff_UnreadableSourceDirectoryErrors` keep an unreadable source out of the "No differences found" path, at the loader and at the command boundary.

Every new test was verified to fail against the behaviour it pins (the one-level walk, a `backupObjectName` without the `NameField` branch, a lexically-ordered curated pass, a root scan that skips nested parents, and a root read that only warns) and pass after. `make test`, `make lint` (0 issues) and `make verify-generated` all clean; end-to-end re-checked with the built binary — three nested/flat resources reported, and an unreadable source now exits 1 instead of printing "No differences found".

Postmortem: `docs/solutions/logic-errors/diff-missed-nested-backup-subdirs-2026-08-19.md`.

Note: no change to `backup`'s on-disk layout — existing backup directories diff correctly as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)