### PR TITLE
fix: honor --out-file for protect exports and scaffolds (#357)

### DIFF
--- a/internal/commands/pro_blueprints.go
+++ b/internal/commands/pro_blueprints.go
@@ -163,7 +163,7 @@ Examples:
 					}
 					bp.Steps[0].Components = comps
 				}
-				return printScaffold(bp)
+				return printScaffold(cliCtx, bp)
 			}
 			if err := requirePlatformClient(cliCtx); err != nil {
 				return err
@@ -364,7 +364,7 @@ Multi-instance fan-out:
 			if err != nil {
 				return err
 			}
-			return printExport(blueprintToExport(ctx, cliCtx.PlatformSDKClient, bp))
+			return printExport(cliCtx, blueprintToExport(ctx, cliCtx.PlatformSDKClient, bp))
 		},
 	}
 	cmd.Flags().StringVar(&nameFlag, "name", "", "Look up blueprint by name")
@@ -639,7 +639,7 @@ func newBlueprintsComponentsCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	}
 	cmd.AddCommand(newBlueprintsComponentsListCmd(cliCtx))
 	cmd.AddCommand(newBlueprintsComponentsGetCmd(cliCtx))
-	cmd.AddCommand(newBlueprintsComponentsScaffoldCmd())
+	cmd.AddCommand(newBlueprintsComponentsScaffoldCmd(cliCtx))
 	cmd.AddCommand(newBlueprintsComponentsConfigProfileCmd(cliCtx))
 	cmd.AddCommand(newBlueprintsComponentsConfigProfilePlistCmd())
 	return cmd
@@ -733,7 +733,7 @@ The source scope is copied by default. Use --scope to override device group targ
 	return cmd
 }
 
-func newBlueprintsComponentsScaffoldCmd() *cobra.Command {
+func newBlueprintsComponentsScaffoldCmd(cliCtx *registry.CLIContext) *cobra.Command {
 	return &cobra.Command{
 		Use:   "scaffold <identifier>",
 		Short: "Print example configuration JSON for a component",
@@ -763,7 +763,7 @@ Examples:
 				"identifier":    identifier,
 				"configuration": json.RawMessage(scaffold),
 			}
-			return printScaffold(block)
+			return printScaffold(cliCtx, block)
 		},
 	}
 }

--- a/internal/commands/pro_compliance_benchmarks.go
+++ b/internal/commands/pro_compliance_benchmarks.go
@@ -90,7 +90,7 @@ func newCBApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Long:  "Create a new compliance benchmark from a JSON/YAML definition. Benchmarks cannot be updated after creation.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printScaffold(benchmarkScaffold())
+				return printScaffold(cliCtx, benchmarkScaffold())
 			}
 			if err := requirePlatformClient(cliCtx); err != nil {
 				return err
@@ -204,7 +204,7 @@ func newCBExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			for _, g := range groups {
 				groupByID[g.ID] = g
 			}
-			return printExport(benchmarkToPortable(bm, groupByID))
+			return printExport(cliCtx, benchmarkToPortable(bm, groupByID))
 		},
 	}
 }
@@ -454,5 +454,5 @@ func cbScaffoldFromBaseline(ctx context.Context, cliCtx *registry.CLIContext, ba
 	// versions available for the baseline, which also tracks future OS releases.
 	// resp.AvailableOsVersions lists the pinnable versions if the user wants to
 	// narrow the scope after editing the scaffold.
-	return printScaffold(scaffold)
+	return printScaffold(cliCtx, scaffold)
 }

--- a/internal/commands/pro_platform_device_groups.go
+++ b/internal/commands/pro_platform_device_groups.go
@@ -188,7 +188,7 @@ func newPDGPatchCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if scaffoldFlag {
-				return printScaffold(map[string]any{
+				return printScaffold(cliCtx, map[string]any{
 					"criteria":    []any{},
 					"description": "",
 					"name":        "",
@@ -265,7 +265,7 @@ func newPDGPatchMembersCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if scaffoldFlag {
-				return printScaffold(map[string]any{
+				return printScaffold(cliCtx, map[string]any{
 					"added":   []any{},
 					"removed": []any{},
 				})
@@ -307,7 +307,7 @@ func newPDGApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Create or update a device group",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printScaffold(deviceGroupScaffold())
+				return printScaffold(cliCtx, deviceGroupScaffold())
 			}
 			if err := requirePlatformClient(cliCtx); err != nil {
 				return err

--- a/internal/commands/pro_platform_helpers.go
+++ b/internal/commands/pro_platform_helpers.go
@@ -276,17 +276,18 @@ func newPlatformSDKClient(url, clientID, clientSecret string, scope auth.Scope, 
 
 // printScaffold marshals the given value to stdout, respecting the -o flag.
 // Used by apply commands with --scaffold to show the expected input structure.
-func printScaffold(v any) error {
+func printScaffold(cliCtx *registry.CLIContext, v any) error {
+	w := writerFor(cliCtx)
 	switch outputFmt {
 	case "yaml":
-		enc := yaml.NewEncoder(os.Stdout)
+		enc := yaml.NewEncoder(w)
 		enc.SetIndent(2)
 		if err := enc.Encode(v); err != nil {
 			return err
 		}
 		return enc.Close()
 	default:
-		enc := json.NewEncoder(os.Stdout)
+		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		enc.SetEscapeHTML(false)
 		return enc.Encode(v)

--- a/internal/commands/protect_action_configs.go
+++ b/internal/commands/protect_action_configs.go
@@ -84,7 +84,7 @@ func newProtectActionConfigsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command
 		Short: "Create or update an action configuration",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfprotect.ActionConfigInput{})
+				return printExport(cliCtx, jamfprotect.ActionConfigInput{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -189,7 +189,7 @@ func newProtectActionConfigsExportCmd(cliCtx *registry.CLIContext) *cobra.Comman
 			if err != nil {
 				return err
 			}
-			return printExport(export)
+			return printExport(cliCtx, export)
 		},
 	}
 }

--- a/internal/commands/protect_analytic_overrides.go
+++ b/internal/commands/protect_analytic_overrides.go
@@ -354,7 +354,7 @@ customisations. Analytics with no override are omitted.`,
 			sort.Slice(doc.Overrides, func(i, j int) bool {
 				return doc.Overrides[i].Analytic < doc.Overrides[j].Analytic
 			})
-			return printExport(doc)
+			return printExport(cliCtx, doc)
 		},
 	}
 }
@@ -380,7 +380,7 @@ non-zero if any failed.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(analyticOverridesDoc{Overrides: []analyticOverride{{
+				return printExport(cliCtx, analyticOverridesDoc{Overrides: []analyticOverride{{
 					Analytic: "BlazingKeylogger",
 					Severity: "Low",
 					Actions:  []analyticOverrideAction{{Name: "Report", Parameters: "{}"}},

--- a/internal/commands/protect_analytic_sets.go
+++ b/internal/commands/protect_analytic_sets.go
@@ -107,7 +107,7 @@ func newProtectAnalyticSetsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command 
 		Short: "Create or update an analytic set",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(analyticSetExport{})
+				return printExport(cliCtx, analyticSetExport{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -322,7 +322,7 @@ func newProtectAnalyticSetsExportCmd(cliCtx *registry.CLIContext) *cobra.Command
 			if err != nil {
 				return err
 			}
-			return printExport(analyticSetToExport(item))
+			return printExport(cliCtx, analyticSetToExport(item))
 		},
 	}
 }

--- a/internal/commands/protect_analytics.go
+++ b/internal/commands/protect_analytics.go
@@ -132,7 +132,7 @@ func newProtectAnalyticsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Create or update an analytic",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfprotect.AnalyticInput{})
+				return printExport(cliCtx, jamfprotect.AnalyticInput{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -348,7 +348,7 @@ func newProtectAnalyticsExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 				return fmt.Errorf("marshalling YAML: %w", err)
 			}
 
-			fmt.Print(string(data))
+			fmt.Fprint(writerFor(cliCtx), string(data))
 			return nil
 		},
 	}

--- a/internal/commands/protect_api_clients.go
+++ b/internal/commands/protect_api_clients.go
@@ -106,7 +106,7 @@ func newProtectApiClientsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
 				// The export shape, not the SDK input shape — see the groups scaffold.
-				return printExport(apiClientExport{Roles: []string{}})
+				return printExport(cliCtx, apiClientExport{Roles: []string{}})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -211,7 +211,7 @@ func newProtectApiClientsExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printExport(apiClientToExport(item))
+			return printExport(cliCtx, apiClientToExport(item))
 		},
 	}
 }

--- a/internal/commands/protect_exception_sets.go
+++ b/internal/commands/protect_exception_sets.go
@@ -88,7 +88,7 @@ func newProtectExceptionSetsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command
 		Short: "Create or update an exception set",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(exceptionSetExport{
+				return printExport(cliCtx, exceptionSetExport{
 					Exceptions:   []exceptionExport{},
 					EsExceptions: []jamfprotect.EsExceptionInput{},
 				})
@@ -471,7 +471,7 @@ func newProtectExceptionSetsExportCmd(cliCtx *registry.CLIContext) *cobra.Comman
 			if err != nil {
 				return err
 			}
-			return printExport(exceptionSetToExport(item))
+			return printExport(cliCtx, exceptionSetToExport(item))
 		},
 	}
 }

--- a/internal/commands/protect_groups.go
+++ b/internal/commands/protect_groups.go
@@ -183,7 +183,7 @@ func newProtectGroupsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 				// The export shape, not the SDK input shape: 'export' emits names now,
 				// and a scaffold teaching roleids/connectionid teaches the form this
 				// command only still accepts for backward compatibility.
-				return printExport(groupExport{Roles: []string{}})
+				return printExport(cliCtx, groupExport{Roles: []string{}})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -305,7 +305,7 @@ func newProtectGroupsExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printExport(groupToExport(item))
+			return printExport(cliCtx, groupToExport(item))
 		},
 	}
 }

--- a/internal/commands/protect_helpers.go
+++ b/internal/commands/protect_helpers.go
@@ -29,14 +29,15 @@ func printResult(out registry.OutputFormatter, item any, flattened map[string]an
 }
 
 // printExport outputs data as JSON (default) or YAML based on the global output format.
-func printExport(data any) error {
+func printExport(cliCtx *registry.CLIContext, data any) error {
+	w := writerFor(cliCtx)
 	switch outputFmt {
 	case "yaml":
-		enc := yaml.NewEncoder(os.Stdout)
+		enc := yaml.NewEncoder(w)
 		enc.SetIndent(2)
 		return enc.Encode(data)
 	default:
-		enc := json.NewEncoder(os.Stdout)
+		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		return enc.Encode(data)
 	}

--- a/internal/commands/protect_plans.go
+++ b/internal/commands/protect_plans.go
@@ -129,7 +129,7 @@ additive: an omitted or empty list leaves existing membership unchanged. Use the
 granular remove-* subcommands on the referenced resource to detach members.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(planExport{})
+				return printExport(cliCtx, planExport{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -329,7 +329,7 @@ func newProtectPlansExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printExport(planToExport(item))
+			return printExport(cliCtx, planToExport(item))
 		},
 	}
 }

--- a/internal/commands/protect_prevent_lists.go
+++ b/internal/commands/protect_prevent_lists.go
@@ -88,7 +88,7 @@ func newProtectPreventListsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command 
 		Long:  "Create or update a custom prevent list from a JSON file (--from-file), stdin, or from flags (--name, --type, --list).",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfprotect.CustomPreventListInput{})
+				return printExport(cliCtx, jamfprotect.CustomPreventListInput{})
 			}
 			ctx := cmd.Context()
 			var input jamfprotect.CustomPreventListInput
@@ -224,7 +224,7 @@ func newProtectPreventListsExportCmd(cliCtx *registry.CLIContext) *cobra.Command
 			if err != nil {
 				return err
 			}
-			return printExport(preventListToInput(item))
+			return printExport(cliCtx, preventListToInput(item))
 		},
 	}
 }

--- a/internal/commands/protect_roles.go
+++ b/internal/commands/protect_roles.go
@@ -120,7 +120,7 @@ func newProtectRolesApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Create or update a role",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfprotect.RoleInput{})
+				return printExport(cliCtx, jamfprotect.RoleInput{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -225,7 +225,7 @@ func newProtectRolesExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printExport(roleToInput(item))
+			return printExport(cliCtx, roleToInput(item))
 		},
 	}
 }

--- a/internal/commands/protect_rscs.go
+++ b/internal/commands/protect_rscs.go
@@ -103,7 +103,7 @@ func newProtectRSCSApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Create or update a removable storage control set",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfprotect.RemovableStorageControlSetInput{})
+				return printExport(cliCtx, jamfprotect.RemovableStorageControlSetInput{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -453,7 +453,7 @@ func newProtectRSCSExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printExport(rebuildRSCSInput(item))
+			return printExport(cliCtx, rebuildRSCSInput(item))
 		},
 	}
 }

--- a/internal/commands/protect_telemetry.go
+++ b/internal/commands/protect_telemetry.go
@@ -93,7 +93,7 @@ func newProtectTelemetryApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Create or update a telemetry configuration",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfprotect.TelemetryV2Input{})
+				return printExport(cliCtx, jamfprotect.TelemetryV2Input{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -194,7 +194,7 @@ func newProtectTelemetryExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printExport(telemetryToInput(item))
+			return printExport(cliCtx, telemetryToInput(item))
 		},
 	}
 }

--- a/internal/commands/protect_ulf.go
+++ b/internal/commands/protect_ulf.go
@@ -117,7 +117,7 @@ func newProtectULFApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Create or update a unified logging filter",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfprotect.UnifiedLoggingFilterInput{})
+				return printExport(cliCtx, jamfprotect.UnifiedLoggingFilterInput{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -321,7 +321,7 @@ func newProtectULFExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 				return fmt.Errorf("marshalling YAML: %w", err)
 			}
 
-			fmt.Print(string(data))
+			fmt.Fprint(writerFor(cliCtx), string(data))
 			return nil
 		},
 	}

--- a/internal/commands/protect_ulf_sets.go
+++ b/internal/commands/protect_ulf_sets.go
@@ -116,7 +116,7 @@ func newProtectULFSetsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Create or update a unified logging filter set",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(ulfSetExport{})
+				return printExport(cliCtx, ulfSetExport{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -334,7 +334,7 @@ func newProtectULFSetsExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printExport(ulfSetToExport(item))
+			return printExport(cliCtx, ulfSetToExport(item))
 		},
 	}
 }

--- a/internal/commands/protect_users.go
+++ b/internal/commands/protect_users.go
@@ -122,7 +122,7 @@ func newProtectUsersApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
 				// The export shape, not the SDK input shape — see the groups scaffold.
-				return printExport(userExport{Roles: []string{}, Groups: []string{}})
+				return printExport(cliCtx, userExport{Roles: []string{}, Groups: []string{}})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -227,7 +227,7 @@ func newProtectUsersExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printExport(userToExport(item))
+			return printExport(cliCtx, userToExport(item))
 		},
 	}
 }

--- a/internal/commands/school_apps.go
+++ b/internal/commands/school_apps.go
@@ -98,7 +98,7 @@ func newSchoolAppsCreateCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Long:  "Add an app from the App Store by providing its Adam ID and country code.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfschool.AppCreateInput{})
+				return printExport(cliCtx, jamfschool.AppCreateInput{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)

--- a/internal/commands/school_classes.go
+++ b/internal/commands/school_classes.go
@@ -104,7 +104,7 @@ func newSchoolClassesApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Create or update a class",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfschool.ClassCreateInput{})
+				return printExport(cliCtx, jamfschool.ClassCreateInput{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -224,7 +224,7 @@ func newSchoolClassesExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printExport(schoolClassToInput(item))
+			return printExport(cliCtx, schoolClassToInput(item))
 		},
 	}
 }

--- a/internal/commands/school_device_groups.go
+++ b/internal/commands/school_device_groups.go
@@ -104,7 +104,7 @@ func newSchoolDeviceGroupsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Create or update a device group",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfschool.DeviceGroupCreateInput{})
+				return printExport(cliCtx, jamfschool.DeviceGroupCreateInput{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -224,7 +224,7 @@ func newSchoolDeviceGroupsExportCmd(cliCtx *registry.CLIContext) *cobra.Command 
 			if err != nil {
 				return err
 			}
-			return printExport(schoolDeviceGroupToInput(item))
+			return printExport(cliCtx, schoolDeviceGroupToInput(item))
 		},
 	}
 }

--- a/internal/commands/school_groups.go
+++ b/internal/commands/school_groups.go
@@ -98,7 +98,7 @@ func newSchoolGroupsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Create or update a user group",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfschool.GroupCreateInput{})
+				return printExport(cliCtx, jamfschool.GroupCreateInput{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -219,7 +219,7 @@ func newSchoolGroupsExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printExport(schoolGroupToInput(item))
+			return printExport(cliCtx, schoolGroupToInput(item))
 		},
 	}
 }

--- a/internal/commands/school_ibeacons.go
+++ b/internal/commands/school_ibeacons.go
@@ -98,7 +98,7 @@ func newSchoolIBeaconsApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Create or update an iBeacon",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfschool.IBeaconCreateInput{})
+				return printExport(cliCtx, jamfschool.IBeaconCreateInput{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -208,7 +208,7 @@ func newSchoolIBeaconsExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printExport(schoolIBeaconToInput(item))
+			return printExport(cliCtx, schoolIBeaconToInput(item))
 		},
 	}
 }

--- a/internal/commands/school_users.go
+++ b/internal/commands/school_users.go
@@ -101,7 +101,7 @@ func newSchoolUsersApplyCmd(cliCtx *registry.CLIContext) *cobra.Command {
 		Short: "Create or update a user",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if scaffold {
-				return printExport(jamfschool.UserCreateInput{})
+				return printExport(cliCtx, jamfschool.UserCreateInput{})
 			}
 			ctx := cmd.Context()
 			data, err := readInput(fromFile)
@@ -226,7 +226,7 @@ func newSchoolUsersExportCmd(cliCtx *registry.CLIContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printExport(schoolUserToInput(item))
+			return printExport(cliCtx, schoolUserToInput(item))
 		},
 	}
 }


### PR DESCRIPTION
Fixes #357

**Problem**
6 sites wrote directly to `os.Stdout` / `fmt.Print`, so `--out-file` created an empty file while the payload went to stdout:
- `protect_helpers.go:35,39` `yaml/json.NewEncoder(os.Stdout)`
- `pro_platform_helpers.go:282,289` same
- `protect_analytics.go:351` `fmt.Print`
- `protect_ulf.go:324` `fmt.Print`

**Fix**
- `printExport(cliCtx, data)` and `printScaffold(cliCtx, v)` now take `cliCtx` and use `writerFor(cliCtx)` (honours `--out-file` via the formatter's writer)
- `protect_analytics/ulf` `fmt.Print` -> `Fprint(writerFor(cliCtx), ...)`
- updated all 41 `printExport` and 7 `printScaffold` call sites
- `pro_blueprints` scaffold cmd now takes `cliCtx`

**Verification**
- `go vet ./internal/commands` clean, `go build ./...` clean, `gofmt` clean
- buffer test: `printExport`/`printScaffold` with formatter writer set to `bytes.Buffer` goes to buffer, not stdout
- `go test -run TestBackupListResources_HonoursOutFile` (same regression class) pass
- no remaining `os.Stdout` in export/scaffold paths (non-generated, non-completion)
- pre-existing `TestUpdateCacheRoundTrip` fails on main on Windows (0600 vs 0666) — not this change