### PR TITLE
feat(pro report): add --bundle-id and --path to software-installs

### DIFF
--- a/docs/site/examples.json
+++ b/docs/site/examples.json
@@ -271,6 +271,14 @@
     {
       "description": "Include system apps",
       "command": "jamf-cli pro report software-installs --include-system"
+    },
+    {
+      "description": "Report a row per bundle ID",
+      "command": "jamf-cli pro report software-installs --bundle-id"
+    },
+    {
+      "description": "Report a row per install path",
+      "command": "jamf-cli pro report software-installs --path"
     }
   ],
   "pro report update-status": [

--- a/internal/commands/pro_report_software.go
+++ b/internal/commands/pro_report_software.go
@@ -39,6 +39,10 @@ merged row. Neither flag is on by default, so the default output is unchanged.
 
 Output columns: title, version, device_count (plus bundle_id with --bundle-id,
 path with --path)`,
+		// --bundle-id and --path are boolean, so their names invite a value that
+		// cobra would leave as a positional. Without this the whole report runs
+		// as if the value had never been typed.
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rows, err := runReportSoftwareInstalls(cmd.Context(), cliCtx.Client, titleFilter, includeSystem, showBundleID, showPath)
 			if err != nil {

--- a/internal/commands/pro_report_software.go
+++ b/internal/commands/pro_report_software.go
@@ -18,6 +18,8 @@ func newReportSoftwareInstallsCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	var (
 		titleFilter   string
 		includeSystem bool
+		showBundleID  bool
+		showPath      bool
 	)
 
 	cmd := &cobra.Command{
@@ -30,9 +32,15 @@ Use --include-system to show all applications.
 
 Use --title to filter to a specific application name (case-insensitive substring match).
 
-Output columns: title, version, device_count`,
+Use --bundle-id to add a bundle_id column, and --path to add a path column.
+Each also becomes part of the grouping, so one title and version that spans
+several bundle IDs or install paths reports a row for each rather than a single
+merged row. Neither flag is on by default, so the default output is unchanged.
+
+Output columns: title, version, device_count (plus bundle_id with --bundle-id,
+path with --path)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			rows, err := runReportSoftwareInstalls(cmd.Context(), cliCtx.Client, titleFilter, includeSystem)
+			rows, err := runReportSoftwareInstalls(cmd.Context(), cliCtx.Client, titleFilter, includeSystem, showBundleID, showPath)
 			if err != nil {
 				return err
 			}
@@ -43,6 +51,8 @@ Output columns: title, version, device_count`,
 
 	cmd.Flags().StringVar(&titleFilter, "title", "", "filter to application names containing this substring (case-insensitive)")
 	cmd.Flags().BoolVar(&includeSystem, "include-system", false, "include system apps from /System/ and /Library/")
+	cmd.Flags().BoolVar(&showBundleID, "bundle-id", false, "add a bundle_id column and group by bundle ID")
+	cmd.Flags().BoolVar(&showPath, "path", false, "add a path column and group by install path")
 
 	return cmd
 }
@@ -57,14 +67,20 @@ func isSystemApp(path string) bool {
 }
 
 // softwareKey groups installs by application name + version.
+//
+// --bundle-id and --path extend this key rather than adding a display column:
+// one title + version can span several bundle IDs or install paths, and a
+// column would print one arbitrary member and silently hide the rest.
 type softwareKey struct {
-	title   string
-	version string
+	title    string
+	version  string
+	bundleID string
+	path     string
 }
 
 // runReportSoftwareInstalls fetches computer inventory with the APPLICATIONS
-// section and aggregates device counts per (title, version).
-func runReportSoftwareInstalls(ctx context.Context, client registry.HTTPClient, titleFilter string, includeSystem bool) ([]map[string]any, error) {
+// section and aggregates device counts per softwareKey.
+func runReportSoftwareInstalls(ctx context.Context, client registry.HTTPClient, titleFilter string, includeSystem, showBundleID, showPath bool) ([]map[string]any, error) {
 	computers, err := FetchAllPaginated(ctx, client, "/v4/computers-inventory?section=APPLICATIONS", 100)
 	if err != nil {
 		return nil, fmt.Errorf("fetching computer inventory: %w", err)
@@ -83,6 +99,7 @@ func runReportSoftwareInstalls(ctx context.Context, client registry.HTTPClient, 
 			name, _ := app["name"].(string)
 			version, _ := app["version"].(string)
 			path, _ := app["path"].(string)
+			bundleID, _ := app["bundleId"].(string)
 
 			if name == "" {
 				continue
@@ -94,7 +111,14 @@ func runReportSoftwareInstalls(ctx context.Context, client registry.HTTPClient, 
 				continue
 			}
 
-			counts[softwareKey{name, version}]++
+			key := softwareKey{title: name, version: version}
+			if showBundleID {
+				key.bundleID = bundleID
+			}
+			if showPath {
+				key.path = path
+			}
+			counts[key]++
 		}
 	}
 
@@ -107,16 +131,29 @@ func runReportSoftwareInstalls(ctx context.Context, client registry.HTTPClient, 
 		if keys[i].title != keys[j].title {
 			return keys[i].title < keys[j].title
 		}
-		return keys[i].version > keys[j].version
+		if keys[i].version != keys[j].version {
+			return keys[i].version > keys[j].version
+		}
+		if keys[i].bundleID != keys[j].bundleID {
+			return keys[i].bundleID < keys[j].bundleID
+		}
+		return keys[i].path < keys[j].path
 	})
 
 	rows := make([]map[string]any, 0, len(keys))
 	for _, k := range keys {
-		rows = append(rows, map[string]any{
+		row := map[string]any{
 			"title":        k.title,
 			"version":      k.version,
 			"device_count": counts[k],
-		})
+		}
+		if showBundleID {
+			row["bundle_id"] = k.bundleID
+		}
+		if showPath {
+			row["path"] = k.path
+		}
+		rows = append(rows, row)
 	}
 
 	if len(rows) == 0 && titleFilter != "" {

--- a/internal/commands/pro_report_test.go
+++ b/internal/commands/pro_report_test.go
@@ -4,7 +4,11 @@ package commands
 
 import (
 	"context"
+	"io"
+	"strings"
 	"testing"
+
+	"github.com/Jamf-Concepts/jamf-cli/internal/exitcode"
 )
 
 // ---------------------------------------------------------------------------
@@ -876,6 +880,203 @@ func TestRunReportSoftwareInstalls_BundleIDAndPathTogether(t *testing.T) {
 		if r["device_count"] != 1 {
 			t.Errorf("row %v device_count = %v, want 1", r, r["device_count"])
 		}
+	}
+}
+
+// --bundle-id and --path are boolean, so `--path /Applications/Foo.app` leaves
+// the value as a positional. Before Args was set the command discarded it and
+// ran the whole report, so the operator got fleet-wide output for what they had
+// typed as a filter. Cobra validates Args ahead of PersistentPreRunE, so the
+// refusal lands before any credential is resolved or request sent.
+func TestReportSoftwareInstalls_StrayPositionalIsRefused(t *testing.T) {
+	root := NewRootCmd("test", "none", "none", "none")
+	root.SetArgs([]string{"pro", "report", "software-installs", "junkarg"})
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+
+	err := ClassifyError(root.Execute())
+	if err == nil {
+		t.Fatal("expected an error for a stray positional, got nil")
+	}
+	if code := exitcode.CodeFrom(err); code != exitcode.Usage {
+		t.Errorf("exit code = %d, want %d (usage)", code, exitcode.Usage)
+	}
+	if !strings.Contains(err.Error(), `unknown command "junkarg"`) {
+		t.Errorf("error should name the stray argument, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "fetching computer inventory") {
+		t.Errorf("the report ran despite the stray positional: %q", err.Error())
+	}
+}
+
+// The comparator has four levels and nothing asserted row order at all, so a
+// control mutation flipping even the original title comparison left every test
+// green. This fixture puts a tie at each level in turn: two titles, two
+// versions inside one title, two bundle IDs inside one title and version, and
+// two paths inside one title, version and bundle ID. Both flags are on because
+// the path level is unreachable otherwise — with --path off every key holds the
+// same empty path, so any two keys reaching that comparison are the same key.
+func TestRunReportSoftwareInstalls_RowOrderFollowsEveryComparatorLevel(t *testing.T) {
+	client := &paginatedMockClient{
+		pages: map[string]string{
+			"/v4/computers-inventory?section=APPLICATIONS&page=0&page-size=100": `{
+				"totalCount": 1,
+				"results": [
+					{
+						"id": "1",
+						"applications": [
+							{"name": "Zulu", "version": "1.0", "bundleId": "com.z.one", "path": "/Applications/Z1.app"},
+							{"name": "Alpha", "version": "1.0", "bundleId": "com.a.one", "path": "/Applications/A1.app"},
+							{"name": "Alpha", "version": "2.0", "bundleId": "com.b.two", "path": "/Applications/A1.app"},
+							{"name": "Alpha", "version": "2.0", "bundleId": "com.a.one", "path": "/Applications/A2.app"},
+							{"name": "Alpha", "version": "2.0", "bundleId": "com.a.one", "path": "/Applications/A1.app"}
+						]
+					}
+				]
+			}`,
+		},
+	}
+
+	rows, err := runReportSoftwareInstalls(context.Background(), client, "", true, true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := [][4]string{
+		{"Alpha", "2.0", "com.a.one", "/Applications/A1.app"},
+		{"Alpha", "2.0", "com.a.one", "/Applications/A2.app"},
+		{"Alpha", "2.0", "com.b.two", "/Applications/A1.app"},
+		{"Alpha", "1.0", "com.a.one", "/Applications/A1.app"},
+		{"Zulu", "1.0", "com.z.one", "/Applications/Z1.app"},
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("got %d rows, want %d", len(rows), len(want))
+	}
+	for i, w := range want {
+		got := [4]string{
+			rows[i]["title"].(string),
+			rows[i]["version"].(string),
+			rows[i]["bundle_id"].(string),
+			rows[i]["path"].(string),
+		}
+		if got != w {
+			t.Errorf("row %d = %v, want %v", i, got, w)
+		}
+	}
+}
+
+// The row builder gates bundle_id on the flag, never on whether the value is
+// empty, so an application the wire reports with no bundleId still gets a row
+// and still carries the column. Gating on emptiness instead would drop it and
+// take the column with it, since a table's columns are the keys of its first
+// row.
+func TestRunReportSoftwareInstalls_AppWithNoBundleIDKeepsTheKeyWithAnEmptyValue(t *testing.T) {
+	client := &paginatedMockClient{
+		pages: map[string]string{
+			"/v4/computers-inventory?section=APPLICATIONS&page=0&page-size=100": `{
+				"totalCount": 3,
+				"results": [
+					{
+						"id": "1",
+						"applications": [
+							{"name": "Zoom", "version": "5.0", "bundleId": "us.zoom.xos", "path": "/Applications/zoom.us.app"}
+						]
+					},
+					{
+						"id": "2",
+						"applications": [
+							{"name": "Zoom", "version": "5.0", "path": "/Applications/zoom.us.app"}
+						]
+					},
+					{
+						"id": "3",
+						"applications": [
+							{"name": "Zoom", "version": "5.0", "path": "/Applications/zoom.us.app"}
+						]
+					}
+				]
+			}`,
+		},
+	}
+
+	rows, err := runReportSoftwareInstalls(context.Background(), client, "", true, true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (the app with no bundleId keeps its own row)", len(rows))
+	}
+
+	var nameless map[string]any
+	for _, r := range rows {
+		v, ok := r["bundle_id"]
+		if !ok {
+			t.Fatalf("row %v carries no bundle_id key", r)
+		}
+		if v == "" {
+			nameless = r
+		}
+	}
+	if nameless == nil {
+		t.Fatalf("no row for the app with no bundleId, got %v", rows)
+	}
+	if nameless["device_count"] != 2 {
+		t.Errorf("empty bundle_id device_count = %v, want 2", nameless["device_count"])
+	}
+}
+
+// The grouping and row-building halves are the same shape as the bundle-ID
+// case, but an empty path has one consumer a missing bundleId has none of:
+// isSystemApp("") is false, so a path-less application is never filtered as a
+// system app and reaches the report even in the default output. This pins that
+// combination — includeSystem off, --path on, a row with an empty path.
+func TestRunReportSoftwareInstalls_AppWithNoPathSurvivesTheDefaultSystemFilter(t *testing.T) {
+	client := &paginatedMockClient{
+		pages: map[string]string{
+			"/v4/computers-inventory?section=APPLICATIONS&page=0&page-size=100": `{
+				"totalCount": 2,
+				"results": [
+					{
+						"id": "1",
+						"applications": [
+							{"name": "Slack", "version": "4.0", "path": "/Applications/Slack.app"},
+							{"name": "Slack", "version": "4.0"}
+						]
+					},
+					{
+						"id": "2",
+						"applications": [
+							{"name": "Slack", "version": "4.0"}
+						]
+					}
+				]
+			}`,
+		},
+	}
+
+	rows, err := runReportSoftwareInstalls(context.Background(), client, "", false, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (the app with no path keeps its own row)", len(rows))
+	}
+
+	var pathless map[string]any
+	for _, r := range rows {
+		v, ok := r["path"]
+		if !ok {
+			t.Fatalf("row %v carries no path key", r)
+		}
+		if v == "" {
+			pathless = r
+		}
+	}
+	if pathless == nil {
+		t.Fatalf("no row for the app with no path, got %v", rows)
+	}
+	if pathless["device_count"] != 2 {
+		t.Errorf("empty path device_count = %v, want 2", pathless["device_count"])
 	}
 }
 

--- a/internal/commands/pro_report_test.go
+++ b/internal/commands/pro_report_test.go
@@ -575,7 +575,7 @@ func TestRunReportSoftwareInstalls_Basic(t *testing.T) {
 		},
 	}
 
-	rows, err := runReportSoftwareInstalls(context.Background(), client, "", true)
+	rows, err := runReportSoftwareInstalls(context.Background(), client, "", true, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -620,7 +620,7 @@ func TestRunReportSoftwareInstalls_TitleFilter(t *testing.T) {
 		},
 	}
 
-	rows, err := runReportSoftwareInstalls(context.Background(), client, "chrome", true)
+	rows, err := runReportSoftwareInstalls(context.Background(), client, "chrome", true, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -647,7 +647,7 @@ func TestRunReportSoftwareInstalls_NoMatchFilter(t *testing.T) {
 		},
 	}
 
-	_, err := runReportSoftwareInstalls(context.Background(), client, "nonexistent-app-xyz", true)
+	_, err := runReportSoftwareInstalls(context.Background(), client, "nonexistent-app-xyz", true, false, false)
 	if err == nil {
 		t.Fatal("expected error for no matches with filter, got nil")
 		return
@@ -661,12 +661,221 @@ func TestRunReportSoftwareInstalls_Empty(t *testing.T) {
 		},
 	}
 
-	rows, err := runReportSoftwareInstalls(context.Background(), client, "", true)
+	rows, err := runReportSoftwareInstalls(context.Background(), client, "", true, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(rows) != 0 {
 		t.Errorf("got %d rows, want 0", len(rows))
+	}
+}
+
+// --bundle-id must extend the grouping key, not merely add a column: these two
+// installs share a title and version, so a display-only column would collapse
+// them into one row and hide a bundle ID.
+func TestRunReportSoftwareInstalls_BundleIDExtendsTheGroupingKey(t *testing.T) {
+	client := &paginatedMockClient{
+		pages: map[string]string{
+			"/v4/computers-inventory?section=APPLICATIONS&page=0&page-size=100": `{
+				"totalCount": 3,
+				"results": [
+					{
+						"id": "1",
+						"applications": [
+							{"name": "Zoom", "version": "5.0", "bundleId": "us.zoom.xos", "path": "/Applications/zoom.us.app"}
+						]
+					},
+					{
+						"id": "2",
+						"applications": [
+							{"name": "Zoom", "version": "5.0", "bundleId": "us.zoom.xos", "path": "/Applications/zoom.us.app"}
+						]
+					},
+					{
+						"id": "3",
+						"applications": [
+							{"name": "Zoom", "version": "5.0", "bundleId": "com.example.zoom-repack", "path": "/Applications/zoom.us.app"}
+						]
+					}
+				]
+			}`,
+		},
+	}
+
+	rows, err := runReportSoftwareInstalls(context.Background(), client, "", true, true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (one per bundle ID)", len(rows))
+	}
+
+	counts := map[string]any{}
+	for _, r := range rows {
+		bundleID, ok := r["bundle_id"].(string)
+		if !ok {
+			t.Fatalf("row %v carries no bundle_id", r)
+		}
+		counts[bundleID] = r["device_count"]
+	}
+	if counts["us.zoom.xos"] != 2 {
+		t.Errorf("us.zoom.xos device_count = %v, want 2", counts["us.zoom.xos"])
+	}
+	if counts["com.example.zoom-repack"] != 1 {
+		t.Errorf("com.example.zoom-repack device_count = %v, want 1", counts["com.example.zoom-repack"])
+	}
+}
+
+// Same shape as the bundle-ID case, for --path: one title and version installed
+// at two different paths must not merge.
+func TestRunReportSoftwareInstalls_PathExtendsTheGroupingKey(t *testing.T) {
+	client := &paginatedMockClient{
+		pages: map[string]string{
+			"/v4/computers-inventory?section=APPLICATIONS&page=0&page-size=100": `{
+				"totalCount": 3,
+				"results": [
+					{
+						"id": "1",
+						"applications": [
+							{"name": "Slack", "version": "4.0", "path": "/Applications/Slack.app"}
+						]
+					},
+					{
+						"id": "2",
+						"applications": [
+							{"name": "Slack", "version": "4.0", "path": "/Applications/Slack.app"}
+						]
+					},
+					{
+						"id": "3",
+						"applications": [
+							{"name": "Slack", "version": "4.0", "path": "/Users/bob/Applications/Slack.app"}
+						]
+					}
+				]
+			}`,
+		},
+	}
+
+	rows, err := runReportSoftwareInstalls(context.Background(), client, "", true, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (one per install path)", len(rows))
+	}
+
+	counts := map[string]any{}
+	for _, r := range rows {
+		path, ok := r["path"].(string)
+		if !ok {
+			t.Fatalf("row %v carries no path", r)
+		}
+		counts[path] = r["device_count"]
+	}
+	if counts["/Applications/Slack.app"] != 2 {
+		t.Errorf("/Applications/Slack.app device_count = %v, want 2", counts["/Applications/Slack.app"])
+	}
+	if counts["/Users/bob/Applications/Slack.app"] != 1 {
+		t.Errorf("/Users/bob/Applications/Slack.app device_count = %v, want 1", counts["/Users/bob/Applications/Slack.app"])
+	}
+}
+
+// With both flags off the row map must carry exactly the three original keys —
+// an extra key would change the column set of every existing user's table.
+func TestRunReportSoftwareInstalls_DefaultRowsCarryOnlyTheThreeOriginalKeys(t *testing.T) {
+	client := &paginatedMockClient{
+		pages: map[string]string{
+			"/v4/computers-inventory?section=APPLICATIONS&page=0&page-size=100": `{
+				"totalCount": 1,
+				"results": [
+					{
+						"id": "1",
+						"applications": [
+							{"name": "Zoom", "version": "5.0", "bundleId": "us.zoom.xos", "path": "/Applications/zoom.us.app"},
+							{"name": "Slack", "version": "4.0", "bundleId": "com.tinyspeck.slackmacgap", "path": "/Applications/Slack.app"}
+						]
+					}
+				]
+			}`,
+		},
+	}
+
+	rows, err := runReportSoftwareInstalls(context.Background(), client, "", true, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	for _, r := range rows {
+		if len(r) != 3 {
+			t.Errorf("row %v has %d keys, want 3", r, len(r))
+		}
+		if _, ok := r["bundle_id"]; ok {
+			t.Errorf("row %v carries bundle_id with --bundle-id off", r)
+		}
+		if _, ok := r["path"]; ok {
+			t.Errorf("row %v carries path with --path off", r)
+		}
+		for _, want := range []string{"title", "version", "device_count"} {
+			if _, ok := r[want]; !ok {
+				t.Errorf("row %v is missing key %q", r, want)
+			}
+		}
+	}
+}
+
+// Both flags on: the two fields are independent parts of the key, so one title
+// and version spanning two bundle IDs and two paths reports a row per pair.
+func TestRunReportSoftwareInstalls_BundleIDAndPathTogether(t *testing.T) {
+	client := &paginatedMockClient{
+		pages: map[string]string{
+			"/v4/computers-inventory?section=APPLICATIONS&page=0&page-size=100": `{
+				"totalCount": 3,
+				"results": [
+					{
+						"id": "1",
+						"applications": [
+							{"name": "Zoom", "version": "5.0", "bundleId": "us.zoom.xos", "path": "/Applications/zoom.us.app"}
+						]
+					},
+					{
+						"id": "2",
+						"applications": [
+							{"name": "Zoom", "version": "5.0", "bundleId": "us.zoom.xos", "path": "/Users/bob/Applications/zoom.us.app"}
+						]
+					},
+					{
+						"id": "3",
+						"applications": [
+							{"name": "Zoom", "version": "5.0", "bundleId": "com.example.zoom-repack", "path": "/Applications/zoom.us.app"}
+						]
+					}
+				]
+			}`,
+		},
+	}
+
+	rows, err := runReportSoftwareInstalls(context.Background(), client, "", true, true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3 (one per bundle ID + path pair)", len(rows))
+	}
+	for _, r := range rows {
+		if len(r) != 5 {
+			t.Errorf("row %v has %d keys, want 5", r, len(r))
+		}
+		for _, want := range []string{"title", "version", "device_count", "bundle_id", "path"} {
+			if _, ok := r[want]; !ok {
+				t.Errorf("row %v is missing key %q", r, want)
+			}
+		}
+		if r["device_count"] != 1 {
+			t.Errorf("row %v device_count = %v, want 1", r, r["device_count"])
+		}
 	}
 }
 

--- a/internal/commands/pro_report_test.go
+++ b/internal/commands/pro_report_test.go
@@ -787,17 +787,31 @@ func TestRunReportSoftwareInstalls_PathExtendsTheGroupingKey(t *testing.T) {
 
 // With both flags off the row map must carry exactly the three original keys —
 // an extra key would change the column set of every existing user's table.
+//
+// The grouping key is the other half of that contract, and it needs a fixture
+// that can see it. Zoom 5.0 spans two bundle IDs and two paths across two
+// devices, so an unconditional key.bundleID or key.path splits it into two
+// rows. With one bundle ID and one path per title the row count was 2 either
+// way, and assigning both fields unconditionally left the whole package green
+// while the default output rendered Zoom 5.0 twice at half the device count —
+// two byte-identical rows with no column that could explain them.
 func TestRunReportSoftwareInstalls_DefaultRowsCarryOnlyTheThreeOriginalKeys(t *testing.T) {
 	client := &paginatedMockClient{
 		pages: map[string]string{
 			"/v4/computers-inventory?section=APPLICATIONS&page=0&page-size=100": `{
-				"totalCount": 1,
+				"totalCount": 2,
 				"results": [
 					{
 						"id": "1",
 						"applications": [
 							{"name": "Zoom", "version": "5.0", "bundleId": "us.zoom.xos", "path": "/Applications/zoom.us.app"},
 							{"name": "Slack", "version": "4.0", "bundleId": "com.tinyspeck.slackmacgap", "path": "/Applications/Slack.app"}
+						]
+					},
+					{
+						"id": "2",
+						"applications": [
+							{"name": "Zoom", "version": "5.0", "bundleId": "com.example.zoom-repack", "path": "/Users/bob/Applications/zoom.us.app"}
 						]
 					}
 				]
@@ -810,7 +824,7 @@ func TestRunReportSoftwareInstalls_DefaultRowsCarryOnlyTheThreeOriginalKeys(t *t
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(rows) != 2 {
-		t.Fatalf("got %d rows, want 2", len(rows))
+		t.Fatalf("got %d rows, want 2 (both Zoom installs merge with the flags off)", len(rows))
 	}
 	for _, r := range rows {
 		if len(r) != 3 {
@@ -827,6 +841,21 @@ func TestRunReportSoftwareInstalls_DefaultRowsCarryOnlyTheThreeOriginalKeys(t *t
 				t.Errorf("row %v is missing key %q", r, want)
 			}
 		}
+	}
+
+	counts := map[string]any{}
+	for _, r := range rows {
+		title, ok := r["title"].(string)
+		if !ok {
+			t.Fatalf("row %v carries no title", r)
+		}
+		counts[title] = r["device_count"]
+	}
+	if counts["Zoom"] != 2 {
+		t.Errorf("Zoom device_count = %v, want 2", counts["Zoom"])
+	}
+	if counts["Slack"] != 1 {
+		t.Errorf("Slack device_count = %v, want 1", counts["Slack"])
 	}
 }
 
@@ -889,7 +918,15 @@ func TestRunReportSoftwareInstalls_BundleIDAndPathTogether(t *testing.T) {
 // typed as a filter. Cobra validates Args ahead of PersistentPreRunE, so the
 // refusal lands before any credential is resolved or request sent.
 func TestReportSoftwareInstalls_StrayPositionalIsRefused(t *testing.T) {
-	root := NewRootCmd("test", "none", "none", "none")
+	// This test executes the real root command. With the Args guard regressed
+	// and a developer's own credentials exported, it ran the paginated
+	// computers-inventory fetch for real — a fleet inventory sweep against
+	// whatever tenant the ambient environment named, out of `go test ./...`.
+	clearAuthEnv(t)
+
+	// "unknown" is the only spec version checkTenantVersion returns early for,
+	// and no assertion below reads the argument that carries it.
+	root := NewRootCmd("test", "abc123", "2024-01-01", "unknown")
 	root.SetArgs([]string{"pro", "report", "software-installs", "junkarg"})
 	root.SetOut(io.Discard)
 	root.SetErr(io.Discard)


### PR DESCRIPTION
Closes #325.

`pro report software-installs` reported three columns: `title`, `version`, `device_count`. This adds `--bundle-id` and `--path`, which report an application's bundle identifier and its install path.

Both fields were already on the wire. The `ComputerApplication` schema declares `bundleId` and `path`, and the function already read `path` to feed `isSystemApp`. No spec change and no regeneration are needed.

## Each flag extends the grouping key

This is the correctness point of the change. One title and version can map to several bundle identifiers or several install paths — a repackaged application, or the same application installed in two locations. A display-only column would print one arbitrary member of the group and hide the rest, with nothing in the output to reveal it. So each flag joins the aggregation key:

```
$ jamf-cli pro report software-installs --title Zoom --bundle-id -o table
 BUNDLE_ID                DEVICE_COUNT  TITLE  VERSION
 com.example.zoom-repack  1             Zoom   5.0
 us.zoom.xos              2             Zoom   5.0
```

Without the flag those three installs are one row reading `3` for `Zoom 5.0`.

Column order is alphabetical. The table formatter reads its column set from `sortedKeys(rows[0])`, which floats only `id` and `name`, so every table in this CLI orders the rest that way. Use `--select title,version,bundle_id,device_count` for a different order.

`softwareKey` gains `bundleID` and `path`, left at the zero value when the flag is off, so the counting loop keys itself correctly in all four flag combinations with no branching. Sorting gained tie-breakers on bundle identifier then path, because a title and version can now span rows.

## The default output is unchanged

The row builder gates each optional key on the flag, never on whether the value is empty. A table's columns are the keys of its first row, so an emptiness gate would make the column set depend on sort order, and an application with no `bundleId` on the wire would drop the column for every row. Both flags are off by default, so anything parsing the current three columns is unaffected. A test asserts that the default rows carry exactly those three keys and no more.

## Flag names

Kebab-case, matching `--include-system` and every other flag in this CLI. The issue text asks for `--bundle_id`; snake_case would be the only such flag in the binary. `--path` covers the `--file_path` request in the issue comment.

## Tests

Four cases beside the existing four:

- `TestRunReportSoftwareInstalls_BundleIDExtendsTheGroupingKey`
- `TestRunReportSoftwareInstalls_PathExtendsTheGroupingKey`
- `TestRunReportSoftwareInstalls_DefaultRowsCarryOnlyTheThreeOriginalKeys`
- `TestRunReportSoftwareInstalls_BundleIDAndPathTogether`

The first two are the ones that fail if the grouping is ever reduced to a display column. That was confirmed by mutation: discarding the two key assignments makes exactly the grouping tests fail, and no others.

`make test` passes in full with zero failures. `go vet ./internal/commands/` is clean. `make verify-site` and `make verify-site-output` both pass, since the change touches `docs/site`.

## Second commit, from review

A deep review found one confirmed defect and two real test gaps.

Both flags are boolean and both names invite a value, so `--path /Applications/Foo.app` set the flag and left the path as a positional argument, which the command discarded in silence and then reported the whole fleet. The operator got fleet-wide output for what they had typed as a filter. `Args: cobra.NoArgs` refuses it: cobra reports it as `unknown command`, which `ClassifyError` already maps to exit 2, and `ValidateArgs` runs ahead of `PersistentPreRunE`, so the refusal lands before any credential resolves or any request is sent.

The hole itself is repo-wide and pre-existing — `pro report inventory-summary junkarg` and `pro categories list junkarg` swallow a positional the same way — so the fix is scoped to the one command whose new flag names make a latent hole reachable. The general case deserves its own change.

The two test gaps: nothing in this file asserted row order at all, so the new tie-breakers were unobservable, and neither empty-value case was covered. `TestRunReportSoftwareInstalls_RowOrderFollowsEveryComparatorLevel` puts a tie at each of the four comparator levels and pins the full sequence; flipping any level in turn fails it. Two further tests cover an application the wire reports with no `bundleId` and one with no `path`, both of which still get a row carrying the column, because the row builder gates on the flag rather than on the value. Mutating either gate to test the value fails them.

The two flags also joined `docs/site/examples.json`. No test validates that file, so it was checked by parsing it, comparing its key set against every other entry, and running both documented commands.

The command needs a live Jamf Pro tenant, so the fixture-client tests are the runtime evidence for the aggregation. The rendered `--help` was checked on the built binary.

`make lint` was not run. The `golangci-lint` on the development machine is built with go1.26.2 while `go.mod` targets 1.27.0, so it aborts at config load before it reads any file. CI installs its own version and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
